### PR TITLE
Updated BeamSpell, relative-offset accepts vector value (x, y, z) it …

### DIFF
--- a/src/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -1,39 +1,61 @@
 package com.nisovin.magicspells.spells.instant;
 
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.util.Vector;
+import java.util.Set;
+import java.util.HashSet;
 
-import com.nisovin.magicspells.MagicSpells;
+import org.bukkit.Location;
+import org.bukkit.util.Vector;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
 import com.nisovin.magicspells.Subspell;
+import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.BoundingBox;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
-import com.nisovin.magicspells.spells.InstantSpell;
-import com.nisovin.magicspells.util.BoundingBox;
-import com.nisovin.magicspells.util.compat.EventUtil;
-import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
-public class BeamSpell extends InstantSpell {
-	
-	float beamWidth;
-	float yOffset;
+public class BeamSpell extends InstantSpell implements TargetedLocationSpell {
+
+	boolean stopOnHitEntity;
+	boolean stopOnHitGround;
+	double hitRadius;
+	double verticalHitRadius;
+	float rotation;
+	float beamHorizOffset;
+	float beamVertOffset;
 	float maxDistance;
 	float interval;
+	float yOffset;
 	String spellNameToCast;
 	Subspell spell;
-	
+	Vector relativeOffset;
+
 	public BeamSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
-		beamWidth = getConfigFloat("beam-width", 2);
+
 		yOffset = getConfigFloat("y-offset", 0);
+		relativeOffset = getConfigVector("relative-offset", "0,0,0");
+		relativeOffset.setY(yOffset);
+		hitRadius = getConfigDouble("hit-radius", 2);
+		verticalHitRadius = getConfigDouble("vertical-hit-radius", 2);
+		rotation = getConfigFloat("rotation", 0);
+		beamHorizOffset = getConfigFloat("beam-horiz-offset", 0);
+		beamVertOffset = getConfigFloat("beam-vert-offset", 0);
 		maxDistance = getConfigFloat("max-distance", 50);
 		interval = getConfigFloat("interval", 0.25F);
 		spellNameToCast = getConfigString("spell", "");
-		
+		stopOnHitEntity = getConfigBoolean("stop-on-hit-entity", false);
+		stopOnHitGround = getConfigBoolean("stop-on-hit-ground", false);
+
 		if (interval < 0.01) interval = 0.01F;
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -44,49 +66,102 @@ public class BeamSpell extends InstantSpell {
 	@Override
 	public PostCastAction castSpell(Player player, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			
-			//float distSq = maxDistance * maxDistance;
-			
-			Vector start = player.getEyeLocation().toVector();
-			start = start.add(new Vector(0, yOffset, 0));
-			Vector dir = player.getEyeLocation().getDirection().multiply(interval);
-			Vector pos = start.clone();
-			
-			float d = 0;
-			while (d < maxDistance) {
-				d += interval;
-				pos.add(dir);
-				if (!isTransparent(pos.toLocation(player.getWorld()).getBlock())) break;
-				playSpellEffects(EffectPosition.SPECIAL, pos.toLocation(player.getWorld()));
-			}
-			
-			BoundingBox box = new BoundingBox(start.toLocation(player.getWorld()), pos.toLocation(player.getWorld()));
-			box.expand(beamWidth);
-			for (LivingEntity e : player.getWorld().getLivingEntities()) {
-				if (e.equals(player)) continue;
-				if (e.isDead()) continue;
-				if (!box.contains(e)) continue;
-				if (validTargetList != null && !validTargetList.canTarget(e)) continue;
-				double dist = pointLineDist(start, pos, e.getLocation().add(0, 0.8, 0).toVector());
-				if (dist < beamWidth/2) {
-					SpellTargetEvent event = new SpellTargetEvent(this, player, e, power);
-					EventUtil.call(event);
-					if (event.isCancelled()) continue;
-					spell.castAtEntity(player, event.getTarget(), event.getPower());
-					playSpellEffects(EffectPosition.TARGET, event.getTarget());
-				}
-			}
-			
-			playSpellEffects(EffectPosition.CASTER, player);
+			new Beam(player, player.getLocation(), power);
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
-	double pointLineDist(Vector p1, Vector p2, Vector p0) {
-		Vector v1 = p2.clone().subtract(p1);
-		Vector v2 = p1.clone().subtract(p0);
-		Vector v3 = v1.clone().crossProduct(v2);
-		return v3.length() / v1.length();
+
+	@Override
+	public boolean castAtLocation(Player player, Location location, float v) {
+		new Beam(player, location, v);
+		return false;
 	}
 
+	@Override
+	public boolean castAtLocation(Location location, float v) {
+		new Beam(null, location, v);
+		return false;
+	}
+
+	class Beam {
+
+		Player caster;
+		float power;
+		Location startLoc;
+		Location currentLoc;
+		Set<Entity> immune;
+
+		public Beam(Player caster, Location from, float power) {
+			this.immune = new HashSet<>();
+			this.caster = caster;
+			this.startLoc = from.clone();
+			this.power = power;
+			BoundingBox box;
+
+			playSpellEffects(EffectPosition.CASTER, this.caster);
+
+			if (BeamSpell.this.beamVertOffset != 0)
+				this.startLoc.setPitch(this.startLoc.getPitch() - BeamSpell.this.beamVertOffset);
+			if (BeamSpell.this.beamHorizOffset != 0)
+				this.startLoc.setYaw(this.startLoc.getYaw() + BeamSpell.this.beamHorizOffset);
+
+			Vector startDir;
+			Vector horizOffset;
+
+			//apply relative offset
+			startDir = from.clone().getDirection().normalize();
+			horizOffset = new Vector(-startDir.getZ(), 0, startDir.getX()).normalize();
+			this.startLoc.add(horizOffset.multiply(BeamSpell.this.relativeOffset.getZ())).getBlock().getLocation();
+			this.startLoc.add(this.startLoc.getDirection().clone().multiply(BeamSpell.this.relativeOffset.getX()));
+			this.startLoc.setY(this.startLoc.getY() + BeamSpell.this.relativeOffset.getY());
+
+			this.currentLoc = this.startLoc.clone();
+
+			Vector dir = this.startLoc.getDirection().multiply(BeamSpell.this.interval);
+
+			float d = 0;
+			mainLoop:
+			while (d < BeamSpell.this.maxDistance) {
+
+				d += BeamSpell.this.interval;
+				this.currentLoc.add(dir);
+
+				if (BeamSpell.this.rotation != 0) {
+					Util.rotateVector(dir, BeamSpell.this.rotation);
+					this.currentLoc.setYaw(this.currentLoc.getYaw() + BeamSpell.this.rotation);
+				}
+
+				//check block collision
+				if (!isTransparent(this.currentLoc.getBlock())) {
+					//play effects when beam hits a block
+					playSpellEffects(EffectPosition.DISABLED, this.currentLoc);
+					if (BeamSpell.this.stopOnHitGround) break;
+				}
+
+				playSpellEffects(EffectPosition.SPECIAL, this.currentLoc);
+
+				box = new BoundingBox(this.currentLoc, BeamSpell.this.hitRadius, BeamSpell.this.verticalHitRadius);
+
+				//check entities in the beam range
+				for (LivingEntity e : this.caster.getWorld().getLivingEntities()) {
+					if (e.equals(this.caster)) continue;
+					if (e.isDead()) continue;
+					if (this.immune.contains(e)) continue;
+					if (!box.contains(e)) continue;
+					if (BeamSpell.this.validTargetList != null && !BeamSpell.this.validTargetList.canTarget(e)) continue;
+
+					SpellTargetEvent event = new SpellTargetEvent(BeamSpell.this, this.caster, e, power);
+					EventUtil.call(event);
+					if (event.isCancelled()) continue;
+
+					BeamSpell.this.spell.castAtEntity(this.caster, event.getTarget(), event.getPower());
+					playSpellEffects(EffectPosition.TARGET, event.getTarget());
+					this.immune.add(e);
+					if (BeamSpell.this.stopOnHitEntity) break mainLoop;
+				}
+			}
+
+		}
+	}
 }


### PR DESCRIPTION
…edits the start location, hit-radius accepts double value - sets the horizontal hit radius, vertical-hit-radius accepts double value - sets the vertical hit radius, rotation accepts float value - rotates the beam (positive numbers for rotation to the right and negative numbers for left rotation), beam-horiz-offset accepts float value - rotates the beam horizontal, beam-vert-offset accepts float value - rotates the beam vertical, stop-on-hit-ground accepts boolean value - stops the beam when it hits a block, stop-on-hit-entity accepts boolean value - stops the beam when it hits an entity

Special Effect Positions for the BeamSpell:
disabled effect position will show up when the beam hits a block