### PR TITLE
Call MagicSpellsEntityDamageByEntityEvent for any entity

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -71,7 +71,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 	}
 	
 	private boolean combust(Player player, final LivingEntity target, float power) {
-		if (target instanceof Player && checkPlugins && player != null) {
+		if (checkPlugins && player != null) {
 			MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, target, DamageCause.ENTITY_ATTACK, 1);
 			EventUtil.call(event);
 			if (event.isCancelled()) return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
@@ -108,7 +108,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 				LivingEntity entity = targetInfo.getTarget();
 				power = targetInfo.getPower();
 				if (entity == null) return noTarget(player);
-				if (entity instanceof Player && checkPlugins) {
+				if (checkPlugins) {
 					// Run a pvp damage check
 					MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, entity, DamageCause.ENTITY_ATTACK, 1D);
 					EventUtil.call(event);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -71,7 +71,7 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 
 		if (damage > 0) {
 			double damage = this.damage * power;
-			if (target instanceof Player && checkPlugins) {
+			if (checkPlugins) {
 				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, target, DamageCause.ENTITY_ATTACK, damage);
 				EventUtil.call(event);
 				if (!avoidDamageModification) damage = event.getDamage();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
@@ -79,7 +79,7 @@ public class GeyserSpell extends TargetedSpell implements TargetedEntitySpell {
 	private boolean geyser(Player caster, LivingEntity target, float power) {
 		double dam = damage * power;
 		
-		if (caster != null && target instanceof Player && checkPlugins && damage > 0) {
+		if (caster != null && checkPlugins && damage > 0) {
 			MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(caster, target, DamageCause.ENTITY_ATTACK, dam);
 			EventUtil.call(event);
 			if (event.isCancelled()) return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -58,7 +58,7 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 					entityTarget = targetInfo.getTarget();
 					power = targetInfo.getPower();
 				}
-				if (entityTarget instanceof Player && checkPlugins) {
+				if (checkPlugins) {
 					MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(player, entityTarget, DamageCause.ENTITY_ATTACK, 1 + additionalDamage);
 					EventUtil.call(event);
 					if (event.isCancelled()) entityTarget = null;


### PR DESCRIPTION
Almost any time MagicSpellsEntityDamageByEntityEvent is called, MagicSpells checks the entity to see if it's a player. However the constructor for this event accepts entities and the name of the event is misleading. There is no reason that MagicSpells should check for this.

This PR  removes that check and calls the event on any entity like it should.

