### PR TITLE
DataSpell getting data from caster instead of target

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
@@ -45,7 +45,7 @@ public class DataSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (target == null) return noTarget(player);
 
 			playSpellEffects(player, target);
-			String value = dataElement.apply(livingEntity);
+			String value = dataElement.apply(target);
 			MagicSpells.getVariableManager().set(variableName, player, value);
 		}
 		return PostCastAction.HANDLE_NORMALLY;


### PR DESCRIPTION
When support was added for missing DataLivingEntity elements, the spell was changed to only get data elements from the caster. As such, regardless of if target-self is true, the spell only targets self.