### PR TITLE
Improved ForcetossSpell.

### DIFF
--- a/src/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -1,32 +1,35 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import org.bukkit.util.Vector;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+import com.nisovin.magicspells.util.Util;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
-import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.compat.EventUtil;
-import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	private int damage;
 	private float hForce;
 	private float vForce;
+	private float rotation;
 	private boolean checkPlugins;
 	private boolean powerAffectsForce;
 	private boolean avoidDamageModification;
-	
+
 	public ForcetossSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		damage = getConfigInt("damage", 0);
-		hForce = getConfigInt("horizontal-force", 20) / 10.0F;
-		vForce = getConfigInt("vertical-force", 10) / 10.0F;
+		hForce = getConfigFloat("horizontal-force", 20) / 10.0F;
+		vForce = getConfigFloat("vertical-force", 10) / 10.0F;
+		rotation = getConfigFloat("rotation", 0);
 		checkPlugins = getConfigBoolean("check-plugins", true);
 		powerAffectsForce = getConfigBoolean("power-affects-force", true);
 		avoidDamageModification = getConfigBoolean("avoid-damage-modification", false);
@@ -38,37 +41,39 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 			// Get target
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(player, power);
 			if (targetInfo == null) return noTarget(player);
-			LivingEntity target = targetInfo.getTarget();
-			power = targetInfo.getPower();
-			
-			// Do damage
-			if (damage > 0) {
-				double damage = this.damage * power;
-				if (target instanceof Player && checkPlugins) {
-					MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, target, DamageCause.ENTITY_ATTACK, damage);
-					EventUtil.call(event);
-					if (event.isCancelled()) return noTarget(player);
-					if (!avoidDamageModification) damage = event.getDamage();
-				}
-				target.damage(damage);
-			}
-			
+
 			// Throw target
-			toss(player, target, power);
-			
-			sendMessages(player, target);
+			toss(player, targetInfo.getTarget(), targetInfo.getPower());
+
+			sendMessages(player, targetInfo.getTarget());
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private void toss(Player player, LivingEntity target, float power) {
 		if (!powerAffectsForce) power = 1f;
-		Vector v = target.getLocation().toVector().subtract(player.getLocation().toVector())
-			.setY(0)
-			.normalize()
-			.multiply(hForce * power)
-			.setY(vForce * power);
+
+		// Deal damage
+		if (damage > 0) {
+			double damage = this.damage * power;
+			if (target instanceof Player && checkPlugins) {
+				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, target, DamageCause.ENTITY_ATTACK, damage);
+				EventUtil.call(event);
+				if (!avoidDamageModification) damage = event.getDamage();
+			}
+			target.damage(damage);
+		}
+
+		Vector v;
+		if (player.equals(target)) {
+			v = player.getLocation().getDirection();
+		} else {
+			v = target.getLocation().toVector().subtract(player.getLocation().toVector());
+		}
+		if (v == null) return;
+		v.setY(0).normalize().multiply(hForce * power).setY(vForce * power);
+		if (rotation != 0) Util.rotateVector(v, rotation);
 		target.setVelocity(v);
 		playSpellEffects(player, target);
 	}


### PR DESCRIPTION
Added - rotation option (float) rotates the toss location (allows you to toss your target to the left or right)
Improved - horizontal-force and vertical-force now accept float values
Fixed:
    - a server crash when the forcetoss spell was targeting the caster while he was sneaking
    - horizontal-force didn't work if the caster was targeting himself
    - damage option didn't work if the forcetoss spell was casted by targeted multi or aoe spells