### PR TITLE
Docs folder, HasScoreboardTag, and TotemSpell fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/Condition.java
@@ -150,6 +150,7 @@ public abstract class Condition {
 		conditions.put("onleash", OnLeashCondition.class);
 		conditions.put("griefpreventionisowner", GriefPreventionIsOwnerCondition.class);
 		conditions.put("slotselected", SlotSelectedCondition.class);
+		conditions.put("hasscoreboardtag", HasScoreboardTagCondition.class);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
@@ -1,0 +1,50 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+
+public class HasScoreboardTagCondition extends Condition {
+
+    private String var;
+    private String tag;
+    private boolean isVar;
+    private Set<String> enttags = new HashSet<>();
+
+    @Override
+    public boolean setVar(String var) {
+        if (var == null || var.isEmpty()) return false;
+        if (var.contains("%var:")) isVar = true;
+        this.var = var;
+        tag = var;
+        return true;
+    }
+
+    @Override
+    public boolean check(LivingEntity livingEntity) {
+        enttags = livingEntity.getScoreboardTags();
+        if (!(livingEntity instanceof Player)) return enttags.contains(tag);
+        if (isVar) tag = MagicSpells.doVariableReplacements((Player) livingEntity, var);
+        return enttags.contains(tag);
+    }
+
+    @Override
+    public boolean check(LivingEntity livingEntity, LivingEntity target) {
+        enttags = target.getScoreboardTags();
+        if (!(target instanceof Player)) return enttags.contains(tag);
+        if (isVar) tag = MagicSpells.doVariableReplacements((Player) target, var);
+        return enttags.contains(tag);
+    }
+
+    @Override
+    public boolean check(LivingEntity livingEntity, Location location) {
+        return false;
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -51,6 +51,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 	private boolean targetable;
 	private boolean totemNameVisible;
 	private boolean onlyCountOnSuccess;
+	private boolean centerStand;
 
 	private String strAtCap;
 	private String totemName;
@@ -99,6 +100,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		targetable = getConfigBoolean("targetable", true);
 		totemNameVisible = getConfigBoolean("totem-name-visible", true);
 		onlyCountOnSuccess = getConfigBoolean("only-count-on-success", false);
+		centerStand = getConfigBoolean("center-stand", true);
 
 		strAtCap = getConfigString("str-at-cap", "You have too many effects at once.");
 		totemName = getConfigString("totem-name", "");
@@ -186,12 +188,18 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		else if (yOffset < 0) block = block.getRelative(BlockFace.DOWN, yOffset);
 
 		if (BlockUtils.isAir(block.getType()) || block.getType() == Material.SNOW || block.getType() == Material.TALL_GRASS) {
-			createTotem(caster, block.getLocation(), power);
+			if (centerStand == false) {
+				Location loc = target.clone();
+				createTotem(caster, loc, power);
+			} else createTotem(caster, block.getLocation(), power);
 			return true;
 		}
 		block = block.getRelative(BlockFace.UP);
 		if (BlockUtils.isAir(block.getType()) || block.getType() == Material.SNOW || block.getType() == Material.TALL_GRASS) {
-			createTotem(caster, block.getLocation(), power);
+			if (centerStand == false) {
+				Location loc = target.clone();
+				createTotem(caster, loc, power);
+			} else createTotem(caster, block.getLocation(), power);
 			return true;
 		}
 		return false;
@@ -203,10 +211,12 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 	}
 
 	private void createTotem(LivingEntity caster, Location loc, float power) {
-		totems.add(new Totem(caster, loc, power));
+		Location loc2 = loc.clone();
+		if (centerStand == true) loc2 = loc.clone().add(0.5, 0, 0.5);
+		totems.add(new Totem(caster, loc2, power));
 		ticker.start();
-		if (caster != null) playSpellEffects(caster, loc);
-		else playSpellEffects(EffectPosition.TARGET, loc);
+		if (caster != null) playSpellEffects(caster, loc2);
+		else playSpellEffects(EffectPosition.TARGET, loc2);
 	}
 
 	@EventHandler
@@ -264,6 +274,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 			totemEquipment = armorStand.getEquipment();
 			armorStand.setGravity(gravity);
+			armorStand.addScoreboardTag("MS_Totem");
 			totemEquipment.setItemInMainHand(mainHand);
 			totemEquipment.setItemInOffHand(hand);
 			totemEquipment.setHelmet(helmet);

--- a/docs/spigot_page.md
+++ b/docs/spigot_page.md
@@ -1,0 +1,43 @@
+// This page is here as a template for the spigot resources page
+// It is formatted to be easily copied over to spigot and can be edited by contributors.
+// If you do edit this, please be specific as to why in your commit!
+
+Title: MagicSpells
+Subtitle: Make your server uniquely yours
+
+Native MC Ver: 1.13
+Tested MC Ver: 1.13, 1.14, 1.15
+Source Code: https://github.com/TheComputerGeek2/MagicSpells
+
+Contributors: Nisovin (Original author), Drawnhorizons, ChronoKeeper, niblexis
+
+Raw Description:
+//##################################===> Start
+MagicSpells is a plugin that allows you to create "spells" which can be chained together to make various unique systems for your server. The MagicSpells community primarily runs out of the Discord<-[https://discord.magicspells.dev/] with various channels dedicated to helping you learn the plugin based on your version. We also have an assortment of resources that can get you started with the plugin.
+
+Useful Links:
+**Community Wiki (Version 4.0+)<-[https://github.com/TheComputerGeek2/MagicSpells/wiki]**
+**Community Guides<-[https://forum.magicspells.dev/categories/configuration-guides]**
+**Official Forum<-[https://forum.magicspells.dev/]**
+**Discord Link (Join for support)<-[https://discord.magicspells.dev/]**
+**Github: Releases<-[https://github.com/TheComputerGeek2/MagicSpells/releases] \ Source<-[https://github.com/TheComputerGeek2/MagicSpells/tree/4.0] \ Commits<-[https://github.com/TheComputerGeek2/MagicSpells/commits/4.0]**
+
+Getting Started
+For getting started, the Forum<-[https://forum.magicspells.dev/] and Discord<-[https://discord.magicspells.dev/] are wonderful resources for learning, support, and development. We have put a lot into this project, so with that, we welcome you to MagicSpells, where we aim for people to create unique content and take pride in their work.
+
+FAQ
+Q: Why doesn't this plugin update often??
+A: We release often on our github<-[https://github.com/TheComputerGeek2/MagicSpells/releases]. Builds are only posted here when they are deemed as a "release build".
+
+Q: Why doesn't this plugin work on 1.7.10??
+A: https://howoldisminecraft1710.today/
+
+Q: How do I...
+A: Stop right there, go here<-[https://discord.magicspells.dev/].
+
+Servers Using MS
+Some servers which make beautiful use of MagicSpells can be found below (with more here)!
+//##################################===> End
+All Headers should be font "6"
+All links should be collapsed when making the post.
+All "Questions" in the FAQ section should be Bold


### PR DESCRIPTION
- Added the docs folder to hold any sort of important document for magicspells including the spigot page layout. More files will be added into this folder at a later date.
- Added `HasScoreboardTag` condition which supports variable replacement. Checks if the target has a scoreboard tag embedded in their NBT.
- Fixed positioning of totem spells when spawning from projectile based spells. They now spawn at precise locations instead of block based locations. This positioning can be used through `center-stand: false` (defaults `true`)
- Totem spells now spawn with the tag `MS_Totem` which allows other plugins a easy way to sense them as well as some user level interactions.