### PR TITLE
Single-Target Capabilities in ConfusionSpell

### DIFF
--- a/src/com/nisovin/magicspells/spells/instant/ConfusionSpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/ConfusionSpell.java
@@ -5,13 +5,15 @@ import java.util.List;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Creature;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.util.MagicConfig;
 
-public class ConfusionSpell extends InstantSpell {
+public class ConfusionSpell extends InstantSpell implements TargetedEntitySpell {
 
 	private int range;
 	
@@ -30,6 +32,7 @@ public class ConfusionSpell extends InstantSpell {
 			for (Entity e : entities) {
 				if (!(e instanceof LivingEntity)) continue;
 				if (!validTargetList.canTarget(player, e)) continue;
+				if (!(e instanceof Creature)) continue;
 				monsters.add((LivingEntity)e);
 			}
 			for (int i = 0; i < monsters.size(); i++) {
@@ -41,6 +44,32 @@ public class ConfusionSpell extends InstantSpell {
 			playSpellEffects(EffectPosition.CASTER, player);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
+	}
+
+	private boolean confuseAround(LivingEntity target, float power) {
+		int castingRange = Math.round(this.range * power);
+		List<Entity> entities = target.getNearbyEntities(castingRange, castingRange, castingRange);
+		List<LivingEntity> monsters = new ArrayList<>();
+		for (Entity e : entities) {
+			if (!(e instanceof LivingEntity)) continue;
+			if (!validTargetList.canTarget(e)) continue;
+			if (!(e instanceof Creature)) continue;
+			monsters.add((LivingEntity)e);
+		}
+		for (LivingEntity monster : monsters) {
+			MagicSpells.getVolatileCodeHandler().setTarget(monster, target);
+			playSpellEffects(EffectPosition.TARGET, monster);
+		}
+		playSpellEffects(EffectPosition.CASTER, target);
+		return true;
+	}
+
+	public boolean castAtEntity(Player caster, LivingEntity target, float power) {
+		return confuseAround(target, power);
+	}
+
+	public boolean castAtEntity(LivingEntity target, float power) {
+		return confuseAround(target, power);
 	}
 
 }


### PR DESCRIPTION
If the confusion spell is casted on an target, it will cause entities around the target to attack the target. This only occurs if the confusion spell is a subspell of targeted spells.