### PR TITLE
First part of Beta 5

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -184,10 +184,10 @@ subprojects {
       url = "https://jitpack.io"
     }
   }
-  it.version = "4.0-Beta-4"
+  it.version = "4.0-Beta-5"
   
   processResources {
-    expand(["version": "4.0-Beta-4"])
+    expand(["version": "4.0-Beta-5"])
   }
   shadowJar {
     configurations = [project.configurations.shadow]

--- a/core/src/main/java/com/nisovin/magicspells/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/CastListener.java
@@ -16,19 +16,17 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerAnimationEvent;
 
-import com.nisovin.magicspells.util.TimeUtil;
 import com.nisovin.magicspells.util.BlockUtils;
-import com.nisovin.magicspells.mana.ManaChangeReason;
 
 public class CastListener implements Listener {
 
-	MagicSpells plugin;
+	private MagicSpells plugin;
 
-	private HashMap<String, Long> noCastUntil = new HashMap<>();
-	//private HashMap<String,Long> lastCast = new HashMap<String, Long>();
+	private Map<String, Long> noCastUntil;
 
 	CastListener(MagicSpells plugin) {
 		this.plugin = plugin;
+		noCastUntil = new HashMap<>();
 	}
 
 	@EventHandler(priority=EventPriority.MONITOR)
@@ -56,10 +54,9 @@ public class CastListener implements Listener {
 			} else if (event.hasItem() && event.getItem().getType().isBlock()) {
 				noInteract = true;
 			}
-			if (m == Material.ENCHANTING_TABLE) {
-				// Force exp bar back to show exp when trying to enchant
-				MagicSpells.getExpBarManager().update(player, player.getLevel(), player.getExp());
-			}
+
+			// Force exp bar back to show exp when trying to enchant
+			if (m == Material.ENCHANTING_TABLE) MagicSpells.getExpBarManager().update(player, player.getLevel(), player.getExp());
 		}
 
 		if (noInteract) {
@@ -75,67 +72,29 @@ public class CastListener implements Listener {
 		}
 
 		if ((event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) && (plugin.cycleSpellsOnOffhandAction || event.getHand() == EquipmentSlot.HAND)) {
-			// Right click -- cycle spell and/or process mana pots
+			// Right click -- cycle spell
 			ItemStack inHand = player.getEquipment().getItemInMainHand();
 			if ((inHand != null && !BlockUtils.isAir(inHand.getType())) || plugin.allowCastWithFist) {
 
 				// Cycle spell
-				Spell spell = null;
+				Spell spell;
 				if (!player.isSneaking()) spell = MagicSpells.getSpellbook(player).nextSpell(inHand);
 				else spell = MagicSpells.getSpellbook(player).prevSpell(inHand);
 
-				if (spell != null) {
-					// Send message
-					MagicSpells.sendMessageAndFormat(player, plugin.strSpellChange, "%s", spell.getName());
-					// Show spell icon
-					if (plugin.spellIconSlot >= 0) {
-						showIcon(player, plugin.spellIconSlot, spell.getSpellIcon());
-					}
-					// Use cool new text thingy
-					boolean yay = false;
-					if (yay) {
-						final ItemStack fake = inHand.clone(); //TODO ensure this is not null
-						ItemMeta meta = fake.getItemMeta();
-						meta.setDisplayName("Spell: " + spell.getName());
-						fake.setItemMeta(meta);
-						MagicSpells.scheduleDelayedTask(() -> MagicSpells.getVolatileCodeHandler().sendFakeSlotUpdate(player, player.getInventory().getHeldItemSlot(), fake), 0);
-					}
-				}
-
-				// Check for mana pots
-				if (plugin.enableManaBars && MagicSpells.getManaPotions() != null) {
-					// Find mana potion TODO: fix this, it's not good
-					int restoreAmt = 0;
-					for (Map.Entry<ItemStack, Integer> entry : MagicSpells.getManaPotions().entrySet()) {
-						if (inHand.isSimilar(entry.getKey())) { //TODO make sure this is not null
-							restoreAmt = entry.getValue();
-							break;
-						}
-					}
-					if (restoreAmt > 0) {
-						// Check cooldown
-						if (plugin.manaPotionCooldown > 0) {
-							Long c = MagicSpells.getManaPotionCooldowns().get(player);
-							if (c != null && c > System.currentTimeMillis()) {
-								MagicSpells.sendMessage(plugin.strManaPotionOnCooldown.replace("%c", "" + (int)((c - System.currentTimeMillis())/TimeUtil.MILLISECONDS_PER_SECOND)), player, MagicSpells.NULL_ARGS);
-								return;
-							}
-						}
-						// Add mana
-						boolean added = MagicSpells.getManaHandler().addMana(player, restoreAmt, ManaChangeReason.POTION);
-						if (added) {
-							// Set cooldown
-							if (plugin.manaPotionCooldown > 0) {
-								MagicSpells.getManaPotionCooldowns().put(player, System.currentTimeMillis() + plugin.manaPotionCooldown * TimeUtil.MILLISECONDS_PER_SECOND);
-							}
-							// Remove item
-							//TODO make sure this is not null
-							if (inHand.getAmount() == 1) inHand = null;
-							else inHand.setAmount(inHand.getAmount() - 1);
-							player.getEquipment().setItemInMainHand(inHand);
-							player.updateInventory();
-						}
-					}
+				if (spell == null) return;
+				// Send message
+				MagicSpells.sendMessageAndFormat(player, plugin.strSpellChange, "%s", spell.getName());
+				// Show spell icon
+				if (plugin.spellIconSlot >= 0) showIcon(player, plugin.spellIconSlot, spell.getSpellIcon());
+				// Use cool new text thingy
+				boolean yay = false;
+				if (yay) {
+					final ItemStack fake = inHand.clone();
+					if (fake == null) return;
+					ItemMeta meta = fake.getItemMeta();
+					meta.setDisplayName("Spell: " + spell.getName());
+					fake.setItemMeta(meta);
+					MagicSpells.scheduleDelayedTask(() -> MagicSpells.getVolatileCodeHandler().sendFakeSlotUpdate(player, player.getInventory().getHeldItemSlot(), fake), 0);
 				}
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/MagicXpHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicXpHandler.java
@@ -36,10 +36,10 @@ public class MagicXpHandler implements Listener {
 
 	private Map<String, String> schools = new HashMap<>();
 	private Map<String, IntMap<String>> xp = new HashMap<>();
-	private Set<String> dirty = new HashSet<>();
 	private Map<String, String> currentWorld = new HashMap<>();
-
 	private Map<String, List<Spell>> spellSchoolRequirements = new HashMap<>();
+
+	private Set<String> dirty = new HashSet<>();
 
 	private boolean autoLearn;
 	private String strXpHeader;
@@ -115,6 +115,7 @@ public class MagicXpHandler implements Listener {
 		if (!autoLearn) return;
 		final LivingEntity caster = event.getCaster();
 		if (!(caster instanceof Player)) return;
+
 		Player player = (Player) caster;
 		final Spell castedSpell = event.getSpell();
 		MagicSpells.scheduleDelayedTask(() -> {

--- a/core/src/main/java/com/nisovin/magicspells/RightClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/RightClickListener.java
@@ -55,7 +55,7 @@ public class RightClickListener implements Listener {
 			lastCast.put(player.getName(), System.currentTimeMillis());
 		}
 			
-		MagicSpells.scheduleDelayedTask(() -> spell.cast(event.getPlayer()), 0);
+		MagicSpells.scheduleDelayedTask(() -> spell.cast(player), 0);
 		event.setCancelled(true);
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/Spellbook.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spellbook.java
@@ -106,9 +106,7 @@ public class Spellbook {
 			MagicSpells.debug(2, "  Op, granting all spells...");
 			for (Spell spell : MagicSpells.getSpellsOrdered()) {
 				if (spell.isHelperSpell()) continue;
-				if (!allSpells.contains(spell)) {
-					addSpell(spell);
-				}
+				if (!allSpells.contains(spell)) addSpell(spell);
 			}
 		}
 
@@ -415,7 +413,7 @@ public class Spellbook {
 	}
 
 	public void addSpell(Spell spell) {
-		addSpell(spell, (CastItem[])null);
+		addSpell(spell, (CastItem[]) null);
 	}
 
 	public void addSpell(Spell spell, CastItem castItem) {
@@ -618,9 +616,9 @@ public class Spellbook {
 		return "Spellbook:[playerName=" + playerName
 				+ ",uniqueId=" + uniqueId
 				+ ",allSpells=" + allSpells
-				+ ",ItemSpells=" + itemSpells
-				+ ",ActiveSpells=" + activeSpells
-				+ ",CustomBindings=" + customBindings
+				+ ",itemSpells=" + itemSpells
+				+ ",activeSpells=" + activeSpells
+				+ ",customBindings=" + customBindings
 				+ ",temporarySpells=" + temporarySpells
 				+ ",cantLearn=" + cantLearn
 				+ ']';

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells;
 import java.util.Random;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.Util;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
@@ -85,6 +85,7 @@ public abstract class Condition {
 		conditions.put("mana", ManaCondition.class);
 		conditions.put("maxmana", MaxManaCondition.class);
 		conditions.put("food", FoodCondition.class);
+		conditions.put("gamemode", GameModeCondition.class);
 		conditions.put("level", LevelCondition.class);
 		conditions.put("magicxpabove", MagicXpAboveCondition.class);
 		conditions.put("magicxpbelow", MagicXpBelowCondition.class);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/GameModeCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/GameModeCondition.java
@@ -1,0 +1,48 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.GameMode;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.DebugHandler;
+import com.nisovin.magicspells.castmodifiers.Condition;
+
+public class GameModeCondition extends Condition {
+
+	private GameMode mode;
+
+	@Override
+	public boolean setVar(String var) {
+		try {
+			mode = GameMode.valueOf(var.toUpperCase());
+			return true;
+		} catch (IllegalArgumentException e) {
+			mode = null;
+			DebugHandler.debugIllegalArgumentException(e);
+			return false;
+		}
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity) {
+		return gameMode(livingEntity);
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity, LivingEntity target) {
+		return gameMode(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity, Location location) {
+		return false;
+	}
+
+	private boolean gameMode(LivingEntity livingEntity) {
+		if (mode == null) return false;
+		if (!(livingEntity instanceof Player)) return false;
+		return ((Player) livingEntity).getGameMode() == mode;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/mana/ManaBar.java
+++ b/core/src/main/java/com/nisovin/magicspells/mana/ManaBar.java
@@ -9,15 +9,17 @@ import com.nisovin.magicspells.events.ManaChangeEvent;
 
 public class ManaBar {
 
-	private String playerName;
-	private ManaRank rank;
-	private int maxMana;
-	private int regenAmount;
 	private String prefix;
+	private String playerName;
+
+	private ManaRank rank;
+
 	private ChatColor colorFull;
 	private ChatColor colorEmpty;
-	
+
 	private int mana;
+	private int maxMana;
+	private int regenAmount;
 	
 	public ManaBar(Player player, ManaRank rank) {
 		playerName = player.getName().toLowerCase();
@@ -26,10 +28,10 @@ public class ManaBar {
 	
 	public void setRank(ManaRank rank) {
 		this.rank = rank;
-		maxMana = rank.maxMana;
-		regenAmount = rank.regenAmount;
-		mana = rank.startingMana;
-		setDisplayData(rank.prefix, rank.colorFull, rank.colorEmpty);
+		mana = rank.getStartingMana();
+		maxMana = rank.getMaxMana();
+		regenAmount = rank.getRegenAmount();
+		setDisplayData(rank.getPrefix(), rank.getColorFull(), rank.getColorEmpty());
 	}
 	
 	public Player getPlayer() {
@@ -62,7 +64,7 @@ public class ManaBar {
 	}
 	
 	private void setDisplayData(String prefix, ChatColor colorFull, ChatColor colorEmpty) {
-		this.prefix = prefix;
+		this.prefix = ChatColor.translateAlternateColorCodes('&', prefix);
 		this.colorFull = colorFull;
 		this.colorEmpty = colorEmpty;
 	}
@@ -107,11 +109,8 @@ public class ManaBar {
 	
 	public boolean setMana(int amount, ManaChangeReason reason) {
 		int newAmt = amount;
-		if (newAmt > maxMana) {
-			newAmt = maxMana;
-		} else if (newAmt < 0) {
-			newAmt = 0;
-		}
+		if (newAmt > maxMana) newAmt = maxMana;
+		else if (newAmt < 0) newAmt = 0;
 		
 		newAmt = callManaChangeEvent(newAmt, reason);
 		if (newAmt == mana) return false;
@@ -126,12 +125,10 @@ public class ManaBar {
 	
 	private int callManaChangeEvent(int newAmt, ManaChangeReason reason) {
 		Player player = getPlayer();
-		if (player != null && player.isOnline()) {
-			ManaChangeEvent event = new ManaChangeEvent(player, mana, newAmt, maxMana, reason);
-			EventUtil.call(event);
-			return event.getNewAmount();
-		}
-		return newAmt;
+		if (player == null || !player.isOnline()) return newAmt;
+		ManaChangeEvent event = new ManaChangeEvent(player, mana, newAmt, maxMana, reason);
+		EventUtil.call(event);
+		return event.getNewAmount();
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/mana/ManaRank.java
+++ b/core/src/main/java/com/nisovin/magicspells/mana/ManaRank.java
@@ -4,22 +4,128 @@ import org.bukkit.ChatColor;
 
 public class ManaRank {
 	
-	String name;
-	int startingMana;
-	int maxMana;
-	int regenAmount;
-	String prefix;
-	ChatColor colorFull;
-	ChatColor colorEmpty;
+	private String name;
+	private String prefix;
+
+	private char symbol;
+
+	private int barSize;
+	private int maxMana;
+	private int startingMana;
+	private int regenAmount;
+	private int regenInterval;
+
+	private ChatColor colorFull;
+	private ChatColor colorEmpty;
+
+	ManaRank() {
+
+	}
+
+	ManaRank(String name, String prefix, char symbol, int barSize, int maxMana, int startingMana, int regenAmount, int regenInterval, ChatColor colorFull, ChatColor colorEmpty) {
+		this.name = name;
+		this.prefix = prefix;
+		this.symbol = symbol;
+		this.barSize = barSize;
+		this.maxMana = maxMana;
+		this.startingMana = startingMana;
+		this.regenAmount = regenAmount;
+		this.regenInterval = regenInterval;
+		this.colorFull = colorFull;
+		this.colorEmpty = colorEmpty;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getPrefix() {
+		return prefix;
+	}
+
+	public void setPrefix(String prefix) {
+		this.prefix = prefix;
+	}
+
+	public char getSymbol() {
+		return symbol;
+	}
+
+	public void setSymbol(char symbol) {
+		this.symbol = symbol;
+	}
+
+	public int getBarSize() {
+		return barSize;
+	}
+
+	public void setBarSize(int barSize) {
+		this.barSize = barSize;
+	}
+
+	public int getMaxMana() {
+		return maxMana;
+	}
+
+	public void setMaxMana(int maxMana) {
+		this.maxMana = maxMana;
+	}
+
+	public int getStartingMana() {
+		return startingMana;
+	}
+
+	public void setStartingMana(int startingMana) {
+		this.startingMana = startingMana;
+	}
+
+	public int getRegenAmount() {
+		return regenAmount;
+	}
+
+	public void setRegenAmount(int regenAmount) {
+		this.regenAmount = regenAmount;
+	}
+
+	public int getRegenInterval() {
+		return regenInterval;
+	}
+
+	public void setRegenInterval(int regenInterval) {
+		this.regenInterval = regenInterval;
+	}
+
+	public ChatColor getColorFull() {
+		return colorFull;
+	}
+
+	public void setColorFull(ChatColor colorFull) {
+		this.colorFull = colorFull;
+	}
+
+	public ChatColor getColorEmpty() {
+		return colorEmpty;
+	}
+
+	public void setColorEmpty(ChatColor colorEmpty) {
+		this.colorEmpty = colorEmpty;
+	}
 	
 	@Override
 	public String toString() {
 		return "ManaRank:["
 			+ "name=" + name
-			+ ",startingMana=" + startingMana
-			+ ",maxMana=" + maxMana
-			+ ",regenAmount=" + regenAmount
 			+ ",prefix=" + prefix
+			+ ",symbol=" + symbol
+			+ ",barSize" + barSize
+			+ ",maxMana=" + maxMana
+			+ ",startingMana=" + startingMana
+			+ ",regenAmount=" + regenAmount
+			+ ",regenInterval=" + regenInterval
 			+ ",colorFull=" + colorFull
 			+ ",colorEmpty=" + colorEmpty
 			+ ']';

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/EffectPosition.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/EffectPosition.java
@@ -17,7 +17,10 @@ public enum EffectPosition {
 	REVERSE_LINE(9, "reverse_line", "reverseline", "rline"),
 	PROJECTILE(10, "projectile"),
 	DYNAMIC_CASTER_PROJECTILE_LINE(11, "casterprojectile", "casterprojectileline"),
-	BLOCK_DESTRUCTION(12, "blockdestroy", "blockdestruction")
+	BLOCK_DESTRUCTION(12, "blockdestroy", "blockdestruction"),
+	COOLDOWN(13, "cooldown"),
+	MISSING_REAGENTS(14, "missingreagents"),
+	CHARGE_USE(15, "chargeuse")
 
 	;
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/TitleEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/TitleEffect.java
@@ -40,7 +40,7 @@ public class TitleEffect extends SpellEffect {
 	}
 	
 	private void send(Player player) {
-		MagicSpells.getVolatileCodeHandler().sendTitleToPlayer(player, title, subtitle, fadeIn, stay, fadeOut);
+		MagicSpells.getVolatileCodeHandler().sendTitleToPlayer(player, MagicSpells.doVariableReplacements(player, title), MagicSpells.doVariableReplacements(player, subtitle), fadeIn, stay, fadeOut);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -257,6 +257,12 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (manager != null) manager.addBuff(livingEntity, this);
 	}
 
+	public float getDuration(LivingEntity livingEntity) {
+		if (durationEndTime == null) return 0;
+		if (!durationEndTime.containsKey(livingEntity)) return 0;
+		return (durationEndTime.get(livingEntity) - System.currentTimeMillis()) / 1000F;
+	}
+
 	/**
 	 * Checks whether the spell's duration has expired for a player
 	 * @param entity the player to check

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
@@ -1,9 +1,9 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
+import java.util.HashMap;
+import java.util.HashSet;
 
 import org.bukkit.event.EventPriority;
 
@@ -75,6 +75,7 @@ public class PassiveTrigger {
 	
 	public static Set<PassiveTrigger> START_GLIDE = addTriggers("startglide", GlideListener.class);
 	public static Set<PassiveTrigger> STOP_GLIDE = addTriggers("stopglide", GlideListener.class);
+	public static Set<PassiveTrigger> SIGN_BOOK = addTriggers("signbook", SignBookListener.class);
 	
 	
 	public static Set<PassiveTrigger> addTriggers(String baseName, Class<? extends PassiveListener> listener) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
@@ -1,0 +1,67 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.ArrayList;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.meta.BookMeta;
+import org.bukkit.event.player.PlayerEditBookEvent;
+
+import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.PassiveSpell;
+import com.nisovin.magicspells.util.OverridePriority;
+
+// Trigger variable is optional
+// If not specified, it will trigger on any book
+// If specified, it should be a comma separated list of page text to trigger on
+public class SignBookListener extends PassiveListener {
+
+	private List<PassiveSpell> spells = new ArrayList<>();
+	private Map<String, List<PassiveSpell>> types = new HashMap<>();
+
+	@Override
+	public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
+		if (var == null || var.isEmpty()) {
+			spells.add(spell);
+			return;
+		}
+
+		String[] split = var.split(",");
+		for (String s : split) {
+			List<PassiveSpell> passives = types.computeIfAbsent(s, p -> new ArrayList<>());
+			passives.add(spell);
+		}
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onBookEdit(PlayerEditBookEvent event) {
+		Player player = event.getPlayer();
+		BookMeta meta = event.getNewBookMeta();
+		if (!meta.hasAuthor()) return;
+
+		Spellbook spellbook = MagicSpells.getSpellbook(player);
+		if (!spells.isEmpty()) {
+			for (PassiveSpell spell : spells) {
+				if (!spellbook.hasSpell(spell)) continue;
+				spell.activate(player);
+			}
+		}
+
+		for (int i = 1; i <= meta.getPageCount(); i++) {
+			if (!types.containsKey(meta.getPage(i))) continue;
+			List<PassiveSpell> list = types.get(meta.getPage(i));
+			for (PassiveSpell spell : list) {
+				if (!spellbook.hasSpell(spell)) continue;
+				spell.activate(player);
+				return;
+			}
+
+		}
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisguiseSpell.java
@@ -29,10 +29,10 @@ import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.EntityData;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.IDisguiseManager;
 import com.nisovin.magicspells.events.SpellCastedEvent;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager;
 
 public class DisguiseSpell extends TargetedSpell implements TargetedEntitySpell {
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
@@ -1,0 +1,79 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import java.util.Set;
+import java.util.List;
+
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
+import com.nisovin.magicspells.util.managers.AttributeManager;
+
+public class EntityEditSpell extends TargetedSpell implements TargetedEntitySpell {
+
+	private Set<AttributeManager.AttributeInfo> attributes;
+
+	private boolean toggle;
+
+	public EntityEditSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		// Attributes
+		// - [AttributeName] [Number] [Operation]
+		List<String> attributeList = getConfigStringList("attributes", null);
+		if (attributeList != null && !attributeList.isEmpty()) attributes = MagicSpells.getAttributeManager().getAttributes(attributeList);
+
+		toggle = getConfigBoolean("toggle", false);
+	}
+
+	@Override
+	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
+		if (state == SpellCastState.NORMAL) {
+			TargetInfo<LivingEntity> target = getTargetedEntity(livingEntity, power);
+			if (target == null) return noTarget(livingEntity);
+
+			applyAttributes(target.getTarget());
+			playSpellEffects(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget());
+			return PostCastAction.NO_MESSAGES;
+		}
+		return PostCastAction.HANDLE_NORMALLY;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		playSpellEffects(caster, target);
+		applyAttributes(target);
+		return true;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		playSpellEffects(EffectPosition.TARGET, target);
+		applyAttributes(target);
+		return true;
+	}
+
+	private void applyAttributes(LivingEntity entity) {
+		if (attributes == null) return;
+		if (toggle) {
+			boolean apply = false;
+			for (AttributeManager.AttributeInfo info : attributes) {
+				apply = MagicSpells.getAttributeManager().hasEntityAttribute(entity, info);
+			}
+			if (!apply) MagicSpells.getAttributeManager().addEntityAttributes(entity, attributes);
+			else MagicSpells.getAttributeManager().clearEntityAttributeModifiers(entity, attributes);
+			return;
+		}
+
+		for (AttributeManager.AttributeInfo info : attributes) {
+			if (MagicSpells.getAttributeManager().hasEntityAttribute(entity, info)) continue;
+			MagicSpells.getAttributeManager().addEntityAttribute(entity, info);
+		}
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/UndisguiseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/UndisguiseSpell.java
@@ -6,7 +6,7 @@ import org.bukkit.entity.LivingEntity;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.IDisguiseManager;
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -1,0 +1,86 @@
+package com.nisovin.magicspells.util;
+
+import java.util.Map;
+import java.util.HashMap;
+
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeModifier;
+
+public class AttributeUtil {
+
+	public enum AttributeOperation {
+
+		ADD_NUMBER("add_number", "addnumber"),
+		ADD_SCALAR("add_scalar", "addscalar"),
+		MULTIPLY_SCALAR_1("multiply_scalar", "multiplyscalar");
+
+		private String[] names;
+
+		private static Map<String, AttributeModifier.Operation> nameMap = new HashMap<>();
+
+		AttributeOperation(String... names) {
+			this.names = names;
+		}
+
+		static {
+			for (AttributeOperation op : AttributeOperation.values()) {
+				AttributeModifier.Operation operation = AttributeModifier.Operation.valueOf(op.name());
+				if (operation == null) continue;
+
+				nameMap.put(op.name().toLowerCase(), operation);
+				for (String s : op.names) {
+					nameMap.put(s.toLowerCase(), operation);
+				}
+
+			}
+		}
+
+		public static AttributeModifier.Operation getOperation(String operation) {
+			return nameMap.get(operation.toLowerCase());
+		}
+
+	}
+
+	public enum AttributeType {
+
+		GENERIC_ARMOR("generic.armor", "armor"),
+		GENERIC_ARMOR_TOUGHNESS("generic.armortoughness", "armortoughness", "armor_toughness"),
+		GENERIC_ATTACK_DAMAGE("generic.attackdamage", "attackdamage", "attack_damage"),
+		GENERIC_ATTACK_SPEED("generic.attackspeed", "attackspeed", "attack_speed"),
+		GENERIC_FLYING_SPEED("generic.flyingspeed", "flyingspeed", "flying_speed"),
+		GENERIC_FOLLOW_RANGE("generic.followrange", "followrange", "follow_range"),
+		GENERIC_KNOCKBACK_RESISTANCE("generic.knockbackresistance", "knockbackresistance", "knockback_resistance"),
+		GENERIC_LUCK("generic.luck", "luck"),
+		GENERIC_MAX_HEALTH("generic.maxhealth", "maxhealth", "max_health"),
+		GENERIC_MOVEMENT_SPEED("generic.movementspeed", "movementspeed", "movement_speed"),
+		HORSE_JUMP_STRENGTH("horsejumpstrength", "horse_jump_strength"),
+		ZOMBIE_SPAWN_REINFORCEMENTS("zombiespawnreinforcements", "zombie_spawn_reinforcements");
+
+		private String[] names;
+
+		private static Map<String, Attribute> nameMap = new HashMap<>();
+
+		AttributeType(String... names) {
+			this.names = names;
+		}
+
+		static {
+			for (AttributeType type : AttributeType.values()) {
+				Attribute attribute = Attribute.valueOf(type.name());
+				if (attribute == null) continue;
+
+				nameMap.put(type.name().toLowerCase(), attribute);
+				for (String s : type.names) {
+					nameMap.put(s.toLowerCase(), attribute);
+				}
+
+			}
+		}
+
+		public static Attribute getAttribute(String attribute) {
+			return nameMap.get(attribute.toLowerCase());
+		}
+
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/BlockPlatform.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BlockPlatform.java
@@ -1,11 +1,11 @@
 package com.nisovin.magicspells.util;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 
-import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.World;
+import org.bukkit.Material;
+import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 
@@ -36,16 +36,16 @@ public class BlockPlatform {
 		List<Block> platform = new ArrayList<>();
 		
 		// Get platform blocks
-		if (this.type.equals("square")) {
+		if (type.equals("square")) {
 			Block block;
 			Block above;
-			int cx = this.center.getX();
-			int cy = this.center.getY();
-			int cz = this.center.getZ();
-			World world = this.center.getWorld();
+			int cx = center.getX();
+			int cy = center.getY();
+			int cz = center.getZ();
+			World world = center.getWorld();
 			int max = world.getMaxHeight();
-			for (int x = cx - this.size; x <= cx + this.size; x++) {
-				for (int z = cz - this.size; z <= cz + this.size; z++) {
+			for (int x = cx - size; x <= cx + size; x++) {
+				for (int z = cz - size; z <= cz + size; z++) {
 					block = world.getBlockAt(x, cy, z);
 					above = block.getRelative(0, 1, 0);
 					if ((block.getType() == replaceType && (cy >= max - 1 || (blocks != null && blocks.contains(above)) || above.getType() == Material.AIR)) || (blocks != null && blocks.contains(block))) {
@@ -54,12 +54,12 @@ public class BlockPlatform {
 					}
 				}
 			}
-		} else if (this.type.equals("cube")) {
+		} else if (type.equals("cube")) {
 			Block block;
-			for (int x = this.center.getX() - size; x <= this.center.getX() + this.size; x++) {
-				for (int y = this.center.getY() - size; y <= this.center.getY() + this.size; y++) {
-					for (int z = this.center.getZ()-size; z <= this.center.getZ() + this.size; z++) {
-						block = this.center.getWorld().getBlockAt(x, y, z);
+			for (int x = center.getX() - size; x <= center.getX() + size; x++) {
+				for (int y = center.getY() - size; y <= center.getY() + size; y++) {
+					for (int z = center.getZ()-size; z <= center.getZ() + size; z++) {
+						block = center.getWorld().getBlockAt(x, y, z);
 						if (block.getType() == replaceType || (blocks != null && blocks.contains(block))) {
 							// Only add if it's a replaceable block or if it is already part of the block set
 							platform.add(block);
@@ -70,11 +70,11 @@ public class BlockPlatform {
 		}
 		
 		// Remove old platform blocks
-		if (this.moving) {
-			for (Block block : this.blocks) {
-				if (!platform.contains(block) && block.getType() == this.platformType) {
+		if (moving && blocks != null) {
+			for (Block block : blocks) {
+				if (!platform.contains(block) && block.getType() == platformType) {
 					BlockState state = block.getState();
-					state.setType(this.replaceType);
+					state.setType(replaceType);
 					state.update(true, false);
 				}
 			}
@@ -82,9 +82,9 @@ public class BlockPlatform {
 		
 		// Add new platform blocks
 		for (Block block : platform) {
-			if (this.blocks == null || !this.blocks.contains(block)) {
+			if (blocks == null || !blocks.contains(block)) {
 				BlockState state = block.getState();
-				state.setType(this.platformType);
+				state.setType(platformType);
 				state.update(true, false);
 			}
 		}
@@ -139,7 +139,7 @@ public class BlockPlatform {
 	}
 	
 	public Block getCenter () {
-		return this.center;
+		return center;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
@@ -90,205 +90,205 @@ public class BlockUtils {
 	public static boolean isAir(Material m) {
 		return
 				m == Material.AIR ||
-						m == Material.VOID_AIR ||
-						m == Material.CAVE_AIR;
+				m == Material.VOID_AIR ||
+				m == Material.CAVE_AIR;
 	}
 
 	public static boolean isBed(Material m) {
 		return
 				m == Material.WHITE_BED ||
-						m == Material.RED_BED ||
-						m == Material.PURPLE_BED ||
-						m == Material.PINK_BED ||
-						m == Material.ORANGE_BED ||
-						m == Material.MAGENTA_BED ||
-						m == Material.LIME_BED ||
-						m == Material.LIGHT_GRAY_BED ||
-						m == Material.LIGHT_BLUE_BED ||
-						m == Material.GREEN_BED ||
-						m == Material.GRAY_BED ||
-						m == Material.CYAN_BED ||
-						m == Material.YELLOW_BED ||
-						m == Material.BROWN_BED ||
-						m == Material.BLUE_BED ||
-						m == Material.BLACK_BED;
+				m == Material.RED_BED ||
+				m == Material.PURPLE_BED ||
+				m == Material.PINK_BED ||
+				m == Material.ORANGE_BED ||
+				m == Material.MAGENTA_BED ||
+				m == Material.LIME_BED ||
+				m == Material.LIGHT_GRAY_BED ||
+				m == Material.LIGHT_BLUE_BED ||
+				m == Material.GREEN_BED ||
+				m == Material.GRAY_BED ||
+				m == Material.CYAN_BED ||
+				m == Material.YELLOW_BED ||
+				m == Material.BROWN_BED ||
+				m == Material.BLUE_BED ||
+				m == Material.BLACK_BED;
 	}
 
 	public static boolean isWoodDoor(Material m) {
 		return
 				m == Material.OAK_DOOR ||
-						m == Material.ACACIA_DOOR ||
-						m == Material.JUNGLE_DOOR ||
-						m == Material.SPRUCE_DOOR ||
-						m == Material.DARK_OAK_DOOR ||
-						m == Material.BIRCH_DOOR;
+				m == Material.ACACIA_DOOR ||
+				m == Material.JUNGLE_DOOR ||
+				m == Material.SPRUCE_DOOR ||
+				m == Material.DARK_OAK_DOOR ||
+				m == Material.BIRCH_DOOR;
 	}
 
 	public static boolean isWoodButton(Material m) {
 		return
 				m == Material.OAK_BUTTON ||
-						m == Material.ACACIA_BUTTON ||
-						m == Material.JUNGLE_BUTTON ||
-						m == Material.SPRUCE_BUTTON ||
-						m == Material.DARK_OAK_BUTTON ||
-						m == Material.BIRCH_BUTTON;
+				m == Material.ACACIA_BUTTON ||
+				m == Material.JUNGLE_BUTTON ||
+				m == Material.SPRUCE_BUTTON ||
+				m == Material.DARK_OAK_BUTTON ||
+				m == Material.BIRCH_BUTTON;
 	}
 
 	public static boolean isWoodPressurePlate(Material m) {
 		return
 				m == Material.OAK_PRESSURE_PLATE ||
-						m == Material.ACACIA_PRESSURE_PLATE ||
-						m == Material.JUNGLE_PRESSURE_PLATE ||
-						m == Material.SPRUCE_PRESSURE_PLATE ||
-						m == Material.DARK_OAK_PRESSURE_PLATE ||
-						m == Material.BIRCH_PRESSURE_PLATE;
+				m == Material.ACACIA_PRESSURE_PLATE ||
+				m == Material.JUNGLE_PRESSURE_PLATE ||
+				m == Material.SPRUCE_PRESSURE_PLATE ||
+				m == Material.DARK_OAK_PRESSURE_PLATE ||
+				m == Material.BIRCH_PRESSURE_PLATE;
 	}
 
 	public static boolean isWoodTrapdoor(Material m) {
 		return
 				m == Material.OAK_TRAPDOOR ||
-						m == Material.ACACIA_TRAPDOOR ||
-						m == Material.JUNGLE_TRAPDOOR ||
-						m == Material.SPRUCE_TRAPDOOR ||
-						m == Material.DARK_OAK_TRAPDOOR ||
-						m == Material.BIRCH_TRAPDOOR;
+				m == Material.ACACIA_TRAPDOOR ||
+				m == Material.JUNGLE_TRAPDOOR ||
+				m == Material.SPRUCE_TRAPDOOR ||
+				m == Material.DARK_OAK_TRAPDOOR ||
+				m == Material.BIRCH_TRAPDOOR;
 	}
 
 	public static boolean isWood(Material m) {
 		return
 				m == Material.OAK_WOOD ||
-						m == Material.ACACIA_WOOD ||
-						m == Material.JUNGLE_WOOD ||
-						m == Material.SPRUCE_WOOD ||
-						m == Material.DARK_OAK_WOOD ||
-						m == Material.BIRCH_WOOD;
+				m == Material.ACACIA_WOOD ||
+				m == Material.JUNGLE_WOOD ||
+				m == Material.SPRUCE_WOOD ||
+				m == Material.DARK_OAK_WOOD ||
+				m == Material.BIRCH_WOOD;
 	}
 
 	public static boolean isLog(Material m) {
 		return
 				m == Material.OAK_LOG ||
-						m == Material.ACACIA_LOG ||
-						m == Material.JUNGLE_LOG||
-						m == Material.SPRUCE_LOG ||
-						m == Material.DARK_OAK_LOG ||
-						m == Material.BIRCH_LOG;
+				m == Material.ACACIA_LOG ||
+				m == Material.JUNGLE_LOG||
+				m == Material.SPRUCE_LOG ||
+				m == Material.DARK_OAK_LOG ||
+				m == Material.BIRCH_LOG;
 	}
 
 	// TODO try using a switch for this
 	public static boolean isPathable(Material mat) {
 		return
 				mat == Material.AIR ||
-						mat == Material.CAVE_AIR ||
-						mat == Material.VOID_AIR ||
-						mat == Material.OAK_SAPLING ||
-						mat == Material.ACACIA_SAPLING ||
-						mat == Material.JUNGLE_SAPLING||
-						mat == Material.SPRUCE_SAPLING ||
-						mat == Material.DARK_OAK_SAPLING ||
-						mat == Material.BIRCH_SAPLING ||
-						mat == Material.WATER ||
-						mat == Material.TALL_GRASS ||
-						mat == Material.LARGE_FERN ||
-						mat == Material.GRASS ||
-						mat == Material.DEAD_BUSH ||
-						mat == Material.FERN ||
-						mat == Material.SEAGRASS ||
-						mat == Material.TALL_SEAGRASS ||
-						mat == Material.LILY_PAD ||
-						mat == Material.DANDELION ||
-						mat == Material.POPPY ||
-						mat == Material.BLUE_ORCHID ||
-						mat == Material.ALLIUM ||
-						mat == Material.AZURE_BLUET ||
-						mat == Material.ORANGE_TULIP ||
-						mat == Material.PINK_TULIP ||
-						mat == Material.RED_TULIP ||
-						mat == Material.WHITE_TULIP ||
-						mat == Material.OXEYE_DAISY ||
-						mat == Material.SUNFLOWER ||
-						mat == Material.LILAC ||
-						mat == Material.PEONY ||
-						mat == Material.ROSE_BUSH ||
-						mat == Material.BROWN_MUSHROOM ||
-						mat == Material.RED_MUSHROOM ||
-						mat == Material.TORCH ||
-						mat == Material.FIRE ||
-						mat == Material.REDSTONE_WIRE ||
-						mat == Material.WHEAT ||
-						mat.name().contains("SIGN") ||
-						mat == Material.LADDER ||
-						mat == Material.RAIL ||
-						mat == Material.ACTIVATOR_RAIL ||
-						mat == Material.DETECTOR_RAIL ||
-						mat == Material.POWERED_RAIL ||
-						mat == Material.LEVER ||
-						mat == Material.REDSTONE_TORCH ||
-						mat == Material.STONE_BUTTON ||
-						mat == Material.OAK_BUTTON ||
-						mat == Material.ACACIA_BUTTON ||
-						mat == Material.JUNGLE_BUTTON||
-						mat == Material.SPRUCE_BUTTON ||
-						mat == Material.DARK_OAK_BUTTON ||
-						mat == Material.BIRCH_BUTTON ||
-						mat == Material.SNOW ||
-						mat == Material.SUGAR_CANE ||
-						mat == Material.VINE ||
-						mat == Material.NETHER_WART ||
-						mat == Material.BLACK_CARPET ||
-						mat == Material.BLUE_CARPET ||
-						mat == Material.CYAN_CARPET ||
-						mat == Material.BROWN_CARPET ||
-						mat == Material.GRAY_CARPET ||
-						mat == Material.GREEN_CARPET ||
-						mat == Material.LIGHT_BLUE_CARPET ||
-						mat == Material.LIGHT_GRAY_CARPET ||
-						mat == Material.LIME_CARPET ||
-						mat == Material.MAGENTA_CARPET ||
-						mat == Material.ORANGE_CARPET ||
-						mat == Material.PINK_CARPET ||
-						mat == Material.PURPLE_CARPET ||
-						mat == Material.RED_CARPET ||
-						mat == Material.WHITE_CARPET ||
-						mat == Material.YELLOW_CARPET ||
-						mat == Material.ACACIA_PRESSURE_PLATE ||
-						mat == Material.BIRCH_PRESSURE_PLATE ||
-						mat == Material.DARK_OAK_PRESSURE_PLATE ||
-						mat == Material.HEAVY_WEIGHTED_PRESSURE_PLATE ||
-						mat == Material.JUNGLE_PRESSURE_PLATE ||
-						mat == Material.LIGHT_WEIGHTED_PRESSURE_PLATE ||
-						mat == Material.OAK_PRESSURE_PLATE ||
-						mat == Material.SPRUCE_PRESSURE_PLATE ||
-						mat == Material.STONE_PRESSURE_PLATE ||
-						mat == Material.TUBE_CORAL ||
-						mat == Material.BRAIN_CORAL ||
-						mat == Material.BUBBLE_CORAL ||
-						mat == Material.FIRE_CORAL ||
-						mat == Material.HORN_CORAL ||
-						mat == Material.DEAD_TUBE_CORAL ||
-						mat == Material.DEAD_BRAIN_CORAL ||
-						mat == Material.DEAD_BUBBLE_CORAL ||
-						mat == Material.DEAD_FIRE_CORAL ||
-						mat == Material.DEAD_HORN_CORAL ||
-						mat == Material.TUBE_CORAL_FAN ||
-						mat == Material.BRAIN_CORAL_FAN ||
-						mat == Material.BUBBLE_CORAL_FAN ||
-						mat == Material.FIRE_CORAL_FAN ||
-						mat == Material.HORN_CORAL_FAN ||
-						mat == Material.DEAD_TUBE_CORAL_FAN ||
-						mat == Material.DEAD_BRAIN_CORAL_FAN ||
-						mat == Material.DEAD_BUBBLE_CORAL_FAN ||
-						mat == Material.DEAD_FIRE_CORAL_FAN ||
-						mat == Material.DEAD_HORN_CORAL_FAN ||
-						mat == Material.TUBE_CORAL_WALL_FAN ||
-						mat == Material.BRAIN_CORAL_WALL_FAN ||
-						mat == Material.BUBBLE_CORAL_WALL_FAN ||
-						mat == Material.FIRE_CORAL_WALL_FAN ||
-						mat == Material.HORN_CORAL_WALL_FAN ||
-						mat == Material.DEAD_TUBE_CORAL_WALL_FAN ||
-						mat == Material.DEAD_BRAIN_CORAL_WALL_FAN ||
-						mat == Material.DEAD_BUBBLE_CORAL_WALL_FAN ||
-						mat == Material.DEAD_FIRE_CORAL_WALL_FAN ||
-						mat == Material.DEAD_HORN_CORAL_WALL_FAN;
+				mat == Material.CAVE_AIR ||
+				mat == Material.VOID_AIR ||
+				mat == Material.OAK_SAPLING ||
+				mat == Material.ACACIA_SAPLING ||
+				mat == Material.JUNGLE_SAPLING||
+				mat == Material.SPRUCE_SAPLING ||
+				mat == Material.DARK_OAK_SAPLING ||
+				mat == Material.BIRCH_SAPLING ||
+				mat == Material.WATER ||
+				mat == Material.TALL_GRASS ||
+				mat == Material.LARGE_FERN ||
+				mat == Material.GRASS ||
+				mat == Material.DEAD_BUSH ||
+				mat == Material.FERN ||
+				mat == Material.SEAGRASS ||
+				mat == Material.TALL_SEAGRASS ||
+				mat == Material.LILY_PAD ||
+				mat == Material.DANDELION ||
+				mat == Material.POPPY ||
+				mat == Material.BLUE_ORCHID ||
+				mat == Material.ALLIUM ||
+				mat == Material.AZURE_BLUET ||
+				mat == Material.ORANGE_TULIP ||
+				mat == Material.PINK_TULIP ||
+				mat == Material.RED_TULIP ||
+				mat == Material.WHITE_TULIP ||
+				mat == Material.OXEYE_DAISY ||
+				mat == Material.SUNFLOWER ||
+				mat == Material.LILAC ||
+				mat == Material.PEONY ||
+				mat == Material.ROSE_BUSH ||
+				mat == Material.BROWN_MUSHROOM ||
+				mat == Material.RED_MUSHROOM ||
+				mat == Material.TORCH ||
+				mat == Material.FIRE ||
+				mat == Material.REDSTONE_WIRE ||
+				mat == Material.WHEAT ||
+				mat.name().contains("SIGN") ||
+				mat == Material.LADDER ||
+				mat == Material.RAIL ||
+				mat == Material.ACTIVATOR_RAIL ||
+				mat == Material.DETECTOR_RAIL ||
+				mat == Material.POWERED_RAIL ||
+				mat == Material.LEVER ||
+				mat == Material.REDSTONE_TORCH ||
+				mat == Material.STONE_BUTTON ||
+				mat == Material.OAK_BUTTON ||
+				mat == Material.ACACIA_BUTTON ||
+				mat == Material.JUNGLE_BUTTON||
+				mat == Material.SPRUCE_BUTTON ||
+				mat == Material.DARK_OAK_BUTTON ||
+				mat == Material.BIRCH_BUTTON ||
+				mat == Material.SNOW ||
+				mat == Material.SUGAR_CANE ||
+				mat == Material.VINE ||
+				mat == Material.NETHER_WART ||
+				mat == Material.BLACK_CARPET ||
+				mat == Material.BLUE_CARPET ||
+				mat == Material.CYAN_CARPET ||
+				mat == Material.BROWN_CARPET ||
+				mat == Material.GRAY_CARPET ||
+				mat == Material.GREEN_CARPET ||
+				mat == Material.LIGHT_BLUE_CARPET ||
+				mat == Material.LIGHT_GRAY_CARPET ||
+				mat == Material.LIME_CARPET ||
+				mat == Material.MAGENTA_CARPET ||
+				mat == Material.ORANGE_CARPET ||
+				mat == Material.PINK_CARPET ||
+				mat == Material.PURPLE_CARPET ||
+				mat == Material.RED_CARPET ||
+				mat == Material.WHITE_CARPET ||
+				mat == Material.YELLOW_CARPET ||
+				mat == Material.ACACIA_PRESSURE_PLATE ||
+				mat == Material.BIRCH_PRESSURE_PLATE ||
+				mat == Material.DARK_OAK_PRESSURE_PLATE ||
+				mat == Material.HEAVY_WEIGHTED_PRESSURE_PLATE ||
+				mat == Material.JUNGLE_PRESSURE_PLATE ||
+				mat == Material.LIGHT_WEIGHTED_PRESSURE_PLATE ||
+				mat == Material.OAK_PRESSURE_PLATE ||
+				mat == Material.SPRUCE_PRESSURE_PLATE ||
+				mat == Material.STONE_PRESSURE_PLATE ||
+				mat == Material.TUBE_CORAL ||
+				mat == Material.BRAIN_CORAL ||
+				mat == Material.BUBBLE_CORAL ||
+				mat == Material.FIRE_CORAL ||
+				mat == Material.HORN_CORAL ||
+				mat == Material.DEAD_TUBE_CORAL ||
+				mat == Material.DEAD_BRAIN_CORAL ||
+				mat == Material.DEAD_BUBBLE_CORAL ||
+				mat == Material.DEAD_FIRE_CORAL ||
+				mat == Material.DEAD_HORN_CORAL ||
+				mat == Material.TUBE_CORAL_FAN ||
+				mat == Material.BRAIN_CORAL_FAN ||
+				mat == Material.BUBBLE_CORAL_FAN ||
+				mat == Material.FIRE_CORAL_FAN ||
+				mat == Material.HORN_CORAL_FAN ||
+				mat == Material.DEAD_TUBE_CORAL_FAN ||
+				mat == Material.DEAD_BRAIN_CORAL_FAN ||
+				mat == Material.DEAD_BUBBLE_CORAL_FAN ||
+				mat == Material.DEAD_FIRE_CORAL_FAN ||
+				mat == Material.DEAD_HORN_CORAL_FAN ||
+				mat == Material.TUBE_CORAL_WALL_FAN ||
+				mat == Material.BRAIN_CORAL_WALL_FAN ||
+				mat == Material.BUBBLE_CORAL_WALL_FAN ||
+				mat == Material.FIRE_CORAL_WALL_FAN ||
+				mat == Material.HORN_CORAL_WALL_FAN ||
+				mat == Material.DEAD_TUBE_CORAL_WALL_FAN ||
+				mat == Material.DEAD_BRAIN_CORAL_WALL_FAN ||
+				mat == Material.DEAD_BUBBLE_CORAL_WALL_FAN ||
+				mat == Material.DEAD_FIRE_CORAL_WALL_FAN ||
+				mat == Material.DEAD_HORN_CORAL_WALL_FAN;
 	}
 
 	public static boolean isSafeToStand(Location location) {

--- a/core/src/main/java/com/nisovin/magicspells/util/BooleanUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BooleanUtils.java
@@ -6,14 +6,24 @@ import java.util.HashSet;
 public class BooleanUtils {
 
 	private static Set<String> yesStrings;
+	private static Set<String> noStrings;
 	static {
 		yesStrings = new HashSet<>();
+		noStrings = new HashSet<>();
+
 		yesStrings.add("yes");
 		yesStrings.add("true");
+
+		noStrings.add("no");
+		noStrings.add("false");
 	}
 	
 	public static boolean isYes(String toCheck) {
 		return yesStrings.contains(toCheck.trim().toLowerCase());
+	}
+
+	public static boolean isNo(String toCheck) {
+		return noStrings.contains(toCheck.trim().toLowerCase());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/BoundingBox.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BoundingBox.java
@@ -4,19 +4,20 @@ import org.bukkit.World;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Entity;
+
 import com.nisovin.magicspells.util.bounds.Space;
 
 public class BoundingBox implements Space {
 
-	World world;
-	double lowX;
-	double lowY;
-	double lowZ;
-	double highX;
-	double highY;
-	double highZ;
-	double horizRadius;
-	double vertRadius;
+	private World world;
+	private double lowX;
+	private double lowY;
+	private double lowZ;
+	private double highX;
+	private double highY;
+	private double highZ;
+	private double horizRadius;
+	private double vertRadius;
 	
 	public BoundingBox(Block center, double radius) {
 		this(center.getLocation().add(0.5, 0, 0.5), radius, radius);
@@ -37,41 +38,41 @@ public class BoundingBox implements Space {
 	}
 	
 	public BoundingBox(Location corner1, Location corner2) {
-		this.world = corner1.getWorld();
-		this.lowX = min(corner1.getX(), corner2.getX());
-		this.highX = max(corner1.getX(), corner2.getX());
-		this.lowY = min(corner1.getY(), corner2.getY());
-		this.highY = max(corner1.getY(), corner2.getY());
-		this.lowZ = min(corner1.getZ(), corner2.getZ());
-		this.highZ = max(corner1.getZ(), corner2.getZ());
+		world = corner1.getWorld();
+		lowX = min(corner1.getX(), corner2.getX());
+		highX = max(corner1.getX(), corner2.getX());
+		lowY = min(corner1.getY(), corner2.getY());
+		highY = max(corner1.getY(), corner2.getY());
+		lowZ = min(corner1.getZ(), corner2.getZ());
+		highZ = max(corner1.getZ(), corner2.getZ());
 	}
 	
 	public void setCenter(Location center) {
-		this.world = center.getWorld();
-		this.lowX = center.getX() - this.horizRadius;
-		this.lowY = center.getY() - this.vertRadius;
-		this.lowZ = center.getZ() - this.horizRadius;
-		this.highX = center.getX() + this.horizRadius;
-		this.highY = center.getY() + this.vertRadius;
-		this.highZ = center.getZ() + this.horizRadius;
+		world = center.getWorld();
+		lowX = center.getX() - horizRadius;
+		lowY = center.getY() - vertRadius;
+		lowZ = center.getZ() - horizRadius;
+		highX = center.getX() + horizRadius;
+		highY = center.getY() + vertRadius;
+		highZ = center.getZ() + horizRadius;
 	}
 	
 	public void expand(double amount) {
-		this.lowX -= amount;
-		this.lowY -= amount;
-		this.lowZ -= amount;
-		this.highX += amount;
-		this.highY += amount;
-		this.highZ += amount;
+		lowX -= amount;
+		lowY -= amount;
+		lowZ -= amount;
+		highX += amount;
+		highY += amount;
+		highZ += amount;
 	}
 	
 	@Override
 	public boolean contains(Location location) {
-		if (!location.getWorld().equals(this.world)) return false;
+		if (!location.getWorld().equals(world)) return false;
 		double x = location.getX();
 		double y = location.getY();
 		double z = location.getZ();
-		return this.lowX <= x && x <= this.highX && this.lowY <= y && y <= this.highY && this.lowZ <= z && z <= this.highZ;
+		return lowX <= x && x <= highX && lowY <= y && y <= highY && lowZ <= z && z <= highZ;
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/util/ColorUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ColorUtil.java
@@ -8,11 +8,10 @@ public class ColorUtil {
 	
 	public static Color getColorFromHexString(String hex) {
 		if (hex == null) return null;
-		String working = hex;
-		working = working.replace("#", "");
+		String working = hex.replace("#", "");
 		try {
-		int value = Integer.parseInt(working, 16);
-		return Color.fromRGB(value);
+			int value = Integer.parseInt(working, 16);
+			return Color.fromRGB(value);
 		} catch (IllegalArgumentException e) {
 			DebugHandler.debugIllegalArgumentException(e);
 			return null;

--- a/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
@@ -1,8 +1,8 @@
 package com.nisovin.magicspells.util;
 
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.conversations.ConversationFactory;
 import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.prompt.PromptType;

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -1,14 +1,14 @@
 package com.nisovin.magicspells.util;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
+import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.regex.Pattern;
 
-import org.bukkit.DyeColor;
-import org.bukkit.Location;
 // this should probably be kept as a star import for version safety
 import org.bukkit.entity.*;
+import org.bukkit.DyeColor;
+import org.bukkit.Location;
 
 import com.nisovin.magicspells.MagicSpells;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ExperienceUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ExperienceUtils.java
@@ -10,7 +10,7 @@ import org.bukkit.entity.Player;
  */
 public class ExperienceUtils {
 	
-	public static final int MAX_LEVEL_SUPPORTED = 500;
+	private static final int MAX_LEVEL_SUPPORTED = 500;
 
 	private static final int xpRequiredForNextLevel[] = new int[MAX_LEVEL_SUPPORTED];
 	private static final int xpTotalToReachLevel[] = new int[MAX_LEVEL_SUPPORTED];
@@ -35,7 +35,7 @@ public class ExperienceUtils {
 		if (newLvl >= MAX_LEVEL_SUPPORTED) return;
 		if (player.getLevel() != newLvl) player.setLevel(newLvl);
 		
-		float pct = (float)(xp - xpTotalToReachLevel[newLvl]) / (float)xpRequiredForNextLevel[newLvl];
+		float pct = (float) (xp - xpTotalToReachLevel[newLvl]) / (float) xpRequiredForNextLevel[newLvl];
 		player.setExp(pct);
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/IntMap.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/IntMap.java
@@ -1,16 +1,16 @@
 package com.nisovin.magicspells.util;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.HashMap;
 
 public class IntMap<T> {
 
 	private Map<T, Integer> map = new HashMap<>();
 	
 	public int put(T key, int value) {
-		Integer prev = this.map.put(key, Integer.valueOf(value));
+		Integer prev = map.put(key, Integer.valueOf(value));
 		if (prev != null) return prev.intValue();
 		return 0;
 	}
@@ -20,31 +20,31 @@ public class IntMap<T> {
 	}
 	
 	public int get(T key) {
-		Integer value = this.map.get(key);
+		Integer value = map.get(key);
 		if (value != null) return value.intValue();
 		return 0;
 	}
 	
 	public int remove(T key) {
-		Integer value = this.map.remove(key);
+		Integer value = map.remove(key);
 		if (value != null) return value.intValue();
 		return 0;
 	}
 	
 	public int size() {
-		return this.map.size();
+		return map.size();
 	}
 	
 	public boolean contains(T key) {
-		return this.map.containsKey(key);
+		return map.containsKey(key);
 	}
 	
 	public boolean containsKey(T key) {
-		return this.map.containsKey(key);
+		return map.containsKey(key);
 	}
 	
 	public boolean containsValue(int value) {
-		return this.map.containsValue(Integer.valueOf(value));
+		return map.containsValue(Integer.valueOf(value));
 	}
 	
 	public int increment(T key) {
@@ -74,41 +74,41 @@ public class IntMap<T> {
 	}
 	
 	public Set<T> keySet() {
-		return this.map.keySet();
+		return map.keySet();
 	}
 	
 	public void clear() {
-		this.map.clear();
+		map.clear();
 	}
 	
 	public boolean isEmpty() {
-		return this.map.isEmpty();
+		return map.isEmpty();
 	}
 	
 	public void putAll(IntMap<? extends T> otherMap) {
-		this.map.putAll(otherMap.map);
+		map.putAll(otherMap.map);
 	}
 	
 	public void putAll(Map<? extends T, Integer> otherMap) {
-		this.map.putAll(otherMap);
+		map.putAll(otherMap);
 	}
 	
 	public Map<T, Integer> getIntegerMap() {
-		return this.map;
+		return map;
 	}
 	
 	@Override
 	public IntMap<T> clone() {
 		IntMap<T> newMap = new IntMap<>();
-		newMap.putAll(this.map);
+		newMap.putAll(map);
 		return newMap;
 	}
 	
 	public void useTreeMap() {
 		Map<T, Integer> newMap = new TreeMap<>();
-		newMap.putAll(this.map);
-		this.map.clear();
-		this.map = newMap;
+		newMap.putAll(map);
+		map.clear();
+		map = newMap;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
@@ -12,11 +12,11 @@ import org.bukkit.event.inventory.InventoryType;
 
 public class InventoryUtil {
 
-	public static final String SERIALIZATION_KEY_SIZE = "size";
-	public static final String SERIALIZATION_KEY_TYPE = "type";
-	public static final String SERIALIZATION_KEY_CONTENTS = "contents";
-	public static final String SERIALIZATION_KEY_TITLE = "title";
-	
+	private static final String SERIALIZATION_KEY_SIZE = "size";
+	private static final String SERIALIZATION_KEY_TYPE = "type";
+	private static final String SERIALIZATION_KEY_TITLE = "title";
+	private static final String SERIALIZATION_KEY_CONTENTS = "contents";
+
 	/*
 	 * type: INVENTORY_TYPE/string
 	 * size: integer
@@ -37,9 +37,9 @@ public class InventoryUtil {
 		
 		ret.put(SERIALIZATION_KEY_SIZE, size);
 		ret.put(SERIALIZATION_KEY_TYPE, inventoryType);
-		ret.put(SERIALIZATION_KEY_CONTENTS, serializedContents);
 		ret.put(SERIALIZATION_KEY_TITLE, title);
-		
+		ret.put(SERIALIZATION_KEY_CONTENTS, serializedContents);
+
 		return ret;
 	}
 	
@@ -59,12 +59,9 @@ public class InventoryUtil {
 		int inventorySize = (Integer) serialized.get(SERIALIZATION_KEY_SIZE);
 		String title = (String) serialized.get(SERIALIZATION_KEY_TITLE);
 		Inventory ret;
-		if (strInventoryType.equals(InventoryType.CHEST.name())) {
-			ret = Bukkit.createInventory(null, inventorySize, title);
-		} else {
-			ret = Bukkit.createInventory(null, InventoryType.valueOf(strInventoryType), title);
-		}
-		
+		if (strInventoryType.equals(InventoryType.CHEST.name())) ret = Bukkit.createInventory(null, inventorySize, title);
+		else ret = Bukkit.createInventory(null, InventoryType.valueOf(strInventoryType), title);
+
 		// Handle the item contents
 		Map<Object, Object> serializedItems = (Map<Object, Object>) serialized.get(SERIALIZATION_KEY_CONTENTS);
 		ret.setContents(deserializeContentsMap(serializedItems, inventorySize));

--- a/core/src/main/java/com/nisovin/magicspells/util/LocationUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/LocationUtil.java
@@ -2,12 +2,12 @@ package com.nisovin.magicspells.util;
 
 import java.util.Objects;
 
+import org.bukkit.World;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.World;
 import org.bukkit.block.Block;
-import org.bukkit.command.BlockCommandSender;
 import org.bukkit.entity.Entity;
+import org.bukkit.command.BlockCommandSender;
 
 public class LocationUtil {
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/MagicConversationPrefix.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MagicConversationPrefix.java
@@ -1,7 +1,7 @@
 package com.nisovin.magicspells.util;
 
-import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.ConversationPrefix;
+import org.bukkit.conversations.ConversationContext;
 
 public class MagicConversationPrefix implements ConversationPrefix {
 
@@ -13,7 +13,7 @@ public class MagicConversationPrefix implements ConversationPrefix {
 	
 	@Override
 	public String getPrefix(ConversationContext paramConversationContext) {
-		return this.prefix;
+		return prefix;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/MagicLocation.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MagicLocation.java
@@ -2,8 +2,8 @@ package com.nisovin.magicspells.util;
 
 import java.util.Objects;
 
-import org.bukkit.Location;
 import org.bukkit.World;
+import org.bukkit.Location;
 
 import com.nisovin.magicspells.MagicSpells;
 
@@ -52,27 +52,27 @@ public class MagicLocation {
 	}
 	
 	public String getWorld() {
-		return this.world;
+		return world;
 	}
 	
 	public double getX() {
-		return this.x;
+		return x;
 	}
 	
 	public double getY() {
-		return this.y;
+		return y;
 	}
 	
 	public double getZ() {
-		return this.z;
+		return z;
 	}
 	
 	public float getYaw() {
-		return this.yaw;
+		return yaw;
 	}
 	
 	public float getPitch() {
-		return this.pitch;
+		return pitch;
 	}
 	
 	// -------------------------------------------- //
@@ -82,12 +82,12 @@ public class MagicLocation {
 	@Override
 	public int hashCode() {
 		return Objects.hash(
-			this.world,
-			this.x,
-			this.y,
-			this.z,
-			this.pitch,
-			this.yaw
+			world,
+			x,
+			y,
+			z,
+			pitch,
+			yaw
 		);
 	}
 	
@@ -98,16 +98,16 @@ public class MagicLocation {
 	@Override
 	public boolean equals(Object o) {
 		if (o instanceof MagicLocation) {
-			MagicLocation loc = (MagicLocation)o;
-			return loc.world.equals(this.world) && loc.x == this.x && loc.y == this.y && loc.z == this.z && loc.yaw == this.yaw && loc.pitch == this.pitch;
+			MagicLocation loc = (MagicLocation) o;
+			return loc.world.equals(world) && loc.x == x && loc.y == y && loc.z == z && loc.yaw == yaw && loc.pitch == pitch;
 		} else if (o instanceof Location) {
-			Location loc = (Location)o;
-			if (!LocationUtil.isSameWorld(loc, this.world)) return false;
-			if (loc.getX() != this.x) return false;
-			if (loc.getY() != this.y) return false;
-			if (loc.getZ() != this.z) return false;
-			if (loc.getYaw() != this.yaw) return false;
-			if (loc.getPitch() != this.pitch) return false;
+			Location loc = (Location) o;
+			if (!LocationUtil.isSameWorld(loc, world)) return false;
+			if (loc.getX() != x) return false;
+			if (loc.getY() != y) return false;
+			if (loc.getZ() != z) return false;
+			if (loc.getYaw() != yaw) return false;
+			if (loc.getPitch() != pitch) return false;
 			return true;
 		}
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/util/MessageBlocker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MessageBlocker.java
@@ -1,28 +1,29 @@
 package com.nisovin.magicspells.util;
 
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.HashSet;
+import java.util.Collections;
 
 import org.bukkit.entity.Player;
 
-import com.comphenix.protocol.PacketType;
-import com.comphenix.protocol.ProtocolLibrary;
-import com.comphenix.protocol.ProtocolManager;
-import com.comphenix.protocol.events.PacketAdapter;
-import com.comphenix.protocol.events.PacketEvent;
 import com.nisovin.magicspells.MagicSpells;
+
+import com.comphenix.protocol.PacketType;
+import com.comphenix.protocol.ProtocolManager;
+import com.comphenix.protocol.ProtocolLibrary;
+import com.comphenix.protocol.events.PacketEvent;
+import com.comphenix.protocol.events.PacketAdapter;
 
 public class MessageBlocker {
 
-	Set<String> blocking = Collections.synchronizedSet(new HashSet<String>());
-	
-	PacketListener packetListener;
+	private Set<String> blocking = Collections.synchronizedSet(new HashSet<>());
+
+	private PacketListener packetListener;
 	
 	public MessageBlocker() {
 		ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
-		this.packetListener = new PacketListener();
-		protocolManager.addPacketListener(this.packetListener);
+		packetListener = new PacketListener();
+		protocolManager.addPacketListener(packetListener);
 	}
 	
 	public void addPlayer(Player player) {
@@ -34,15 +35,15 @@ public class MessageBlocker {
 	}
 	
 	public void turnOff() {
-		if (this.packetListener == null) return;
+		if (packetListener == null) return;
 		ProtocolManager protocolManager = ProtocolLibrary.getProtocolManager();
-		protocolManager.removePacketListener(this.packetListener);
-		this.packetListener = null;
+		protocolManager.removePacketListener(packetListener);
+		packetListener = null;
 	}
 	
-	class PacketListener extends PacketAdapter {
+	private class PacketListener extends PacketAdapter {
 		
-		public PacketListener() {
+		PacketListener() {
 			super(MagicSpells.plugin, PacketType.Play.Server.CHAT);
 		}
 		

--- a/core/src/main/java/com/nisovin/magicspells/util/MoneyHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MoneyHandler.java
@@ -12,26 +12,26 @@ public class MoneyHandler {
 
 	public MoneyHandler() {
 		RegisteredServiceProvider<Economy> provider = CompatBasics.getServiceProvider(Economy.class);
-		if (provider != null) this.economy = provider.getProvider();
+		if (provider != null) economy = provider.getProvider();
 	}
 
 	public boolean hasMoney(Player player, float money) {
-		if (this.economy == null) return false;
+		if (economy == null) return false;
 		return economy.has(player, money);
 	}
 
 	public void removeMoney(Player player, float money) {
-		if (this.economy == null) return;
+		if (economy == null) return;
 		economy.withdrawPlayer(player, money);
 	}
 
 	public void addMoney(Player player, float money) {
-		if (this.economy == null) return;
+		if (economy == null) return;
 		economy.depositPlayer(player, money);
 	}
 
 	public double checkMoney(Player player) {
-		if (this.economy == null) return 0;
+		if (economy == null) return 0;
 		return economy.getBalance(player);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
@@ -59,14 +59,14 @@ public abstract class SpellAnimation implements Runnable {
 	 * Start the spell animation.
 	 */
 	public void play() {
-		this.taskId = MagicSpells.scheduleRepeatingTask(this, delay, interval);
+		taskId = MagicSpells.scheduleRepeatingTask(this, delay, interval);
 	}
 	
 	/**
 	 * Stop the spell animation.
 	 */
 	protected void stop() {
-		MagicSpells.cancelTask(this.taskId);
+		MagicSpells.cancelTask(taskId);
 	}
 	
 	/**
@@ -77,7 +77,7 @@ public abstract class SpellAnimation implements Runnable {
 	
 	@Override
 	public final void run() {
-		onTick(++this.tick);
+		onTick(++tick);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
@@ -1,8 +1,8 @@
 package com.nisovin.magicspells.util;
 
-import java.util.HashSet;
-import java.util.List;
 import java.util.Set;
+import java.util.List;
+import java.util.HashSet;
 
 import com.nisovin.magicspells.Spell;
 
@@ -19,38 +19,30 @@ public class SpellFilter {
 	public SpellFilter(List<String> allowedSpells, List<String> blacklistedSpells, List<String> allowedTags, List<String> disallowedTags) {
 		
 		// Initialize the collections
-		if (allowedSpells != null && !allowedSpells.isEmpty()) {
-			this.allowedSpells = new HashSet<>(allowedSpells);
-		}
-		if (blacklistedSpells != null && !blacklistedSpells.isEmpty()) {
-			this.blacklistedSpells = new HashSet<>(blacklistedSpells);
-		}
-		if (allowedTags != null && !allowedTags.isEmpty()) {
-			this.allowedTags = new HashSet<>(allowedTags);
-		}
-		if (disallowedTags != null && !disallowedTags.isEmpty()) {
-			this.disallowedTags = new HashSet<>(disallowedTags);
-		}
-		
+		if (allowedSpells != null && !allowedSpells.isEmpty()) this.allowedSpells = new HashSet<>(allowedSpells);
+		if (blacklistedSpells != null && !blacklistedSpells.isEmpty()) this.blacklistedSpells = new HashSet<>(blacklistedSpells);
+		if (allowedTags != null && !allowedTags.isEmpty()) this.allowedTags = new HashSet<>(allowedTags);
+		if (disallowedTags != null && !disallowedTags.isEmpty()) this.disallowedTags = new HashSet<>(disallowedTags);
+
 		// Determine the default outcome if nothing catches
-		this.defaultReturn = determineDefaultValue();
+		defaultReturn = determineDefaultValue();
 	}
 	
 	private boolean determineDefaultValue() {
 		// This means there is a tag whitelist check
-		if (this.allowedTags != null) return false;
+		if (allowedTags != null) return false;
 		
 		// If there is a spell whitelist check
-		if (this.allowedSpells != null) return false;
+		if (allowedSpells != null) return false;
 		
 		// This means there is a tag blacklist
-		if (this.disallowedTags != null) return true;
+		if (disallowedTags != null) return true;
 		
 		// If there is a spell blacklist
-		if (this.blacklistedSpells != null) return true;
+		if (blacklistedSpells != null) return true;
 		
 		// If all of the collections are null, then there is no filter
-		this.emptyFilter = true;
+		emptyFilter = true;
 		return true;
 	}
 	
@@ -59,29 +51,29 @@ public class SpellFilter {
 		if (spell == null) return false;
 		
 		// Quick check to exit early if possible
-		if (this.emptyFilter) return true;
+		if (emptyFilter) return true;
 		
 		// Is it whitelisted explicitly?
-		if (this.allowedSpells != null && this.allowedSpells.contains(spell.getInternalName())) return true;
+		if (allowedSpells != null && allowedSpells.contains(spell.getInternalName())) return true;
 		
 		// Is it blacklisted?
-		if (this.blacklistedSpells != null && this.blacklistedSpells.contains(spell.getInternalName())) return false;
+		if (blacklistedSpells != null && blacklistedSpells.contains(spell.getInternalName())) return false;
 		
 		// Does it have a blacklisted tag?
-		if (this.disallowedTags != null) {
-			for (String tag: this.disallowedTags) {
+		if (disallowedTags != null) {
+			for (String tag : disallowedTags) {
 				if (spell.hasTag(tag)) return false;
 			}
 		}
 		
 		// Does it have a whitelisted tag?
-		if (this.allowedTags != null) {
-			for (String tag: this.allowedTags) {
+		if (allowedTags != null) {
+			for (String tag : allowedTags) {
 				if (spell.hasTag(tag)) return true;
 			}
 		}
 		
-		return this.defaultReturn;
+		return defaultReturn;
 	}
 	
 	public static SpellFilter fromConfig(MagicConfig config, String basePath) {
@@ -92,6 +84,5 @@ public class SpellFilter {
 		List<String> deniedTagList = config.getStringList(basePath + "denied-spell-tags", null);
 		return new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
-	
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
@@ -1,16 +1,17 @@
 package com.nisovin.magicspells.util;
 
+import java.util.Map;
+import java.util.Set;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
+import java.util.Collection;
 
 import org.bukkit.inventory.ItemStack;
 
 public class SpellReagents {
 	
-	private HashSet<ItemStack> items;
+	private Set<ItemStack> items;
 	private int mana;
 	private int health;
 	private int hunger;
@@ -18,162 +19,155 @@ public class SpellReagents {
 	private int levels;
 	private int durability;
 	private float money;
-	private HashMap<String, Double> variables;
+	private Map<String, Double> variables;
 	
 	public SpellReagents() {
-		this.items = null;
-		this.mana = 0;
-		this.health = 0;
-		this.hunger = 0;
-		this.experience = 0;
-		this.levels = 0;
-		this.money = 0;
-		this.variables = null;
+		items = null;
+		mana = 0;
+		health = 0;
+		hunger = 0;
+		experience = 0;
+		levels = 0;
+		money = 0;
+		variables = null;
 	}
 	
 	public SpellReagents(SpellReagents other) {
 		if (other.items != null) {
-			this.items = new HashSet<>();
-			other.items.forEach(item -> this.items.add(item.clone()));
+			items = new HashSet<>();
+			other.items.forEach(item -> items.add(item.clone()));
 		}
-		this.mana = other.mana;
-		this.health = other.health;
-		this.hunger = other.hunger;
-		this.experience = other.experience;
-		this.levels = other.levels;
-		this.money = other.money;
+		mana = other.mana;
+		health = other.health;
+		hunger = other.hunger;
+		experience = other.experience;
+		levels = other.levels;
+		money = other.money;
 		if (other.variables != null) {
-			this.variables = new HashMap<>();
-			this.variables.putAll(other.variables);
+			variables = new HashMap<>();
+			variables.putAll(other.variables);
 		}
 	}
 	
-	public HashSet<ItemStack> getItems() {
-		return this.items;
+	public Set<ItemStack> getItems() {
+		return items;
 	}
 	
 	public ItemStack[] getItemsAsArray() {
-		if (this.items == null || this.items.isEmpty()) return null;
-		ItemStack[] arr = new ItemStack[this.items.size()];
-		arr = this.items.toArray(arr);
+		if (items == null || items.isEmpty()) return null;
+		ItemStack[] arr = new ItemStack[items.size()];
+		arr = items.toArray(arr);
 		return arr;
 	}
 	
 	public void setItems(Collection<ItemStack> newItems) {
-		if (newItems == null || newItems.isEmpty()) {
-			this.items = null;
-		} else {
-			this.items = new HashSet<>(newItems);
-		}
+		if (newItems == null || newItems.isEmpty()) items = null;
+		else items = new HashSet<>(newItems);
 	}
 	
 	// TODO can this safely be varargs?
 	public void setItems(ItemStack[] newItems) {
-		if (newItems == null || newItems.length == 0) {
-			this.items = null;
-		} else {
-			this.items = new HashSet<>(Arrays.asList(newItems));
-		}
+		if (newItems == null || newItems.length == 0) items = null;
+		else items = new HashSet<>(Arrays.asList(newItems));
 	}
 	
 	public void addItem(ItemStack item) {
-		if (this.items == null) this.items = new HashSet<>();
-		this.items.add(item);
+		if (items == null) items = new HashSet<>();
+		items.add(item);
 	}
 	
 	public int getMana() {
-		return this.mana;
+		return mana;
 	}
 	
 	public void setMana(int newMana) {
-		this.mana = newMana;
+		mana = newMana;
 	}
 	
 	public int getHealth() {
-		return this.health;
+		return health;
 	}
 	
 	public void setHealth(int newHealth) {
-		this.health = newHealth;
+		health = newHealth;
 	}
 	
 	public int getHunger() {
-		return this.hunger;
+		return hunger;
 	}
 	
 	public void setHunger(int newHunger) {
-		this.hunger = newHunger;
+		hunger = newHunger;
 	}
 	
 	public int getExperience() {
-		return this.experience;
+		return experience;
 	}
 	
 	public void setExperience(int newExperience) {
-		this.experience = newExperience;
+		experience = newExperience;
 	}
 	
 	public int getLevels() {
-		return this.levels;
+		return levels;
 	}
 	
 	public void setLevels(int newLevels) {
-		this.levels = newLevels;
+		levels = newLevels;
 	}
 	
 	public int getDurability() {
-		return this.durability;
+		return durability;
 	}
 	
 	public void setDurability(int newDurability) {
-		this.durability = newDurability;
+		durability = newDurability;
 	}
 	
 	public float getMoney() {
-		return this.money;
+		return money;
 	}
 	
 	public void setMoney(float newMoney) {
-		this.money = newMoney;
+		money = newMoney;
 	}
 	
-	public HashMap<String, Double> getVariables() {
-		return this.variables;
+	public Map<String, Double> getVariables() {
+		return variables;
 	}
 	
 	public void addVariable(String var, double val) {
-		if (this.variables == null) this.variables = new HashMap<>();
-		this.variables.put(var, val);
+		if (variables == null) variables = new HashMap<>();
+		variables.put(var, val);
 	}
 	
 	public void setVariables(Map<String, Double> newVariables) {
-		if (newVariables == null || newVariables.isEmpty()) {
-			this.variables = null;
-		} else {
-			this.variables = new HashMap<>();
-			this.variables.putAll(newVariables);
+		if (newVariables == null || newVariables.isEmpty()) variables = null;
+		else {
+			variables = new HashMap<>();
+			variables.putAll(newVariables);
 		}
 	}
 	
 	@Override
 	public SpellReagents clone() {
 		SpellReagents other = new SpellReagents();
-		if (this.items != null) {
+		if (items != null) {
 			other.items = new HashSet<>();
-			for (ItemStack item : this.items) {
+			for (ItemStack item : items) {
 				other.items.add(item.clone());
 			}
 		}
-		other.mana = this.mana;
-		other.health = this.health;
-		other.hunger = this.hunger;
-		other.experience = this.experience;
-		other.levels = this.levels;
-		other.durability = this.durability;
-		other.money = this.money;
-		if (this.variables != null) {
+		other.mana = mana;
+		other.health = health;
+		other.hunger = hunger;
+		other.experience = experience;
+		other.levels = levels;
+		other.durability = durability;
+		other.money = money;
+		if (variables != null) {
 			other.variables = new HashMap<>();
-			for (Map.Entry<String, Double> entry : this.variables.entrySet()) {
+			for (Map.Entry<String, Double> entry : variables.entrySet()) {
 				other.variables.put(entry.getKey(), entry.getValue());
 			}
 		}
@@ -182,24 +176,24 @@ public class SpellReagents {
 	
 	public SpellReagents multiply(float x) {
 		SpellReagents other = new SpellReagents();
-		if (this.items != null) {
+		if (items != null) {
 			other.items = new HashSet<>();
-			for (ItemStack item : this.items) {
+			for (ItemStack item : items) {
 				ItemStack i = item.clone();
 				i.setAmount(Math.round(i.getAmount() * x));
 				other.items.add(i);
 			}
 		}
-		other.mana = Math.round(this.mana * x);
-		other.health = Math.round(this.health * x);
-		other.hunger = Math.round(this.hunger * x);
-		other.experience = Math.round(this.experience * x);
-		other.levels = Math.round(this.levels * x);
-		other.durability = Math.round(this.durability * x);
-		other.money = this.money * x;
-		if (this.variables != null) {
+		other.mana = Math.round(mana * x);
+		other.health = Math.round(health * x);
+		other.hunger = Math.round(hunger * x);
+		other.experience = Math.round(experience * x);
+		other.levels = Math.round(levels * x);
+		other.durability = Math.round(durability * x);
+		other.money = money * x;
+		if (variables != null) {
 			other.variables = new HashMap<>();
-			for (Map.Entry<String, Double> entry : this.variables.entrySet()) {
+			for (Map.Entry<String, Double> entry : variables.entrySet()) {
 				other.variables.put(entry.getKey(), entry.getValue() * x);
 			}
 		}
@@ -209,15 +203,15 @@ public class SpellReagents {
 	@Override
 	public String toString() {
 		return "SpellReagents:["
-			+ "items=" + this.items
-			+ ",mana=" + this.mana
-			+ ",health=" + this.health
-			+ ",hunger=" + this.hunger
-			+ ",experience=" + this.experience
-			+ ",levels=" + this.levels
-			+ ",durability=" + this.durability
-			+ ",money=" + this.money
-			+ ",variables=" + this.variables
+			+ "items=" + items
+			+ ",mana=" + mana
+			+ ",health=" + health
+			+ ",hunger=" + hunger
+			+ ",experience=" + experience
+			+ ",levels=" + levels
+			+ ",durability=" + durability
+			+ ",money=" + money
+			+ ",variables=" + variables
 			+ ']';
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
@@ -1,12 +1,12 @@
 package com.nisovin.magicspells.util;
 
-import com.nisovin.magicspells.Spell;
-
+import java.util.Set;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Set;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.function.Predicate;
+
+import com.nisovin.magicspells.Spell;
 
 public class SpellUtil {
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/TargetBooleanState.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TargetBooleanState.java
@@ -1,7 +1,7 @@
 package com.nisovin.magicspells.util;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.HashMap;
 
 public enum TargetBooleanState {
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/TargetInfo.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TargetInfo.java
@@ -13,11 +13,11 @@ public class TargetInfo<E extends Entity> {
 	}
 	
 	public E getTarget() {
-		return this.target;
+		return target;
 	}
 	
 	public float getPower() {
-		return this.power;
+		return power;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
@@ -1,21 +1,22 @@
 package com.nisovin.magicspells.util;
 
-import com.nisovin.magicspells.MagicSpells;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
+
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
-import org.bukkit.command.CommandSender;
-import org.bukkit.entity.Player;
-
-import java.util.ArrayList;
-import java.util.List;
+import com.nisovin.magicspells.MagicSpells;
 
 public class TxtUtil {
 	
 	public static String getStringNumber(double number, int places) {
 		if (places < 0) return number + "";
-		if (places == 0) return (int)Math.round(number) + "";
-		int x = (int)Math.pow(10, places);
-		return ((double)Math.round(number * x) / x) + "";
+		if (places == 0) return (int) Math.round(number) + "";
+		int x = (int) Math.pow(10, places);
+		return ((double) Math.round(number * x) / x) + "";
 	}
 	
 	public static String getStringNumber(String textNumber, int places) {
@@ -31,36 +32,29 @@ public class TxtUtil {
 	public static List<String> tabCompleteSpellName(CommandSender sender, String partial) {
 		List<String> matches = new ArrayList<>();
 		if (sender instanceof Player) {
-			Spellbook spellbook = MagicSpells.getSpellbook((Player)sender);
+			Spellbook spellbook = MagicSpells.getSpellbook((Player) sender);
 			for (Spell spell : spellbook.getSpells()) {
-				if (spellbook.canTeach(spell)) {
-					if (spell.getName().toLowerCase().startsWith(partial)) {
-						matches.add(spell.getName());
-					} else {
-						String[] aliases = spell.getAliases();
-						if (aliases != null && aliases.length > 0) {
-							for (String alias : aliases) {
-								if (alias.toLowerCase().startsWith(partial)) {
-									matches.add(alias);
-								}
-							}
-						}
-					}
+				if (!spellbook.canTeach(spell)) continue;
+				if (spell.getName().toLowerCase().startsWith(partial)) {
+					matches.add(spell.getName());
+					continue;
+				}
+				String[] aliases = spell.getAliases();
+				if (aliases == null || aliases.length <= 0) continue;
+				for (String alias : aliases) {
+					if (alias.toLowerCase().startsWith(partial)) matches.add(alias);
 				}
 			}
 		} else if (sender.isOp()) {
 			for (Spell spell : MagicSpells.spells()) {
 				if (spell.getName().toLowerCase().startsWith(partial)) {
 					matches.add(spell.getName());
-				} else {
-					String[] aliases = spell.getAliases();
-					if (aliases != null && aliases.length > 0) {
-						for (String alias : aliases) {
-							if (alias.toLowerCase().startsWith(partial)) {
-								matches.add(alias);
-							}
-						}
-					}
+					continue;
+				}
+				String[] aliases = spell.getAliases();
+				if (aliases == null || aliases.length <= 0) continue;
+				for (String alias : aliases) {
+					if (alias.toLowerCase().startsWith(partial)) matches.add(alias);
 				}
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -26,6 +26,7 @@ import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.Particle;
 import org.bukkit.ChatColor;
+import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.util.Vector;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -613,6 +614,11 @@ public class Util {
 
 	public static String[] splitParams(String[] split) {
 		return splitParams(arrayJoin(split, ' '), 0);
+	}
+
+	public static int getItemDurability(ItemStack item) {
+		ItemMeta meta = item.getItemMeta();
+		return meta == null ? 0 : ((Damageable) meta).getDamage();
 	}
 
 	public static boolean removeFromInventory(Inventory inventory, ItemStack item) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/AlternativeReaderManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/AlternativeReaderManager.java
@@ -1,15 +1,15 @@
 package com.nisovin.magicspells.util.itemreader.alternative;
 
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.inventory.ItemStack;
-
-import java.util.HashMap;
 import java.util.Map;
+import java.util.HashMap;
+
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.configuration.ConfigurationSection;
 
 public class AlternativeReaderManager {
 	
-	public static Map<String, ItemConfigTransformer> readers = new HashMap<>();
-	public static final String KEY_PROCESSOR = "type";
+	private static Map<String, ItemConfigTransformer> readers = new HashMap<>();
+	private static final String KEY_PROCESSOR = "type";
 	
 	private static void register(ItemConfigTransformer transformer) {
 		String key = transformer.getReaderKey();

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/ItemConfigTransformer.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/ItemConfigTransformer.java
@@ -1,7 +1,7 @@
 package com.nisovin.magicspells.util.itemreader.alternative;
 
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.configuration.ConfigurationSection;
 
 public interface ItemConfigTransformer {
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/SpigotReader.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/SpigotReader.java
@@ -1,8 +1,8 @@
 package com.nisovin.magicspells.util.itemreader.alternative;
 
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.configuration.file.YamlConfiguration;
-import org.bukkit.inventory.ItemStack;
 
 public class SpigotReader implements ItemConfigTransformer {
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/AttributeManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/AttributeManager.java
@@ -1,0 +1,226 @@
+package com.nisovin.magicspells.util.managers;
+
+import java.util.Set;
+import java.util.List;
+import java.util.HashSet;
+import java.util.Collection;
+
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.attribute.AttributeModifier;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.DebugHandler;
+import com.nisovin.magicspells.util.AttributeUtil;
+
+public class AttributeManager {
+
+	// get attribute operation from string
+	public AttributeModifier.Operation getAttributeOperation(String str) {
+		return AttributeUtil.AttributeOperation.getOperation(str);
+	}
+
+	// get attribute from string
+	public Attribute getAttribute(String str) {
+		return AttributeUtil.AttributeType.getAttribute(str);
+	}
+
+	// add attributes to item meta
+	public ItemMeta addMetaAttribute(ItemMeta meta, Attribute attribute, AttributeModifier modifier) {
+		if (meta == null) throw new NullPointerException("itemMeta");
+		if (attribute == null) throw new NullPointerException("attribute");
+		if (modifier == null) throw new NullPointerException("modifier");
+		try {
+			meta.addAttributeModifier(attribute, modifier);
+		} catch (IllegalArgumentException exception) {
+			MagicSpells.log("That attribute has already been applied!");
+			DebugHandler.debugIllegalArgumentException(exception);
+		}
+		return meta;
+	}
+
+	public ItemMeta addMetaAttribute(ItemMeta meta, AttributeInfo attributeInfo) {
+		return addMetaAttribute(meta, attributeInfo.getAttribute(), attributeInfo.getAttributeModifier());
+	}
+
+	// add attributes to item stack
+	public void addItemAttribute(ItemStack item, Attribute attribute, AttributeModifier modifier) {
+		if (item == null) throw new NullPointerException("itemStack");
+		item.setItemMeta(addMetaAttribute(item.getItemMeta(), attribute, modifier));
+	}
+
+	public void addItemAttribute(ItemStack item, AttributeInfo attributeInfo) {
+		if (item == null) throw new NullPointerException("itemStack");
+		item.setItemMeta(addMetaAttribute(item.getItemMeta(), attributeInfo));
+	}
+
+	public void addItemAttributes(ItemStack itemStack, Set<AttributeInfo> attributes) {
+		attributes.forEach(attributeInfo -> addItemAttribute(itemStack, attributeInfo));
+	}
+
+	// add attributes to the living entity
+	public void addEntityAttribute(LivingEntity livingEntity, Attribute attribute, AttributeModifier modifier) {
+		if (livingEntity == null) throw new NullPointerException("livingEntity");
+		if (attribute == null) throw new NullPointerException("attribute");
+		if (modifier == null) throw new NullPointerException("modifier");
+		if (livingEntity.getAttribute(attribute) == null) throw new NullPointerException("inapplicable attribute");
+		try {
+			livingEntity.getAttribute(attribute).addModifier(modifier);
+		} catch (IllegalArgumentException exception) {
+			MagicSpells.log("That attribute has already been applied!");
+			DebugHandler.debugIllegalArgumentException(exception);
+		}
+	}
+
+	public void addEntityAttribute(LivingEntity livingEntity, AttributeInfo attributeInfo) {
+		addEntityAttribute(livingEntity, attributeInfo.getAttribute(), attributeInfo.getAttributeModifier());
+	}
+
+	public void addEntityAttributes(LivingEntity livingEntity, Set<AttributeInfo> attributes) {
+		attributes.forEach(attributeInfo -> addEntityAttribute(livingEntity, attributeInfo));
+	}
+
+	// has attribute modifier
+	public boolean hasEntityAttribute(LivingEntity entity, Attribute attribute, AttributeModifier modifier) {
+		return entity.getAttribute(attribute).getModifiers().contains(modifier);
+	}
+
+	public boolean hasEntityAttribute(LivingEntity entity, AttributeInfo attributeInfo) {
+		return entity.getAttribute(attributeInfo.getAttribute()).getModifiers().contains(attributeInfo.getAttributeModifier());
+	}
+
+	// get attribute and attribute modifier from string
+	// - [AttributeName] [Number] [Operation]
+	public AttributeInfo getAttributeInfo(String str) {
+		String[] args = str.split(" ");
+
+		if (args.length < 3) return null;
+
+		String attributeName = args[0];
+
+		double number;
+		try {
+			number = Double.parseDouble(args[1]);
+		} catch (NumberFormatException e) {
+			DebugHandler.debugNumberFormat(e);
+			return null;
+		}
+
+		String attributeOperation = args[2];
+
+		Attribute attribute = getAttribute(attributeName);
+		if (attribute == null) {
+			MagicSpells.error("AttributeManager has an invalid attribute defined: " + attributeName);
+			return null;
+		}
+
+		AttributeModifier.Operation operation = getAttributeOperation(attributeOperation);
+		if (operation == null) {
+			MagicSpells.error("AttributeManager has an invalid attribute operation defined: " + attributeOperation);
+			return null;
+		}
+
+		return new AttributeInfo(attribute, new AttributeModifier("MagicSpells " + attributeName, number, operation));
+	}
+
+	// get attribute info from string list
+	public Set<AttributeInfo> getAttributes(List<String> attributes) {
+		if (attributes == null || attributes.isEmpty()) return null;
+		Set<AttributeInfo> attributeMap = new HashSet<>();
+
+		for (String str : attributes) {
+			AttributeInfo attributeInfo = getAttributeInfo(str);
+			if (attributeInfo == null) continue;
+			attributeMap.add(attributeInfo);
+		}
+
+		return attributeMap;
+	}
+
+	// clear meta attributes
+	public ItemMeta removeMetaAttributeModifier(ItemMeta meta, Attribute attribute, AttributeModifier modifier) {
+		if (meta == null) throw new NullPointerException("itemMeta");
+		if (attribute == null) throw new NullPointerException("attribute");
+		if (modifier == null) throw new NullPointerException("modifier");
+		meta.removeAttributeModifier(attribute, modifier);
+		return meta;
+	}
+
+	public ItemMeta clearMetaAttributeModifiers(ItemMeta meta, Attribute attribute) {
+		if (meta == null) throw new NullPointerException("itemMeta");
+		if (attribute == null) throw new NullPointerException("attribute");
+		Collection<AttributeModifier> modifiers = meta.getAttributeModifiers(attribute);
+		modifiers.forEach(modifier -> meta.removeAttributeModifier(attribute, modifier));
+		return meta;
+	}
+
+	public ItemMeta clearMetaAttributeModifiers(ItemMeta meta, Set<AttributeInfo> attributeInfos) {
+		for (AttributeInfo attributeInfo : attributeInfos) {
+			meta = removeMetaAttributeModifier(meta, attributeInfo.getAttribute(), attributeInfo.getAttributeModifier());
+		}
+		return meta;
+	}
+
+	// clear item stack attributes
+	public void removeItemAttributeModifier(ItemStack item, Attribute attribute, AttributeModifier modifier) {
+		item.setItemMeta(removeMetaAttributeModifier(item.getItemMeta(), attribute, modifier));
+	}
+
+	public void clearItemAttributeModifiers(ItemStack item, Attribute attribute) {
+		item.setItemMeta(clearMetaAttributeModifiers(item.getItemMeta(), attribute));
+	}
+
+	public void clearItemAttributeModifiers(ItemStack item, Set<AttributeInfo> attributeInfos) {
+		item.setItemMeta(clearMetaAttributeModifiers(item.getItemMeta(), attributeInfos));
+	}
+
+	// clear entity attributes
+	public void removeEntityAttributeModifier(LivingEntity livingEntity, Attribute attribute, AttributeModifier modifier) {
+		if (livingEntity == null) throw new NullPointerException("livingEntity");
+		if (attribute == null) throw new NullPointerException("attribute");
+		if (modifier == null) throw new NullPointerException("modifier");
+		livingEntity.getAttribute(attribute).removeModifier(modifier);
+	}
+
+	public void clearEntityAttributeModifiers(LivingEntity livingEntity, Attribute attribute) {
+		if (livingEntity == null) throw new NullPointerException("livingEntity");
+		if (attribute == null) throw new NullPointerException("attribute");
+		Collection<AttributeModifier> modifiers = livingEntity.getAttribute(attribute).getModifiers();
+		modifiers.forEach(modifier -> livingEntity.getAttribute(attribute).removeModifier(modifier));
+	}
+
+	public void clearEntityAttributeModifiers(LivingEntity livingEntity, Set<AttributeInfo> attributeInfos) {
+		attributeInfos.forEach(attributeInfo -> removeEntityAttributeModifier(livingEntity, attributeInfo.getAttribute(), attributeInfo.getAttributeModifier()));
+	}
+
+	public static class AttributeInfo {
+
+		private Attribute attribute;
+		private AttributeModifier attributeModifier;
+
+		public AttributeInfo(Attribute attribute, AttributeModifier attributeModifier) {
+			this.attribute = attribute;
+			this.attributeModifier = attributeModifier;
+		}
+
+		public Attribute getAttribute() {
+			return attribute;
+		}
+
+		public void setAttribute(Attribute attribute) {
+			this.attribute = attribute;
+		}
+
+		public AttributeModifier getAttributeModifier() {
+			return attributeModifier;
+		}
+
+		public void setAttributeModifier(AttributeModifier attributeModifier) {
+			this.attributeModifier = attributeModifier;
+		}
+
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.util;
+package com.nisovin.magicspells.util.managers;
 
 import java.util.Map;
 import java.util.UUID;
@@ -11,6 +11,8 @@ import org.bukkit.boss.BossBar;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.managers.interfaces.IBossBarManager;
 
 public class BossBarManager implements IBossBarManager {
 

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/DisguiseManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/DisguiseManager.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.util;
+package com.nisovin.magicspells.util.managers;
 
 import java.util.Collections;
 import java.util.HashSet;
@@ -7,6 +7,8 @@ import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.Player;

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ExperienceBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ExperienceBarManager.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.util;
+package com.nisovin.magicspells.util.managers;
 
 import java.util.Map;
 import java.util.HashMap;
@@ -18,7 +18,7 @@ public class ExperienceBarManager {
 	}
 	
 	public void update(Player player, int level, float percent, Object object) {
-		Object lock = this.locks.get(player);
+		Object lock = locks.get(player);
 		if (lock == null || Objects.equals(object, lock)) {
 			if (player.getOpenInventory().getType() != InventoryType.ENCHANTING) {
 				MagicSpells.getVolatileCodeHandler().setExperienceBar(player, level, percent);
@@ -27,16 +27,16 @@ public class ExperienceBarManager {
 	}
 	
 	public void lock(Player player, Object object) {
-		Object lock = this.locks.get(player);
+		Object lock = locks.get(player);
 		if (lock == null || lock.equals(object)) {
-			this.locks.put(player, object);
+			locks.put(player, object);
 		}
 	}
 	
 	public void unlock(Player player, Object object) {
-		Object lock = this.locks.get(player);
+		Object lock = locks.get(player);
 		if (lock == null) return;
-		if (lock.equals(object)) this.locks.remove(player);
+		if (lock.equals(object)) locks.remove(player);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/interfaces/IBossBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/interfaces/IBossBarManager.java
@@ -1,7 +1,7 @@
-package com.nisovin.magicspells.util;
+package com.nisovin.magicspells.util.managers.interfaces;
 
-import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarFlag;
+import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.entity.Player;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/interfaces/IDisguiseManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/interfaces/IDisguiseManager.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.util;
+package com.nisovin.magicspells.util.managers.interfaces;
 
 import org.bukkit.entity.Player;
 

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/DisguiseManagerEmpty.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/DisguiseManagerEmpty.java
@@ -3,7 +3,7 @@ package com.nisovin.magicspells.volatilecode;
 import org.bukkit.entity.Player;
 
 import com.nisovin.magicspells.spells.targeted.DisguiseSpell.Disguise;
-import com.nisovin.magicspells.util.DisguiseManager;
+import com.nisovin.magicspells.util.managers.DisguiseManager;
 import com.nisovin.magicspells.util.MagicConfig;
 
 public class DisguiseManagerEmpty extends DisguiseManager {

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/DisguiseManagerLibsDisguises.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/DisguiseManagerLibsDisguises.java
@@ -46,7 +46,7 @@ import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.magicspells.spells.targeted.DisguiseSpell;
 import com.nisovin.magicspells.spells.targeted.DisguiseSpell.Disguise;
-import com.nisovin.magicspells.util.IDisguiseManager;
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager;
 import com.nisovin.magicspells.util.MagicConfig;
 
 public class DisguiseManagerLibsDisguises implements Listener, IDisguiseManager {

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -25,7 +25,7 @@ import org.bukkit.attribute.AttributeModifier.Operation;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.DisguiseManager;
+import com.nisovin.magicspells.util.managers.DisguiseManager;
 
 public class VolatileCodeDisabled implements VolatileCodeHandle {
 
@@ -186,45 +186,6 @@ public class VolatileCodeDisabled implements VolatileCodeHandle {
 	@Override
 	public void removeAI(LivingEntity entity) {
 		// Need the volatile code for this
-	}
-
-	@Override
-	public void addEntityAttribute(LivingEntity entity, String attribute, double amount, int operation) {
-		Attribute attr = null;
-		switch (attribute) {
-			case "generic.maxHealth":
-				attr = Attribute.GENERIC_MAX_HEALTH;
-				break;
-			case "generic.followRange":
-				attr = Attribute.GENERIC_FOLLOW_RANGE;
-				break;
-			case "generic.knockbackResistance":
-				attr = Attribute.GENERIC_KNOCKBACK_RESISTANCE;
-				break;
-			case "generic.movementSpeed":
-				attr = Attribute.GENERIC_MOVEMENT_SPEED;
-				break;
-			case "generic.attackDamage":
-				attr = Attribute.GENERIC_ATTACK_DAMAGE;
-				break;
-			case "generic.attackSpeed":
-				attr = Attribute.GENERIC_ATTACK_SPEED;
-				break;
-			case "generic.armor":
-				attr = Attribute.GENERIC_ARMOR;
-				break;
-			case "generic.luck":
-				attr = Attribute.GENERIC_LUCK;
-				break;
-		}
-
-		Operation oper = null;
-		if (operation == 0) oper = Operation.ADD_NUMBER;
-		else if (operation == 1) oper = Operation.MULTIPLY_SCALAR_1;
-		else if (operation == 2) oper = Operation.ADD_SCALAR;
-
-		if (attr == null || oper == null) return;
-		entity.getAttribute(attr).addModifier(new AttributeModifier("MagicSpells " + attribute, amount, oper));
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -11,7 +11,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.util.Vector;
 
-import com.nisovin.magicspells.util.IDisguiseManager;
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager;
 import com.nisovin.magicspells.util.MagicConfig;
 
 public interface VolatileCodeHandle {
@@ -63,9 +63,7 @@ public interface VolatileCodeHandle {
 	// TODO this should be moved to it's own handler
 	ItemStack addAttributes(ItemStack item, String[] names, String[] types, double[] amounts, int[] operations, String[] slots);
 	ItemStack hideTooltipCrap(ItemStack item);
-	
-	void addEntityAttribute(LivingEntity entity, String attribute, double amount, int operation);
-	
+
 	void removeAI(LivingEntity entity);
 	
 	void addAILookAtPlayer(LivingEntity entity, int range);

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_12_R1/VolatileCode1_12_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_12_R1/VolatileCode1_12_R1.kt
@@ -6,6 +6,7 @@ import com.nisovin.magicspells.MagicSpells
 import com.nisovin.magicspells.util.*
 import com.nisovin.magicspells.util.compat.CompatBasics
 import com.nisovin.magicspells.util.compat.EventUtil
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager
 import com.nisovin.magicspells.volatilecode.DisguiseManagerEmpty
 import com.nisovin.magicspells.volatilecode.DisguiseManagerLibsDisguises
 import com.nisovin.magicspells.volatilecode.VolatileCodeDisabled
@@ -465,30 +466,6 @@ class VolatileCode1_12_R1: VolatileCodeHandle {
         meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS)
         item.itemMeta = meta
         return item
-    }
-
-    override fun addEntityAttribute(entity: LivingEntity, attribute: String, amount: Double, operation: Int) {
-        var attr: Attribute? = null
-        when (attribute) {
-            "generic.maxHealth" -> attr = Attribute.GENERIC_MAX_HEALTH
-            "generic.followRange" -> attr = Attribute.GENERIC_FOLLOW_RANGE
-            "generic.knockbackResistance" -> attr = Attribute.GENERIC_KNOCKBACK_RESISTANCE
-            "generic.movementSpeed" -> attr = Attribute.GENERIC_MOVEMENT_SPEED
-            "generic.attackDamage" -> attr = Attribute.GENERIC_ATTACK_DAMAGE
-            "generic.attackSpeed" -> attr = Attribute.GENERIC_ATTACK_SPEED
-            "generic.armor" -> attr = Attribute.GENERIC_ARMOR
-            "generic.luck" -> attr = Attribute.GENERIC_LUCK
-        }
-
-        var oper: AttributeModifier.Operation? = null
-        when (operation) {
-            0 -> oper = AttributeModifier.Operation.ADD_NUMBER
-            1 -> oper = AttributeModifier.Operation.MULTIPLY_SCALAR_1
-            2 -> oper = AttributeModifier.Operation.ADD_SCALAR
-        }
-        if (attr != null && oper != null) {
-            entity.getAttribute(attr)!!.addModifier(AttributeModifier("MagicSpells $attribute", amount, oper))
-        }
     }
 
     override fun removeAI(entity: LivingEntity) {

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
@@ -6,6 +6,7 @@ import com.nisovin.magicspells.MagicSpells
 import com.nisovin.magicspells.util.*
 import com.nisovin.magicspells.util.compat.CompatBasics
 import com.nisovin.magicspells.util.compat.EventUtil
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager
 import com.nisovin.magicspells.volatilecode.DisguiseManagerEmpty
 import com.nisovin.magicspells.volatilecode.DisguiseManagerLibsDisguises
 import com.nisovin.magicspells.volatilecode.VolatileCodeDisabled
@@ -407,30 +408,6 @@ class VolatileCode1_13_R2: VolatileCodeHandle {
         meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS)
         item.itemMeta = meta
         return item
-    }
-
-    override fun addEntityAttribute(entity: LivingEntity, attribute: String, amount: Double, operation: Int) {
-        var attr: Attribute? = null
-        when (attribute) {
-            "generic.maxHealth" -> attr = Attribute.GENERIC_MAX_HEALTH
-            "generic.followRange" -> attr = Attribute.GENERIC_FOLLOW_RANGE
-            "generic.knockbackResistance" -> attr = Attribute.GENERIC_KNOCKBACK_RESISTANCE
-            "generic.movementSpeed" -> attr = Attribute.GENERIC_MOVEMENT_SPEED
-            "generic.attackDamage" -> attr = Attribute.GENERIC_ATTACK_DAMAGE
-            "generic.attackSpeed" -> attr = Attribute.GENERIC_ATTACK_SPEED
-            "generic.armor" -> attr = Attribute.GENERIC_ARMOR
-            "generic.luck" -> attr = Attribute.GENERIC_LUCK
-        }
-
-        var oper: AttributeModifier.Operation? = null
-        when (operation) {
-            0 -> oper = AttributeModifier.Operation.ADD_NUMBER
-            1 -> oper = AttributeModifier.Operation.MULTIPLY_SCALAR_1
-            2 -> oper = AttributeModifier.Operation.ADD_SCALAR
-        }
-        if (attr != null && oper != null) {
-            entity.getAttribute(attr)!!.addModifier(AttributeModifier("MagicSpells $attribute", amount, oper))
-        }
     }
 
     override fun removeAI(entity: LivingEntity) {

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
@@ -6,6 +6,7 @@ import com.nisovin.magicspells.MagicSpells
 import com.nisovin.magicspells.util.*
 import com.nisovin.magicspells.util.compat.CompatBasics
 import com.nisovin.magicspells.util.compat.EventUtil
+import com.nisovin.magicspells.util.managers.interfaces.IDisguiseManager
 import com.nisovin.magicspells.volatilecode.DisguiseManagerEmpty
 import com.nisovin.magicspells.volatilecode.DisguiseManagerLibsDisguises
 import com.nisovin.magicspells.volatilecode.VolatileCodeDisabled
@@ -407,30 +408,6 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
         meta.addItemFlags(ItemFlag.HIDE_POTION_EFFECTS)
         item.itemMeta = meta
         return item
-    }
-
-    override fun addEntityAttribute(entity: LivingEntity, attribute: String, amount: Double, operation: Int) {
-        var attr: Attribute? = null
-        when (attribute) {
-            "generic.maxHealth" -> attr = Attribute.GENERIC_MAX_HEALTH
-            "generic.followRange" -> attr = Attribute.GENERIC_FOLLOW_RANGE
-            "generic.knockbackResistance" -> attr = Attribute.GENERIC_KNOCKBACK_RESISTANCE
-            "generic.movementSpeed" -> attr = Attribute.GENERIC_MOVEMENT_SPEED
-            "generic.attackDamage" -> attr = Attribute.GENERIC_ATTACK_DAMAGE
-            "generic.attackSpeed" -> attr = Attribute.GENERIC_ATTACK_SPEED
-            "generic.armor" -> attr = Attribute.GENERIC_ARMOR
-            "generic.luck" -> attr = Attribute.GENERIC_LUCK
-        }
-
-        var oper: AttributeModifier.Operation? = null
-        when (operation) {
-            0 -> oper = AttributeModifier.Operation.ADD_NUMBER
-            1 -> oper = AttributeModifier.Operation.MULTIPLY_SCALAR_1
-            2 -> oper = AttributeModifier.Operation.ADD_SCALAR
-        }
-        if (attr != null && oper != null) {
-            entity.getAttribute(attr)!!.addModifier(AttributeModifier("MagicSpells $attribute", amount, oper))
-        }
     }
 
     override fun removeAI(entity: LivingEntity) {

--- a/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneCuboid.java
+++ b/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneCuboid.java
@@ -6,12 +6,12 @@ import org.bukkit.configuration.ConfigurationSection;
 public class NoMagicZoneCuboid extends NoMagicZone {
 	
 	private String worldName;
-	private int minx;
-	private int miny;
-	private int minz;
-	private int maxx;
-	private int maxy;
-	private int maxz;
+	private int minX;
+	private int minY;
+	private int minZ;
+	private int maxX;
+	private int maxY;
+	private int maxZ;
 	
 	@Override
 	public void initialize(ConfigurationSection config) {
@@ -27,25 +27,27 @@ public class NoMagicZoneCuboid extends NoMagicZone {
 		int z2 = Integer.parseInt(p2[2]);
 		
 		if (x1 < x2) {
-			minx = x1;
-			maxx = x2;
+			minX = x1;
+			maxX = x2;
 		} else {
-			minx = x2;
-			maxx = x1;
+			minX = x2;
+			maxX = x1;
 		}
+
 		if (y1 < y2) {
-			miny = y1;
-			maxy = y2;
+			minY = y1;
+			maxY = y2;
 		} else {
-			miny = y2;
-			maxy = y1;
+			minY = y2;
+			maxY = y1;
 		}
+
 		if (z1 < z2) {
-			minz = z1;
-			maxz = z2;
+			minZ = z1;
+			maxZ = z2;
 		} else {
-			minz = z2;
-			maxz = z1;
+			minZ = z2;
+			maxZ = z1;
 		}
 	}
 
@@ -55,7 +57,7 @@ public class NoMagicZoneCuboid extends NoMagicZone {
 		int x = location.getBlockX();
 		int y = location.getBlockY();
 		int z = location.getBlockZ();
-		return minx <= x && x <= maxx && miny <= y && y <= maxy && minz <= z && z <= maxz;
+		return minX <= x && x <= maxX && minY <= y && y <= maxY && minZ <= z && z <= maxZ;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneWorldGuard.java
+++ b/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneWorldGuard.java
@@ -18,39 +18,34 @@ public class NoMagicZoneWorldGuard extends NoMagicZone {
 
 	private String worldName;
 	private String regionName;
+
 	private ProtectedRegion region;
+	private WorldGuardPlugin worldGuard;
 
 	@Override
 	public void initialize(ConfigurationSection config) {
 		worldName = config.getString("world", "");
 		regionName = config.getString("region", "");
+
+		if (CompatBasics.pluginEnabled("WorldGuard")) worldGuard = (WorldGuardPlugin) CompatBasics.getPlugin("WorldGuard");
+		if (worldGuard == null) return;
+
+		World w = Bukkit.getServer().getWorld(worldName);
+		if (w == null) return;
+
+		RegionManager rm = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(w));
+		if (rm != null) region = rm.getRegion(regionName);
 	}
 
 	@Override
 	public boolean inZone(Location location) {
-		// Check world
 		if (!worldName.equals(location.getWorld().getName())) return false;
-
-		// Get region, if necessary
 		if (region == null) {
-			WorldGuardPlugin worldGuard = null;
-			if (CompatBasics.pluginEnabled("WorldGuard")) worldGuard = (WorldGuardPlugin)CompatBasics.getPlugin("WorldGuard");
-			if (worldGuard != null) {
-				World w = Bukkit.getServer().getWorld(worldName);
-				if (w != null) {
-					RegionManager rm = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(w));
-					if (rm != null) region = rm.getRegion(regionName);
-				}
-			}
+			MagicSpells.error("Failed to access WorldGuard region '" + regionName + '\'');
+			return false;
 		}
 
-		// Check if contains
-		if (region != null) {
-			return region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
-		}
-
-		MagicSpells.error("Failed to access WorldGuard region '" + regionName + '\'');
-		return false;
+		return region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
 	}
 
 }

--- a/core/src/main/resources/mana.yml
+++ b/core/src/main/resources/mana.yml
@@ -1,43 +1,50 @@
 enable-mana-system: true
-mana-bar-prefix: "Mana:"
-mana-bar-size: 35
-color-full: 1
-color-empty: 0
+
+default-prefix: "Mana:"
+default-symbol: '='
+default-size: 35
+default-color-full: 1
+default-color-empty: 0
 
 default-max-mana: 100
+default-starting-mana: 100
 default-regen-amount: 5
-regen-interval: 100
-
-ranks:
-    master:
-        max-mana: 200
-        regen-amount: 10
-        prefix: "Mana:"
-        color-full: 1
-        color-empty: 0
-    adept:
-        max-mana: 150
-        regen-amount: 7
-        prefix: "Mana:"
-        color-full: 1
-        color-empty: 0
-    novice:
-        max-mana: 100
-        regen-amount: 5
-        prefix: "Mana:"
-        color-full: 1
-        color-empty: 0
+default-regen-interval: 20
 
 show-mana-on-use: false
 show-mana-on-regen: false
-show-mana-on-wood-tool: false
 show-mana-on-hunger-bar: false
+show-mana-on-action-bar: false
 show-mana-on-experience-bar: true
-tool-slot: 8
 
-mana-potion-cooldown: 30
-str-mana-potion-on-cooldown: You cannot use another mana potion yet (%c seconds).
-mana-potions:
-    - LAPIS_LAZULI 100
-#    - 348 60
-#    - 331 30
+ranks:
+    master:
+        prefix: "Mana:"
+        symbol: '='
+        size: 35
+        max-mana: 200
+        starting-mana: 200
+        regen-amount: 10
+        regen-interval: 20
+        color-full: 1
+        color-empty: 0
+    adept:
+        prefix: "Mana:"
+        symbol: '='
+        size: 35
+        max-mana: 150
+        starting-mana: 150
+        regen-amount: 7
+        regen-interval: 20
+        color-full: 1
+        color-empty: 0
+    novice:
+        prefix: "Mana:"
+        symbol: '='
+        size: 35
+        max-mana: 100
+        starting-mana: 100
+        regen-amount: 5
+        regen-interval: 20
+        color-full: 1
+        color-empty: 0


### PR DESCRIPTION
Added EntityEditSpell
Added GameModeCondition
Added spell name replacement (%s) for str-on-cooldown message
Added signbook passive trigger
Added 3 new effect positions: cooldown, chargeuse, missingreagents
NoMagicZones use a spellfilter: allowed-spells, disallowed-spells, allowed-spell-tags, disallowed-spell-tags
TitleEffect supports variable replacement

Mana changes:
  * Removed mana-potions
  * Removed mana-potion-cooldown
  * Removed str-mana-potion-on-cooldown
  * Removed show-mana-on-wood-tool
  * Removed tool-slot
  * Renamed regen-interval to default-regen-interval
  * Renamed mana-bar-prefix to default-prefix
  * Renamed color-full to default-color-full
  * Renamed color-empty to default-color-empty
  * Renamed mana-bar-size to default-size
  * Added color codes support for default-prefix and mana rank prefixes
  * Added default-symbol
  * Added default-size
  * Added default-starting-mana
  * Added size to mana ranks
  * Added starting-mana to mana ranks
  * Added regen-interval to mana ranks
  * Added symbol to mana ranks
  * Added show-mana-on-action-bar