### PR TITLE
Conjure Spell change to support kill passives

### DIFF
--- a/src/com/nisovin/magicspells/spells/instant/ConjureSpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/ConjureSpell.java
@@ -319,7 +319,10 @@ public class ConjureSpell extends InstantSpell implements TargetedEntitySpell, T
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!(target instanceof Player)) return false;
+		if (!(target instanceof Player)) {
+			castAtLocation(target.getLocation(), power);
+			return true;
+		}
 		conjureItems((Player)target, power);
 		return true;
 	}


### PR DESCRIPTION
If a kill passive tries to conjure an item at the death location of an entity, this allows it to target the entity in the specific event it dies and conjure the items at their location accordingly.