### PR TITLE
Properly handle cooldowns and reagents for bow spells

### DIFF
--- a/src/com/nisovin/magicspells/spells/ArrowSpell.java
+++ b/src/com/nisovin/magicspells/spells/ArrowSpell.java
@@ -248,7 +248,7 @@ public class ArrowSpell extends Spell {
 							Player shooter = (Player) arrow.getShooter();
 							if (data.casted) return;
 							if (data.spell.onCooldown(shooter)) {
-								MagicSpells.sendMessage(formatMessage(data.spell.strOnCooldown, "%c", Math.round(getCooldown(shooter)) + ""), shooter, null);
+								MagicSpells.sendMessage(formatMessage(strOnCooldown, "%c", Math.round(getCooldown(shooter)) + ""), shooter, null);
 								return;
 							}
 							if (!data.spell.hasReagents(shooter, data.arrowSpellDataReagents)) {

--- a/src/com/nisovin/magicspells/spells/ArrowSpell.java
+++ b/src/com/nisovin/magicspells/spells/ArrowSpell.java
@@ -245,17 +245,24 @@ public class ArrowSpell extends Spell {
 					MagicSpells.scheduleDelayedTask(new Runnable() {
 						@Override
 						public void run() {
-							// FIXME this needs to be flattened
-							Player shooter = (Player)arrow.getShooter();
-							if (!data.casted && !data.spell.onCooldown(shooter) && data.spell.hasReagents(shooter, data.arrowSpellDataReagents)) {
-								boolean success = data.spell.spellOnHitGround.castAtLocation(shooter, arrow.getLocation(), data.power);
-								if (success) {
-									data.spell.setCooldown(shooter, data.spell.cooldown);
-									data.spell.removeReagents(shooter, data.arrowSpellDataReagents);
-								}
-								data.casted = true;
-								arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+							Player shooter = (Player) arrow.getShooter();
+							if (data.casted) return;
+							if (data.spell.onCooldown(shooter)) {
+								MagicSpells.sendMessage(formatMessage(data.spell.strOnCooldown, "%c", Math.round(getCooldown(shooter)) + ""), shooter, null);
+								return;
 							}
+							if (!data.spell.hasReagents(shooter, data.arrowSpellDataReagents)) {
+								MagicSpells.sendMessage(strMissingReagents, shooter, null);
+								return;
+							}
+
+                            boolean success = data.spell.spellOnHitGround.castAtLocation(shooter, arrow.getLocation(), data.power);
+                            if (success) {
+                                data.spell.setCooldown(shooter, data.spell.cooldown);
+                                data.spell.removeReagents(shooter, data.arrowSpellDataReagents);
+                            }
+                            data.casted = true;
+                            arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
 						}
 					}, 0);
 				}

--- a/src/com/nisovin/magicspells/spells/ArrowSpell.java
+++ b/src/com/nisovin/magicspells/spells/ArrowSpell.java
@@ -256,13 +256,13 @@ public class ArrowSpell extends Spell {
 								return;
 							}
 
-                            boolean success = data.spell.spellOnHitGround.castAtLocation(shooter, arrow.getLocation(), data.power);
-                            if (success) {
-                                data.spell.setCooldown(shooter, data.spell.cooldown);
-                                data.spell.removeReagents(shooter, data.arrowSpellDataReagents);
-                            }
-                            data.casted = true;
-                            arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+							boolean success = data.spell.spellOnHitGround.castAtLocation(shooter, arrow.getLocation(), data.power);
+							if (success) {
+								data.spell.setCooldown(shooter, data.spell.cooldown);
+								data.spell.removeReagents(shooter, data.arrowSpellDataReagents);
+							}
+							data.casted = true;
+							arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
 						}
 					}, 0);
 				}

--- a/src/com/nisovin/magicspells/spells/BowSpell.java
+++ b/src/com/nisovin/magicspells/spells/BowSpell.java
@@ -123,6 +123,8 @@ public class BowSpell extends Spell {
 			event.setCancelled(true);
 			event.getProjectile().remove();
 			spell.spellOnShoot.cast(shooter, evt1.getPower());
+			thisSpell.setCooldown(shooter, thisSpell.cooldown);
+			thisSpell.removeReagents(shooter);
 			SpellCastedEvent evt2 = new SpellCastedEvent(thisSpell, shooter, SpellCastState.NORMAL, evt1.getPower(), null, thisSpell.cooldown, thisSpell.reagents, PostCastAction.HANDLE_NORMALLY);
 			EventUtil.call(evt2);
 		}

--- a/src/com/nisovin/magicspells/spells/BowSpell.java
+++ b/src/com/nisovin/magicspells/spells/BowSpell.java
@@ -120,7 +120,7 @@ public class BowSpell extends Spell {
 				return;
 			}
 			if (!thisSpell.hasReagents(shooter)) {
-				MagicSpells.sendMessage(strMissingReagents, shooter, null);
+				MagicSpells.sendMessage(thisSpell.strMissingReagents, shooter, null);
 				return;
 			}
 

--- a/src/com/nisovin/magicspells/spells/BowSpell.java
+++ b/src/com/nisovin/magicspells/spells/BowSpell.java
@@ -115,7 +115,15 @@ public class BowSpell extends Spell {
 			if (spell == null) return;
 			if (!spellbook.hasSpell(spell)) return;
 			if (!spellbook.canCast(spell)) return;
-			
+			if (thisSpell.onCooldown(shooter)) {
+				MagicSpells.sendMessage(formatMessage(thisSpell.strOnCooldown, "%c", Math.round(getCooldown(shooter)) + ""), shooter, null);
+				return;
+			}
+			if (!thisSpell.hasReagents(shooter)) {
+				MagicSpells.sendMessage(strMissingReagents, shooter, null);
+				return;
+			}
+
 			SpellCastEvent evt1 = new SpellCastEvent(thisSpell, shooter, SpellCastState.NORMAL, useBowForce ? event.getForce() : 1.0F, null, thisSpell.cooldown, thisSpell.reagents, 0);
 			EventUtil.call(evt1);
 			if (evt1.isCancelled()) return;


### PR DESCRIPTION
Right now, bow spells don't care about cooldowns nor reagents. Additionally, no information is shown to the user when bow/arrow spells are on cooldown or missing reagents. This PR addresses both of these.