### PR TITLE
Force, Leap, Velocity spells can add velocity instead of set.

### DIFF
--- a/src/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
@@ -19,6 +19,7 @@ public class ForcepushSpell extends InstantSpell {
 	private int force;
 	private int yForce;
 	private int maxYForce;
+	private boolean addVelocityInstead;
 	
 	public ForcepushSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -27,6 +28,7 @@ public class ForcepushSpell extends InstantSpell {
 		this.force = getConfigInt("pushback-force", 30);
 		this.yForce = getConfigInt("additional-vertical-force", 15);
 		this.maxYForce = getConfigInt("max-vertical-force", 20);
+		this.addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
 	}
 
 	@Override
@@ -64,7 +66,8 @@ public class ForcepushSpell extends InstantSpell {
 				v.setY(this.yForce/10.0 * power);
 			}
 			if (v.getY() > (this.maxYForce/10.0)) v.setY(this.maxYForce/10.0);
-			target.setVelocity(v);
+			if (!addVelocityInstead) target.setVelocity(v);
+			else target.setVelocity(target.getVelocity().add(v));
 			playSpellEffects(EffectPosition.TARGET, target);
 	    }
 		playSpellEffects(EffectPosition.CASTER, player);

--- a/src/com/nisovin/magicspells/spells/instant/LeapSpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/LeapSpell.java
@@ -20,6 +20,7 @@ public class LeapSpell extends InstantSpell {
 	private float rotation;
 	private double forwardVelocity;
 	private double upwardVelocity;
+	private boolean addVelocityInstead;
 	private boolean cancelDamage;
 	private boolean clientOnly;
 	private Subspell landSpell;
@@ -35,6 +36,7 @@ public class LeapSpell extends InstantSpell {
 		this.rotation = getConfigFloat("rotation", 0F);
 		this.forwardVelocity = getConfigInt("forward-velocity", 40) / 10D;
 		this.upwardVelocity = getConfigInt("upward-velocity", 15) / 10D;
+		this.addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
 		this.cancelDamage = getConfigBoolean("cancel-damage", true);
 		this.clientOnly = getConfigBoolean("client-only", false);
 		this.landSpellName = getConfigString("land-spell", "");
@@ -64,7 +66,8 @@ public class LeapSpell extends InstantSpell {
 			if (clientOnly) {
 				MagicSpells.getVolatileCodeHandler().setClientVelocity(player, v);
 			} else {
-				player.setVelocity(v);
+				if (!addVelocityInstead) player.setVelocity(v);
+				else player.setVelocity(player.getVelocity().add(v));
 			}
 			jumping.add(player);
 			playSpellEffects(EffectPosition.CASTER, player);

--- a/src/com/nisovin/magicspells/spells/instant/VelocitySpell.java
+++ b/src/com/nisovin/magicspells/spells/instant/VelocitySpell.java
@@ -12,11 +12,13 @@ import org.bukkit.util.Vector;
 public class VelocitySpell extends InstantSpell {
 	
 	private double speed;
+	private boolean addVelocityInstead;
 	
 	public VelocitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 		
 		this.speed = getConfigDouble("speed", 4.0);
+		this.addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
 	}
 	
 	@Override
@@ -25,7 +27,8 @@ public class VelocitySpell extends InstantSpell {
 			Vector v = player.getEyeLocation().getDirection();
 			v = v.normalize();
 			v = v.multiply(speed * power);
-			player.setVelocity(v);
+			if (!addVelocityInstead) player.setVelocity(v);
+			else player.setVelocity(player.getVelocity().add(v));
 			playSpellEffects(EffectPosition.CASTER, player);
 		}
 		

--- a/src/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
@@ -25,6 +25,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 	private int force;
 	private int yForce;
 	private int maxYForce;
+	private boolean addVelocityInstead;
 	private boolean callTargetEvents;
 	
 	public ForcebombSpell(MagicConfig config, String spellName) {
@@ -36,6 +37,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 		force = getConfigInt("pushback-force", 30);
 		yForce = getConfigInt("additional-vertical-force", 15);
 		maxYForce = getConfigInt("max-vertical-force", 20);
+		addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
 		callTargetEvents = getConfigBoolean("call-target-events", false);
 	}
 
@@ -97,7 +99,8 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 					v.setY(yForce/10.0 * power);
 				}
 				if (v.getY() > maxYForce/10.0) v.setY(maxYForce/10.0);
-				entity.setVelocity(v);
+				if (!addVelocityInstead) entity.setVelocity(v);
+				else entity.setVelocity(entity.getVelocity().add(v));
 				playSpellEffects(EffectPosition.TARGET, entity);
 			}
 	    }

--- a/src/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -21,6 +21,7 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 	private float rotation;
 	private boolean checkPlugins;
 	private boolean powerAffectsForce;
+	private boolean addVelocityInstead;
 	private boolean avoidDamageModification;
 
 	public ForcetossSpell(MagicConfig config, String spellName) {
@@ -32,6 +33,7 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 		rotation = getConfigFloat("rotation", 0);
 		checkPlugins = getConfigBoolean("check-plugins", true);
 		powerAffectsForce = getConfigBoolean("power-affects-force", true);
+		addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
 		avoidDamageModification = getConfigBoolean("avoid-damage-modification", false);
 	}
 
@@ -74,7 +76,8 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 		if (v == null) throw new NullPointerException("v");
 		v.setY(0).normalize().multiply(hForce * power).setY(vForce * power);
 		if (rotation != 0) Util.rotateVector(v, rotation);
-		target.setVelocity(v);
+		if (!addVelocityInstead) target.setVelocity(v);
+		else target.setVelocity(target.getVelocity().add(v));
 		playSpellEffects(player, target);
 	}
 


### PR DESCRIPTION
Spells affected:

Forcepush, ForceToss, ForceBomb, Leap, Velocity.

All these spells have an add-velocity-instead option that adds that force to the target instead of setting it.

If I had 3 velocity to the right and I add 2 to the left. I will move slower.

Perfect for black-hole or gravity spells. This option is false by default.