### PR TITLE
Stun, DoT, Levitate are now cleansable

### DIFF
--- a/src/com/nisovin/magicspells/spelleffects/EffectPosition.java
+++ b/src/com/nisovin/magicspells/spelleffects/EffectPosition.java
@@ -19,11 +19,11 @@ public enum EffectPosition {
 	
 	/** Can be referenced as: disabled
 	 *  Used in:
-	 *      - SteedSpell
-	 *      - ExternalCommandSpell
-	 *      - BuffSpell (and all sub classes)
-	 *      - DisguiseSpell
-	 *	- TotemSpell
+	 *  - SteedSpell
+	 *  - ExternalCommandSpell
+	 *  - BuffSpell (and all sub classes)
+	 *  - DisguiseSpell
+	 *  - TotemSpell
 	 **/
 	DISABLED(4, "disabled"),
 	
@@ -55,32 +55,32 @@ public enum EffectPosition {
 	
 	/** Can be referenced as: buff, active 
 	 *  Used in:
-	 *      - BuffSpell (and all subclasses)
-	 *      - StunSpell
+	 *  - BuffSpell (and all subclasses)
+	 *  - StunSpell
 	 **/
 	BUFF(7, "buff", "active"),
 	
 	/** Can be referenced as: orbit
 	 *  Used in:
-	 *      - BuffSpell (and all subclasses)
-	 *      - StunSpell
-	 *  	- BeamSpell
-	 *  	- ConjureSpell
-	 *  	- ConjureBookSpell
-	 *  	- ConjureFireworkSpell
-	 *  	- FirenovaSpell
-	 *  	- FlightPathSpell
-	 *  	- ParticleProjectileSpell
-	 *  	- MenuSpell
-	 *  	- AreaEffectSpell
-	 *  	- DrainlifeSpell
-	 *  	- EntombSpell
-	 *  	- ForcebombSpell
-	 *  	- HomingArrowSpell
-	 *  	- HomingMissileSpell
-	 *  	- OrbitSpell
-	 *  	- RewindSpell
-	 *  	- TotemSpell
+	 *  - BuffSpell (and all subclasses)
+	 *  - StunSpell
+	 *  - BeamSpell
+	 *  - ConjureSpell
+	 *  - ConjureBookSpell
+	 *  - ConjureFireworkSpell
+	 *  - FirenovaSpell
+	 *  - FlightPathSpell
+	 *  - ParticleProjectileSpell
+	 *  - MenuSpell
+	 *  - AreaEffectSpell
+	 *  - DrainlifeSpell
+	 *  - EntombSpell
+	 *  - ForcebombSpell
+	 *  - HomingArrowSpell
+	 *  - HomingMissileSpell
+	 *  - OrbitSpell
+	 *  - RewindSpell
+	 *  - TotemSpell
 	 **/
 	ORBIT(8, "orbit"),
 	
@@ -91,52 +91,61 @@ public enum EffectPosition {
 	/** May be referenced as: projectile
 	 * Some spells may use this to play an effect on projectile entities.
 	 * Currently enabled in:
-	 *   - ArrowSpell
-	 *   - DestroySpell
-	 *   - FireballSpell
-	 *   - FreezeSpell
-	 *   - HomingArrowSpell
-	 *   - ItemProjectileSpell
-	 *   - ProjectileSpell
-	 *   - SpawnTntSpell
-	 *   - ThrowBlockSpell
-	 *   - VolleySpell
-	 *   - WitherSkullSpell
-	 *   - Magnetspell
+	 *  - ArrowSpell
+	 *  - DestroySpell
+	 *  - FireballSpell
+	 *  - FreezeSpell
+	 *  - HomingArrowSpell
+	 *  - ItemProjectileSpell
+	 *  - ProjectileSpell
+	 *  - SpawnTntSpell
+	 *  - ThrowBlockSpell
+	 *  - VolleySpell
+	 *  - WitherSkullSpell
+	 *  - Magnetspell
 	 **/
 	PROJECTILE(10, "projectile"),
 	
 	/**
 	 * May be referenced as: casterprojectile or casterprojectileline
 	 * Currently supported effects:
-	 *    - effectlibline
+	 *  - effectlibline
 	 * Currently enabled in:
-	 *    - ArrowSpell
-	 *    - DestroySpell
-	 *    - FireballSpell
-	 *    - FreezeSpell
-	 *    - HomingArrowSpell
-	 *    - ItemProjectileSpell
-	 *    - ProjectileSpell
-	 *    - SpawnTntSpell
-	 *    - ThrowBlockSpell
-	 *    - VolleySpell
-	 *    - WitherSkullSpell
-	 *    - LevitateSpell
+	 *  - ArrowSpell
+	 *  - DestroySpell
+	 *  - FireballSpell
+	 *  - FreezeSpell
+	 *  - HomingArrowSpell
+	 *  - ItemProjectileSpell
+	 *  - ProjectileSpell
+	 *  - SpawnTntSpell
+	 *  - ThrowBlockSpell
+	 *  - VolleySpell
+	 *  - WitherSkullSpell
+	 *  - LevitateSpell
 	 */
 	DYNAMIC_CASTER_PROJECTILE_LINE(11, "casterprojectile", "casterprojectileline"),
 	
 	/**
 	 * May be referenced as: blockdestroy or blockdestruction
 	 * Spells supported in:
-	 *     - ThrowBlockSpell
-	 *     - SpawnTntSpell
-	 *     - MaterializeSpell
-	 *     - PulserSpell
-	 *     - EntombSpell
+	 *  - ThrowBlockSpell
+	 *  - SpawnTntSpell
+	 *  - MaterializeSpell
+	 *  - PulserSpell
+	 *  - EntombSpell
 	 */
-	BLOCK_DESTRUCTION(12, "blockdestroy", "blockdestruction");
+	BLOCK_DESTRUCTION(12, "blockdestroy", "blockdestruction"),
 	//TODO add this effect position to the WallSpell
+
+	/**
+	 * May be referenced in cleansable spells as: clear or cleansed
+	 * Spells supports in:
+	 *  - LevitateSpell
+	 *  - DotSpell
+	 *  - StunSpell
+	 */
+	CLEANSED(13, "clear", "cleansed");
 	
 	private int id;
 	private String[] names;

--- a/src/com/nisovin/magicspells/spells/targeted/DotSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/DotSpell.java
@@ -79,6 +79,24 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell, Spel
 		applyDot(null, target, power);
 		return true;
 	}
+
+	public boolean isActive(LivingEntity entity) {
+		return activeDots.keySet().stream()
+				.anyMatch(key -> {
+					Dot dot = activeDots.get(key);
+					return dot.target.getUniqueId().equals(entity.getUniqueId());
+				});
+	}
+
+	public void cancelDot(LivingEntity entity) {
+		activeDots.keySet().stream()
+				.map(key -> activeDots.get(key))
+				.filter(d -> d.target.getUniqueId().equals(entity.getUniqueId()))
+				.findFirst().ifPresent(dot -> {
+					dot.cancel();
+					playSpellEffects(EffectPosition.CLEANSED, entity);
+				});
+	}
 	
 	@EventHandler
 	void onDeath(PlayerDeathEvent event) {

--- a/src/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -92,6 +92,24 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 	public boolean castAtEntity(LivingEntity target, float power) {
 		return false;
 	}
+
+	public boolean isActive(LivingEntity entity) {
+		return levitating.keySet().stream()
+				.anyMatch(key -> {
+					Levitator levitator = levitating.get(key);
+					return levitator.target.getUniqueId().equals(entity.getUniqueId());
+				});
+	}
+
+	public void cancelLevitation(LivingEntity entity) {
+		levitating.keySet().stream()
+				.map(key -> levitating.get(key))
+				.filter(d -> d.target.getUniqueId().equals(entity.getUniqueId()))
+				.findFirst().ifPresent(levitator -> {
+					levitator.stop();
+					playSpellEffects(EffectPosition.CLEANSED, entity);
+				});
+	}
 	
 	public void onPlayerDeath(PlayerDeathEvent event) {
 		if (!levitating.containsKey(event.getEntity())) return;
@@ -184,7 +202,14 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 			stopped = true;
 			levitating.remove(caster);
 		}
-		
+
+		public Player getCaster() {
+			return caster;
+		}
+
+		public Entity getTarget() {
+			return target;
+		}
 	}
 
 }

--- a/src/com/nisovin/magicspells/spells/targeted/StunSpell.java
+++ b/src/com/nisovin/magicspells/spells/targeted/StunSpell.java
@@ -64,6 +64,27 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
+
+	public boolean isStunned(Player player) {
+		return stunnedPlayersUntil.containsKey(player.getName());
+	}
+
+	public boolean isStunned(LivingEntity entity) {
+		return stunnedEntitiesUntil.containsKey(entity);
+	}
+
+	public void cancelStun(Player player) {
+		if (listener == null) return;
+		StunListener listener = (StunListener) this.listener;
+		listener.removePlayer(player.getName());
+		playSpellEffects(EffectPosition.CLEANSED, player);
+	}
+
+	public void cancelStun(LivingEntity entity) {
+		stunnedEntitiesUntil.remove(entity);
+		stunnedEntitiesLocation.remove(entity);
+		playSpellEffects(EffectPosition.CLEANSED, entity);
+	}
 	
 	void stunPlayer(Player caster, Player target, int duration) {
 		stunnedPlayersUntil.put(target.getName(), System.currentTimeMillis() + duration);


### PR DESCRIPTION
Example Config
```
cleanse:
    spell-class: ".targeted.CleanseSpell"
    cast-item: nether_star
    remove:
      - "stun:stun"
      - "levitate:levitate"
      - "dot:dot"
    target-self: true
```

New Effect Position -> CLEANSED
Only works on cleanseable spells. Which are Stun, DoT, and Levitate for now.
You can refer to this position with either clear or cleansed

Example Config

```
levitate:
    spell-class: ".targeted.LevitateSpell"
    cast-item: nether_star
    duration: 10
    effects:
        cleanse:
            position: clear
            effect: particles
            particle-name: cloud
            speed: 0.1
            vert-spread: 3
            horiz-spread: 0.5
            count: 200
```