### PR TITLE
New Modifier Actions to expand on Cooldowns

### DIFF
--- a/src/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/src/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -193,6 +193,66 @@ public enum ModifierType {
 		
 	},
 	
+	ADD_COOLDOWN(false, true, false, false, "addcooldown", "addcd", "+cd") {
+
+		@Override
+		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			if (check) event.setCooldown(event.getCooldown() + modifierVarFloat);
+			return true;
+		}
+
+		@Override
+		public boolean apply(ManaChangeEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(SpellTargetEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(SpellTargetLocationEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+	},
+
+	MINUS_COOLDOWN(false, true, false, false, "minuscooldown", "minuscd", "-cd") {
+
+		@Override
+		public boolean apply(SpellCastEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			if (check) event.setCooldown(event.getCooldown() - modifierVarFloat);
+			return true;
+		}
+
+		@Override
+		public boolean apply(ManaChangeEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(SpellTargetEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(SpellTargetLocationEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+		@Override
+		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, String modifierVar, float modifierVarFloat, int modifierVarInt, Object customData) {
+			return true;
+		}
+
+	},
+
 	REAGENTS(false, true, false, false, "reagents") {
 		
 		@Override


### PR DESCRIPTION
**_add_cooldown and minus_cooldown modifier actions added._**

when adding cooldown to a spell use, **addcooldown** or **addcd** or **+cd**
when removing cooldown to a spell use, **minuscooldown** or **minuscd** or **-cd**

All 3 options are valid of the modifier actions.
Here are some examples

**modifiers:**
    - onblock grass -cd 5
Adds 5 cooldown to the spell when on grass

**modifiers:**
    - onblock lava -cd 5
Removes 5 cooldown to the spell when on lava