### PR TITLE
Durability costs don't work

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1245,8 +1245,9 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 				if (newDura >= inHand.getType().getMaxDurability()) {
 					livingEntity.getEquipment().setItemInMainHand(null);
 				} else {
-					((Damageable) inHand.getItemMeta()).setDamage(newDura);
-					livingEntity.getEquipment().setItemInMainHand(inHand);
+					ItemMeta meta = inHand.getItemMeta();
+					((Damageable) meta).setDamage(newDura);
+					inHand.setItemMeta(meta);
 				}
 			}
 		}


### PR DESCRIPTION
Durability costs don't work - when you do getItemMeta(), you get a clone of the item's meta. So, when you change the durability damage on that clone, it doesn't change the original item's meta.