### PR TITLE
Bugfix and Additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/RightClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/RightClickListener.java
@@ -23,6 +23,7 @@ public class RightClickListener implements Listener {
 		for (Spell spell : MagicSpells.getSpells().values()) {
 			CastItem[] items = spell.getRightClickCastItems();
 			if (items.length <= 0) continue;
+			if (items.length == 1 && items[0] == null) continue;
 			for (CastItem item : items) {
 				Spell old = rightClickCastItems.put(item, spell);
 				if (old == null) continue;

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -213,7 +213,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			castItems = new CastItem[sItems.length];
 			for (int i = 0; i < sItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems[i]);
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid cast item specified: " + sItems[i]);
+					continue;
+				}
 				castItems[i] = new CastItem(is);
 			}
 		} else if (config.contains(path + "cast-items")) {
@@ -222,7 +225,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			castItems = new CastItem[sItems.size()];
 			for (int i = 0; i < castItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems.get(i));
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid cast item listed: " + sItems.get(i));
+					continue;
+				}
 				castItems[i] = new CastItem(is);
 			}
 		} else {
@@ -233,7 +239,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			rightClickCastItems = new CastItem[sItems.length];
 			for (int i = 0; i < sItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems[i]);
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid right click cast item specified: " + sItems[i]);
+					continue;
+				}
 				rightClickCastItems[i] = new CastItem(is);
 			}
 		} else if (config.contains(path + "right-click-cast-items")) {
@@ -242,7 +251,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			rightClickCastItems = new CastItem[sItems.size()];
 			for (int i = 0; i < rightClickCastItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems.get(i));
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid right click cast item listed: " + sItems.get(i));
+					continue;
+				}
 				rightClickCastItems[i] = new CastItem(is);
 			}
 		} else {
@@ -253,7 +265,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			consumeCastItems = new CastItem[sItems.length];
 			for (int i = 0; i < sItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems[i]);
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid consume cast item specified: " + sItems[i]);
+					continue;
+				}
 				consumeCastItems[i] = new CastItem(is);
 			}
 		} else if (config.contains(path + "consume-cast-items")) {
@@ -262,7 +277,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			consumeCastItems = new CastItem[sItems.size()];
 			for (int i = 0; i < consumeCastItems.length; i++) {
 				ItemStack is = Util.getItemStackFromString(sItems.get(i));
-				if (is == null) continue;
+				if (is == null) {
+					MagicSpells.error("Spell '" + internalName + "' has an invalid consume cast item listed: " + sItems.get(i));
+					continue;
+				}
 				consumeCastItems[i] = new CastItem(is);
 			}
 		} else {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -80,6 +80,9 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 	public void turnOff() {
 		super.turnOff();
 
+		for (Block block : blocks.keySet()) {
+			block.setType(Material.AIR);
+		}
 		blocks.clear();
 		if (checker != null) checker.stop();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -24,6 +24,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 	private boolean replaceAll;
 	private List<Material> replace;
 	private List<Material> replaceWith;
+	private List<Material> replaceBlacklist;
 
 	private Random random;
 
@@ -43,6 +44,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 		blocks = new HashMap<>();
 		replace = new ArrayList<>();
 		replaceWith = new ArrayList<>();
+		replaceBlacklist = new ArrayList<>();
 
 		random = new Random();
 
@@ -88,6 +90,19 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 				}
 
 				replaceWith.add(material);
+			}
+		}
+
+		list = getConfigStringList("replace-blacklist", null);
+		if (list != null) {
+			for (String s : list) {
+				Material material = Material.getMaterial(s.toUpperCase());
+				if (material == null) {
+					MagicSpells.error("ReplaceSpell " + internalName + " has an invalid replace-blacklist item: " + s);
+					continue;
+				}
+
+				replaceBlacklist.add(material);
 			}
 		}
 
@@ -146,6 +161,8 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 						if (!replaceAll && !replace.get(i).equals(block.getType())) continue;
 						// If all blocks are being replaced, skip if the block is already replaced.
 						if (replaceAll && replaceWith.get(i).equals(block.getType())) continue;
+
+						if (replaceBlacklist.contains(block.getType())) continue;
 
 						blocks.put(block, block.getType());
 						Block finalBlock = block;


### PR DESCRIPTION
# Changes:
### ReplaceSpell:
* You can list "all" in `replace-blocks` in order to whitelist all blocks for replacement.
* Added `replace-blacklist`.
### CarpetSpell:
* Blocks created by this spell are now removed on plugin reload.
### Cast Items:
* Added debug message for invalid items specified for any cast items.
* Fixed bug with **right click cast item(s)** where if the specified item is invalid, it could cause the "spell1 has same right click cast item specified as spell2" to be sent even if the item strings are unique.