### PR TITLE
Remove excess main from SoundEffect.java

### DIFF
--- a/src/com/nisovin/magicspells/spelleffects/SoundEffect.java
+++ b/src/com/nisovin/magicspells/spelleffects/SoundEffect.java
@@ -95,15 +95,6 @@ public class SoundEffect extends SpellEffect {
 		return null;
 	}
 	
-	public static void main(String[] args) {
-		Collection<String> sounds = new TreeSet<>();
-		File file = new File("C:\\Users\\Justin.Baker\\AppData\\Roaming\\.minecraft\\assets\\sound");
-		parseFolder(file, "", sounds);
-		for (String sound : sounds) {
-			System.out.println("   * " + sound);
-		}
-	}
-	
 	static void parseFolder(File folder, String path, Collection<String> sounds) {
 		File[] files = folder.listFiles();
 		for (File file : files) {			


### PR DESCRIPTION
This commit removes a Main method found in the SoundEffect.java on the basis of it being unused and containing personal information.