### PR TITLE
Added GriefPrevention Support + Variablecompare updates

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,7 @@ public class MSConfig {
   def resourceResidenceUrl = 'http://nexus.hc.to/content/repositories/pub_releases/com/bekvon/bukkit/residence/Residence/4.5.3.0/Residence-4.5.3.0.jar'
   def resourceNcpUrl = 'https://ci.md-5.net/job/NoCheatPlus/lastSuccessfulBuild/artifact/target/NoCheatPlus.jar'
   def resourcePlaceholderapiUrl = 'http://repo.extendedclip.com/content/repositories/placeholderapi/me/clip/placeholderapi/2.8.2/placeholderapi-2.8.2.jar'
+  def resourceGriefPreventionUrl = 'https://github.com/TechFortress/GriefPrevention/releases/download/16.8/GriefPrevention.jar'
 
   def versionSuffix
 
@@ -109,6 +110,9 @@ def magicspellsGetResources() {
 
   // Get PlaceholderAPI
   downloadFile(new File(libFolder, 'PlaceholderAPI.jar'), new URL(project.ext.magicspellsData.resourcePlaceholderapiUrl))
+
+  // Get GriefPrevention
+  downloadFile(new File(libFolder, 'GriefPrevention.jar'), new URL(project.ext.magicspellsData.resourceGriefPreventionUrl))
 
   println 'Finished running the get resources phase'
 }
@@ -150,6 +154,7 @@ def magicspellsClasspathBase() {
     .plus(project.files("${-> project.ext.magicspellsData.libDir}${File.separator}Residence.jar"))
     .plus(project.files("${-> project.ext.magicspellsData.libDir}${File.separator}PlaceholderAPI.jar"))
     .plus(project.files("${-> project.ext.magicspellsData.libDir}${File.separator}Vault.jar"))
+	.plus(project.files("${-> project.ext.magicspellsData.libDir}${File.separator}GriefPrevention.jar"))
 }
 
 def magicspellsClasspathMSJar() {

--- a/src/com/nisovin/magicspells/castmodifiers/Condition.java
+++ b/src/com/nisovin/magicspells/castmodifiers/Condition.java
@@ -166,6 +166,7 @@ public abstract class Condition {
 		conditions.put("thundering", ThunderingCondition.class);
 		conditions.put("raining", RainingCondition.class);
 		conditions.put("onleash", OnLeashCondition.class);
+		conditions.put("griefpreventionisowner", GriefPreventionIsOwnerCondition.class);
 	}
 	
 }

--- a/src/com/nisovin/magicspells/castmodifiers/conditions/GriefPreventionIsOwnerCondition.java
+++ b/src/com/nisovin/magicspells/castmodifiers/conditions/GriefPreventionIsOwnerCondition.java
@@ -1,0 +1,43 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.castmodifiers.Condition;
+
+import me.ryanhamshire.GriefPrevention.GriefPrevention;
+import me.ryanhamshire.GriefPrevention.Claim;
+import me.ryanhamshire.GriefPrevention.PlayerData;
+import me.ryanhamshire.GriefPrevention.DataStore;
+
+public class GriefPreventionIsOwnerCondition extends Condition {
+
+	@Override
+	public boolean setVar(String var) {
+		return true;
+	}
+
+	@Override
+	public boolean check(Player player) {
+		// Does the claim recognize the player as the owner?
+		Claim currentClaim = GriefPrevention.instance.dataStore.getClaimAt(player.getLocation(), false, null);
+		if (currentClaim == null) return false;
+		return (player.getUniqueId().equals(currentClaim.ownerID));
+	}
+
+	@Override
+	public boolean check(Player player, LivingEntity target) {
+		// Does the claim recognize the target as the owner?
+		Claim currentClaim = GriefPrevention.instance.dataStore.getClaimAt(target.getLocation(), false, null);
+		if (currentClaim == null) return false;
+		return (target.getUniqueId().equals(currentClaim.ownerID));
+	}
+
+	@Override
+	public boolean check(Player player, Location location) {
+		// Locations, coming soon.
+		return false;
+	}
+
+}

--- a/src/com/nisovin/magicspells/castmodifiers/conditions/VariableCompareCondition.java
+++ b/src/com/nisovin/magicspells/castmodifiers/conditions/VariableCompareCondition.java
@@ -8,48 +8,83 @@ import com.nisovin.magicspells.DebugHandler;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.castmodifiers.Condition;
 
-import java.util.Objects;
-
 public class VariableCompareCondition extends Condition {
 
-    String variable;
-    String firstVariable = null;
-    String secondVariable = null;
+	public String variable;
+	int op = 0;
+	String firstVariable;
+	String secondVariable;
 
-    @Override
-    public boolean setVar(String var) {
-        try {
-            String[] split = var.split(":",2);
-            firstVariable = split[0]; //The variable that is being checked
-            secondVariable = split[1]; //The string that the variable is being checked against
-            return true;
-        } catch (ArrayIndexOutOfBoundsException missingColon) {
-            // Someone didn't read the GitHub commit
-            MagicSpells.error("You must use a colon to separate the two variables");
-            return false;
-        }
-    }
+	@Override
+	public boolean setVar(String var) {
+		this.variable = var;
+		if(var.contains(":")) {
+			// Find out if its comparing dual values
+			String[] split = var.split(":",2);
+			firstVariable = split[0]; //The variable that is being checked
+			secondVariable = split[1]; //The string that the variable is being checked against
+			op = 1;
+			return true;
+		}
+		if(var.contains("<")) {
+			// Find out if its a more than equation
+			String[] split = var.split("<",2);
+			firstVariable = split[0];
+			secondVariable = split[1];
+			op = 2;
+			return true;
+		}
+		if(var.contains(">")) {
+			// Find out if its a less than equation
+			String[] split = var.split(">",2);
+			firstVariable = split[0];
+			secondVariable = split[1];
+			op = 3;
+			return true;
+		}
 
-    @Override
-    public boolean check(Player player) {
-        // Get variable values
-        String value = MagicSpells.getVariableManager().getStringValue(firstVariable, player);
-        String valueSecond = MagicSpells.getVariableManager().getStringValue(secondVariable, player);
+		// Someone didn't read the GitHub commit
+		MagicSpells.error("You must use either <, >, or : to split the variables");
+		return false;
+	}
 
-        // Do comparison
-        return (value.equals(valueSecond));
-    }
+	@Override
+	public boolean check(Player player) {
+		// Get variable values
+		String value = MagicSpells.getVariableManager().getStringValue(firstVariable, player);
+		String valueSecond = MagicSpells.getVariableManager().getStringValue(secondVariable, player);
+		double valueDouble;
+		double valueDoubleSecond;
 
-    @Override
-    public boolean check(Player player, LivingEntity target) {
-        // Someone didn't read the GitHub commit x2
-        MagicSpells.error("VariableCompare cannot be used in target-modifiers, use VariableMatches");
-        return false;
-    }
+		// Will it require the string to be a double?
+		if(op == 2 || op == 3) {
+			// Parse the string into a double so it can be read correctly
+			valueDouble = Double.parseDouble(value);
+			valueDoubleSecond = Double.parseDouble(valueSecond);
+		}else if(op == 1) {
+			return (value.equals(valueSecond));
+		}
 
-    @Override
-    public boolean check(Player player, Location location) {
-        // Against defaults (only possible comparison here)
-        return check(player);
-    }
+		// Do the actual comparison
+		if(op == 2) {
+			return Double.compare(valueDouble,valueDoubleSecond) < 0;
+		}
+		if(op == 3) {
+			return Double.compare(valueDouble,valueDoubleSecond) > 0;
+		}
+		throw new IllegalStateException(op + " should never be reached!");
+	}
+
+	@Override
+	public boolean check(Player player, LivingEntity target) {
+		// Someone didn't read the GitHub commit x2
+		MagicSpells.error("VariableCompare cannot be used in target-modifiers, use VariableMatches");
+		return false;
+	}
+
+	@Override
+	public boolean check(Player player, Location location) {
+		// Against defaults (only possible comparison here)
+		return check(player);
+	}
 }

--- a/src/com/nisovin/magicspells/castmodifiers/conditions/VariableCompareCondition.java
+++ b/src/com/nisovin/magicspells/castmodifiers/conditions/VariableCompareCondition.java
@@ -53,8 +53,8 @@ public class VariableCompareCondition extends Condition {
 		// Get variable values
 		String value = MagicSpells.getVariableManager().getStringValue(firstVariable, player);
 		String valueSecond = MagicSpells.getVariableManager().getStringValue(secondVariable, player);
-		double valueDouble;
-		double valueDoubleSecond;
+		double valueDouble = 0;
+		double valueDoubleSecond = 0;
 
 		// Will it require the string to be a double?
 		if(op == 2 || op == 3) {

--- a/src/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -126,30 +126,26 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		super.initialize();
 
 		Subspell s = new Subspell(hitSpellName);
-		if (s.process()) {
+		if (!s.process() && !hitSpellName.isEmpty()) {
 			spell = s;
-		} else {
 			MagicSpells.error("HomingMissileSpell " + internalName + " has an invalid spell defined!");
 		}
 
 		Subspell s2 = new Subspell(groundSpellName);
-		if (s2.process()) {
+		if (!s2.process() && !groundSpellName.isEmpty()) {
 			groundSpell = s2;
-		} else {
 			MagicSpells.error("HomingMissileSpell " + internalName + " has an invalid spell-on-hit-ground defined!");
 		}
 
 		Subspell s3 = new Subspell(airSpellName);
-		if (s3.process()) {
+		if (!s3.process() && !airSpellName.isEmpty()) {
 			airSpell = s3;
-		} else {
 			MagicSpells.error("HomingMissileSpell " + internalName + " has an invalid spell-on-hit-air defined!");
 		}
 
 		Subspell s4 = new Subspell(durationSpellName);
-		if (s4.process()) {
+		if (!s4.process() && !durationSpellName.isEmpty()) {
 			durationSpell = s4;
-		} else {
 			MagicSpells.error("HomingMissileSpell " + internalName + " has an invalid spell-after-duration defined!");
 		}
 	}

--- a/src/plugin.yml
+++ b/src/plugin.yml
@@ -2,7 +2,7 @@ name: MagicSpells
 main: com.nisovin.magicspells.MagicSpells
 version: $project.ext.magicspellsData.stringVersionCore
 authors: [nisovin, TheComputerGeek2,Chronoken]
-softdepend: [Vault,ProtocolLib,WorldGuard,Residence,PowerNBT,LibsDisguises,NoCheatPlus,PlaceholderAPI]
+softdepend: [GriefPrevention,Vault,ProtocolLib,WorldGuard,Residence,PowerNBT,LibsDisguises,NoCheatPlus,PlaceholderAPI]
 depend: [EffectLib]
 commands:
     magicspellcast:


### PR DESCRIPTION
Magicspells now supports GriefPrevention modifiers. Currently only "griefpreventionisowner" is present but more will appear soon. Checks if the target/player is the owner of the current claim.
- `griefpreventionisowner (action)`

Condition "variablecompare" now supports greater than + less than.
- `variablecompare var1<var2`
- `variablecompare var1>var2`
- `variablecompare var1:var2`

Homing Missile errors should quiet down now.

**Coming soon**: OpenTerrainGeneratorBiome modifier!