### PR TITLE
Don't manually add permissions to Bukkit's permission manager and speed up /c reload

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Perm.java
+++ b/core/src/main/java/com/nisovin/magicspells/Perm.java
@@ -72,14 +72,14 @@ public enum Perm {
 	
 	public boolean has(Permissible permissible) {
 		if (requiresOp() && !permissible.isOp()) return false;
-		if (requiresNode() && !permissible.hasPermission(getNode())) return false;
-		return true;
+		return !requiresNode() || permissible.hasPermission(getNode());
 	}
 	
 	public boolean has(Permissible permissible, Spell spell) {
 		if (requiresOp() && !permissible.isOp()) return false;
-		if (requiresNode() && !permissible.hasPermission(getNode(spell))) return false;
-		return true;
+		return !requiresNode() || permissible.hasPermission(getNode(spell))
+				|| (getNode(spell).endsWith(".") && permissible.hasPermission(node + "*"))
+				|| spell.isAlwaysGranted();
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -809,7 +809,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		}
 
 		if (event.hasSpellCastStateChanged()) debug(2, "    Spell cast state changed: " + state);
-		if (Perm.NOCASTTIME.has(livingEntity)) event.setCastTime(0);
+		if (Perm.NOCASTTIME.has(livingEntity) || (livingEntity.isOp() && MagicSpells.getInstance().opsIgnoreCastTimes)) event.setCastTime(0);
 		return event;
 	}
 
@@ -975,7 +975,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 * @return whether the spell is on cooldown
 	 */
 	public boolean onCooldown(LivingEntity livingEntity) {
-		if (Perm.NOCOOLDOWN.has(livingEntity)) return false;
+		if (Perm.NOCOOLDOWN.has(livingEntity) || (livingEntity.isOp() && MagicSpells.getInstance().opsIgnoreCooldowns)) return false;
 		if (charges > 0) return chargesConsumed.get(livingEntity.getUniqueId()) >= charges;
 		if (serverCooldown > 0 && nextCastServer > System.currentTimeMillis()) return true;
 
@@ -1081,7 +1081,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 */
 	private boolean hasReagents(LivingEntity livingEntity, ItemStack[] reagents, int healthCost, int manaCost, int hungerCost, int experienceCost, int levelsCost, int durabilityCost, float moneyCost, Map<String, Double> variables) {
 		// Is the livingEntity exempt from reagent costs?
-		if (Perm.NOREAGENTS.has(livingEntity)) return true;
+		if (Perm.NOREAGENTS.has(livingEntity) || (livingEntity.isOp() && MagicSpells.getInstance().opsIgnoreReagents)) return true;
 
 		// player reagents
 		if (livingEntity instanceof Player) {
@@ -1183,7 +1183,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 * @param manaCost the mana to remove
 	 */
 	private void removeReagents(LivingEntity livingEntity, ItemStack[] reagents, int healthCost, int manaCost, int hungerCost, int experienceCost, int levelsCost, int durabilityCost, float moneyCost, Map<String, Double> variables) {
-		if (Perm.NOREAGENTS.has(livingEntity)) return;
+		if (Perm.NOREAGENTS.has(livingEntity) || (livingEntity.isOp() && MagicSpells.getInstance().opsIgnoreReagents)) return;
 
 		if (reagents != null) {
 			for (ItemStack item : reagents) {

--- a/core/src/main/java/com/nisovin/magicspells/Spellbook.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spellbook.java
@@ -231,17 +231,17 @@ public class Spellbook {
 		}
 
 		MagicSpells.debug("Checking learn permissions for " + player.getName());
-		return Perm.LEARN.has(player, spell);
+		return Perm.LEARN.has(player, spell) || !MagicSpells.getInstance().defaultAllPermsFalse;
 	}
 
 	public boolean canCast(Spell spell) {
 		if (spell.isHelperSpell()) return true;
-		return plugin.ignoreCastPerms || Perm.CAST.has(player, spell);
+		return plugin.ignoreCastPerms || Perm.CAST.has(player, spell) || !MagicSpells.getInstance().defaultAllPermsFalse;
 	}
 
 	public boolean canTeach(Spell spell) {
 		if (spell.isHelperSpell()) return false;
-		return Perm.TEACH.has(player, spell);
+		return Perm.TEACH.has(player, spell) || !MagicSpells.getInstance().defaultAllPermsFalse;
 	}
 
 	public boolean hasAdvancedPerm(String spell) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -150,7 +150,7 @@ public class ImbueSpell extends CommandSpell {
 				else if (uses <= 0) uses = 1;
 			}
 			
-			if (chargeReagentsForSpellPerUse && !Perm.NOREAGENTS.has(player)) {
+			if (chargeReagentsForSpellPerUse && !(Perm.NOREAGENTS.has(player) || (livingEntity.isOp() && MagicSpells.getInstance().opsIgnoreReagents))) {
 				SpellReagents reagents = spell.getReagents().multiply(uses);
 				if (!hasReagents(player, reagents)) {
 					sendMessage(strMissingReagents, player, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -231,8 +231,8 @@ public class ScrollSpell extends CommandSpell {
 			return;
 		}
 
-		if (ignoreCastPerm && !Perm.CAST.has(player, spell)) player.addAttachment(MagicSpells.plugin, Perm.CAST.getNode(spell), true, 1);
-		if (castForFree && !Perm.NOREAGENTS.has(player)) player.addAttachment(MagicSpells.plugin, Perm.NOREAGENTS.getNode(), true, 1);
+		if (ignoreCastPerm && !(Perm.CAST.has(player, spell) || MagicSpells.getInstance().defaultAllPermsFalse)) player.addAttachment(MagicSpells.plugin, Perm.CAST.getNode(spell), true, 1);
+		if (castForFree && !(Perm.NOREAGENTS.has(player) || (player.isOp() && MagicSpells.getInstance().opsIgnoreReagents))) player.addAttachment(MagicSpells.plugin, Perm.NOREAGENTS.getNode(), true, 1);
 
 		SpellCastState state;
 		PostCastAction action;

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -19,3 +19,39 @@ commands:
         description: Show magic XP info
         usage: /<command>
         aliases: [magicxp,spellxp]
+permissions:
+    magicspells.silent:
+        description: "If spell messages should be silenced"
+        default: false
+    magicspells.notarget:
+       description: "If the player should not be affected by any spells or targetted."
+       default: false
+    magicspells.noreagents:
+        description: "If reagents should be ignored."
+        default: false
+    magicspells.nocooldown:
+        description: "If cooldowns should be ignored."
+        default: false
+    magicspells.nocasttime:
+        description: "If cast time should be ignored."
+        default: false
+    magicspells.advanced.*:
+        description: "Gives access to all advanced MagicSpells permissions."
+        default: op
+        children:
+            magicspells.advanced.list: true
+            magicspells.advanced.forget: true
+            magicspells.advanced.scroll: true
+            magicspells.advanced.imbue: true
+    magicspells.advanced.list:
+        description: "If the player should be able to use the List Spell to see a list of a player's known spells."
+        default: op
+    magicspells.advanced.forget:
+        description: "If the player should be able to use the Forget Spell to force another player to forget a spell."
+        default: op
+    magicspells.advanced.scroll:
+        description: "If the player should be able to use the Scroll Spell to create a base scroll."
+        default: op
+    magicspells.advanced.imbue:
+        description: "If the player should be able to imbue (bind) spells to a scroll for a certain amount of time."
+        default: op


### PR DESCRIPTION
This in some events drastically improves performance when it comes to setting permissions within MagicSpells, most notably when reloading the plugin using /c reload. Any constant permissions are now specified within the plugin.yml, and any permissions that previously had their default value modified depending on specified config values have received code changes where those permission checks took place.

Tested with latest beta off of Discord on a test server with roughly 50 bots. Upon running the /c reload command with the default spells, an additional second was added to the reload command when loading permissions. While this may not seem like a lot, as I added on more spells and copied in configurations, this number continued to increase. Adding new spells increased reload time by quite a bit upon their first load, but subsequent loads sped up. However, the overall amount of time it took to reload the plugin with more and more spells slowed down these subsequent reloads considerably. Others have reported that these reloads can take up to 30 seconds, mostly hanging on the finalizing permissions stages, on servers with lots of spells and high playercounts.

This is likely due to permissions needing to be recalculated for every single player online when it's done through Bukkit's plugin/permission manager. Adding new permissions through the plugin manager also causes some noticeable lag (since it recalculates here too), which is most likely why adding new spells in the config and reloading caused the reload time to increase. 

With ~100 bots and the added spell configurations from previous testing, using this version, I was able to reload the entire plugin with /c reload in under 80ms, or just a little under 2 Minecraft ticks. The performance improvements in this case is massive. Upon adding new spells to the config, when I normally observed an additional 2 or 3 seconds for these new spells to load, with this version there is hardly any additional time added.

Testing has been done to ensure the permissions still work as they should, however this PR could benefit from more rigorous testing. Please let me know if something is not working properly or there is anything that should be changed. 