### PR TITLE
Improved bow support

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -148,6 +148,8 @@ public class MagicSpells extends JavaPlugin {
 	boolean allowCastWithFist;
 	boolean castWithLeftClick;
 	boolean castWithRightClick;
+	boolean reverseBowCycleButtons;
+	boolean bowCycleSpellsSneaking;
 	boolean allowCycleToNoSpell;
 
 	boolean checkScoreboardTeams;
@@ -258,6 +260,8 @@ public class MagicSpells extends JavaPlugin {
 
 		separatePlayerSpellsPerWorld = config.getBoolean(path + "separate-player-spells-per-world", false);
 		allowCycleToNoSpell = config.getBoolean(path + "allow-cycle-to-no-spell", false);
+		reverseBowCycleButtons = config.getBoolean(path + "reverse-bow-cycle-buttons", false);
+		bowCycleSpellsSneaking = config.getBoolean(path + "bow-cycle-spells-sneaking", false);
 		alwaysShowMessageOnCycle = config.getBoolean(path + "always-show-message-on-cycle", false);
 		onlyCycleToCastableSpells = config.getBoolean(path + "only-cycle-to-castable-spells", true);
 		spellIconSlot = config.getInt(path + "spell-icon-slot", -1);
@@ -811,6 +815,14 @@ public class MagicSpells extends JavaPlugin {
 
 	public static boolean isDebugNumberFormat() {
 		return plugin.debugNumberFormat;
+	}
+	
+	public static boolean areBowCycleButtonsReversed() {
+		return plugin.reverseBowCycleButtons;
+	}
+
+	public static boolean canBowCycleSpellsSneaking() {
+		return plugin.bowCycleSpellsSneaking;
 	}
 
 	public static boolean isCastingOnAnimate() {

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -69,31 +69,22 @@ public class CastListener implements Listener {
 			return;
 		}
 
-		if ((event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK) && (!MagicSpells.areBowCycleButtonsReversed() || (event.hasItem() && event.getItem().getType() != Material.BOW && event.getItem().getType() != Material.CROSSBOW))) {
-			// Left click - cast
+		if (isEventCastAction(event)) {
+			// Cast
 			if (!MagicSpells.isCastingOnAnimate()) castSpell(event.getPlayer());
 			return;
 		}
 
-		//if ((event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK) && (MagicSpells.isCyclingSpellsOnOffhandAction() || event.getHand() == EquipmentSlot.HAND)) {
-		if ((event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK)
-				&& (!MagicSpells.areBowCycleButtonsReversed() || (event.hasItem() && event.getItem().getType() != Material.BOW && event.getItem().getType() != Material.CROSSBOW))
-				&& (MagicSpells.isCyclingSpellsOnOffhandAction() || event.getHand() == EquipmentSlot.HAND)
-				||
-				(event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK)
-						&& MagicSpells.areBowCycleButtonsReversed() && event.hasItem() && (event.getItem().getType() == Material.BOW || event.getItem().getType() == Material.CROSSBOW)
-						&& event.getHand() == EquipmentSlot.HAND) {
-			// Right click -- cycle spell
+		if (isEventCycleAction(event) && (MagicSpells.isCyclingSpellsOnOffhandAction() || event.getHand() == EquipmentSlot.HAND)) {
 			ItemStack inHand = player.getEquipment().getItemInMainHand();
 			
-			if (inHand != null && (inHand.getType() == Material.BOW || event.getItem().getType() != Material.CROSSBOW)) {
+			if (inHand != null && isBow(inHand.getType())) {
 				if (!MagicSpells.canBowCycleSpellsSneaking() && player.isSneaking()) {
 					return;
 				}
 			}
 			
 			if ((inHand != null && !BlockUtils.isAir(inHand.getType())) || MagicSpells.canCastWithFist()) {
-
 				// Cycle spell
 				Spell spell;
 				if (!player.isSneaking()) spell = MagicSpells.getSpellbook(player).nextSpell(inHand);
@@ -173,4 +164,27 @@ public class CastListener implements Listener {
 		MagicSpells.getVolatileCodeHandler().sendFakeSlotUpdate(player, slot, icon);
 	}
 
+	private boolean isBow(Material material) {
+		if (material == null) {
+			return false;
+		}
+		
+		return material.name().equalsIgnoreCase("BOW") || material.name().equalsIgnoreCase("CROSSBOW");
+	}
+	
+	private boolean isEventCastAction(PlayerInteractEvent event) {
+		if (MagicSpells.areBowCycleButtonsReversed() && event.hasItem() && isBow(event.getItem().getType())) {
+			return false;
+		}
+		
+		return event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK;
+	}
+	
+	private boolean isEventCycleAction(PlayerInteractEvent event) {
+		if (MagicSpells.areBowCycleButtonsReversed() && event.hasItem() && isBow(event.getItem().getType())) {
+			return event.getAction() == Action.LEFT_CLICK_AIR || event.getAction() == Action.LEFT_CLICK_BLOCK;
+		}
+		
+		return event.getAction() == Action.RIGHT_CLICK_AIR || event.getAction() == Action.RIGHT_CLICK_BLOCK;
+	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
@@ -1,0 +1,126 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.ArrayList;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.inventory.ItemStack;
+
+import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.PassiveSpell;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+
+public class HitArrowListener extends PassiveListener {
+	
+	private Set<Material> materials = new HashSet<>();
+	private Map<MagicItemData, List<PassiveSpell>> types = new HashMap<>();
+	private List<PassiveSpell> allTypes = new ArrayList<>();
+    
+    @Override
+    public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
+		if (var == null || var.isEmpty()) {
+			allTypes.add(spell);
+			return;
+		}
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+			MagicItem magicItem = MagicItems.getMagicItemFromString(s);
+			MagicItemData itemData = null;
+			if (magicItem != null) itemData = magicItem.getMagicItemData();
+			if (itemData == null) continue;
+
+			List<PassiveSpell> list = types.computeIfAbsent(itemData, material -> new ArrayList<>());
+			list.add(spell);
+			materials.add(itemData.getType());
+		}
+    }
+    
+    @OverridePriority
+    @EventHandler
+    public void onDamage(EntityDamageByEntityEvent event) {
+        Player player = getPlayerAttacker(event);
+        if (player == null || !(event.getEntity() instanceof LivingEntity)) {
+            return;
+        }
+        LivingEntity attacked = (LivingEntity) event.getEntity();
+        Spellbook spellbook = null;
+        
+        if (!allTypes.isEmpty()) {
+            spellbook = MagicSpells.getSpellbook(player);
+            for (PassiveSpell spell : allTypes) {
+                if (!isCancelStateOk(spell, event.isCancelled())) {
+                    continue;
+                }
+                if (!spellbook.hasSpell(spell, false)) {
+                    continue;
+                }
+                boolean casted = spell.activate(player, attacked);
+                if (!PassiveListener.cancelDefaultAction(spell, casted)) {
+                    continue;
+                }
+                event.setCancelled(true);
+            }
+        }
+        
+        if (!types.isEmpty()) {
+            ItemStack item = player.getEquipment().getItemInMainHand();
+            if (item != null && item.getType() != Material.AIR) {
+                List<PassiveSpell> list = getSpells(item);
+                if (list != null) {
+                    if (spellbook == null) {
+                        spellbook = MagicSpells.getSpellbook(player);
+                    }
+                    for (PassiveSpell spell : list) {
+                        if (!isCancelStateOk(spell, event.isCancelled())) {
+                            continue;
+                        }
+                        if (!spellbook.hasSpell(spell, false)) {
+                            continue;
+                        }
+                        boolean casted = spell.activate(player, attacked);
+                        if (!PassiveListener.cancelDefaultAction(spell, casted)) {
+                            continue;
+                        }
+                        event.setCancelled(true);
+                    }
+                }
+            }
+        }
+    }
+    
+    private Player getPlayerAttacker(EntityDamageByEntityEvent event) {
+        Entity e = event.getDamager();
+        if (e instanceof Arrow) {
+            if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof Player) {
+                return (Player) ((Arrow) e).getShooter();
+            }
+        }
+        return null;
+    }
+    
+	private List<PassiveSpell> getSpells(ItemStack item) {
+		if (!materials.contains(item.getType())) return null;
+		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+		if (itemData == null) return null;
+
+		for (Map.Entry<MagicItemData, List<PassiveSpell>> entry : types.entrySet()) {
+			if (entry.getKey().equals(itemData)) return entry.getValue();
+		}
+		return null;
+	}
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
@@ -25,13 +25,13 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
 public class HitArrowListener extends PassiveListener {
-	
+
 	private Set<Material> materials = new HashSet<>();
 	private Map<MagicItemData, List<PassiveSpell>> types = new HashMap<>();
 	private List<PassiveSpell> allTypes = new ArrayList<>();
-    
-    @Override
-    public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
+
+	@Override
+	public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
 		if (var == null || var.isEmpty()) {
 			allTypes.add(spell);
 			return;
@@ -48,71 +48,61 @@ public class HitArrowListener extends PassiveListener {
 			list.add(spell);
 			materials.add(itemData.getType());
 		}
-    }
-    
-    @OverridePriority
-    @EventHandler
-    public void onDamage(EntityDamageByEntityEvent event) {
-        Player player = getPlayerAttacker(event);
-        if (player == null || !(event.getEntity() instanceof LivingEntity)) {
-            return;
-        }
-        LivingEntity attacked = (LivingEntity) event.getEntity();
-        Spellbook spellbook = null;
-        
-        if (!allTypes.isEmpty()) {
-            spellbook = MagicSpells.getSpellbook(player);
-            for (PassiveSpell spell : allTypes) {
-                if (!isCancelStateOk(spell, event.isCancelled())) {
-                    continue;
-                }
-                if (!spellbook.hasSpell(spell, false)) {
-                    continue;
-                }
-                boolean casted = spell.activate(player, attacked);
-                if (!PassiveListener.cancelDefaultAction(spell, casted)) {
-                    continue;
-                }
-                event.setCancelled(true);
-            }
-        }
-        
-        if (!types.isEmpty()) {
-            ItemStack item = player.getEquipment().getItemInMainHand();
-            if (item != null && item.getType() != Material.AIR) {
-                List<PassiveSpell> list = getSpells(item);
-                if (list != null) {
-                    if (spellbook == null) {
-                        spellbook = MagicSpells.getSpellbook(player);
-                    }
-                    for (PassiveSpell spell : list) {
-                        if (!isCancelStateOk(spell, event.isCancelled())) {
-                            continue;
-                        }
-                        if (!spellbook.hasSpell(spell, false)) {
-                            continue;
-                        }
-                        boolean casted = spell.activate(player, attacked);
-                        if (!PassiveListener.cancelDefaultAction(spell, casted)) {
-                            continue;
-                        }
-                        event.setCancelled(true);
-                    }
-                }
-            }
-        }
-    }
-    
-    private Player getPlayerAttacker(EntityDamageByEntityEvent event) {
-        Entity e = event.getDamager();
-        if (e instanceof Arrow) {
-            if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof Player) {
-                return (Player) ((Arrow) e).getShooter();
-            }
-        }
-        return null;
-    }
-    
+	}
+	
+	@OverridePriority
+	@EventHandler
+	public void onDamage(EntityDamageByEntityEvent event) {
+		Player player = getPlayerAttacker(event);
+		if (player == null || !(event.getEntity() instanceof LivingEntity)) {
+			return;
+		}
+		LivingEntity attacked = (LivingEntity) event.getEntity();
+		Spellbook spellbook = null;
+		
+		if (!allTypes.isEmpty()) {
+			spellbook = MagicSpells.getSpellbook(player);
+			for (PassiveSpell spell : allTypes) {
+				if (!isCancelStateOk(spell, event.isCancelled())) continue;
+				if (!spellbook.hasSpell(spell, false)) continue;
+				boolean casted = spell.activate(player, attacked);
+				if (PassiveListener.cancelDefaultAction(spell, casted)) event.setCancelled(true);
+			}
+		}
+		
+		if (types.isEmpty()) return;
+		
+		ItemStack item = player.getEquipment().getItemInMainHand();
+		
+		if (item == null) return;
+		if (item.getType() == Material.AIR) return;
+		
+		List<PassiveSpell> list = getSpells(item);
+		
+		if (list == null) return;
+
+		if (spellbook == null) {
+			spellbook = MagicSpells.getSpellbook(player);
+		}
+		
+		for (PassiveSpell spell : list) {
+			if (!isCancelStateOk(spell, event.isCancelled())) continue;
+			if (!spellbook.hasSpell(spell, false)) continue;
+			boolean casted = spell.activate(player, attacked);
+			if (PassiveListener.cancelDefaultAction(spell, casted)) event.setCancelled(true);
+		}
+	}
+	
+	private Player getPlayerAttacker(EntityDamageByEntityEvent event) {
+		Entity e = event.getDamager();
+		if (e instanceof Arrow) {
+			if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof Player) {
+				return (Player) ((Arrow) e).getShooter();
+			}
+		}
+		return null;
+	}
+	
 	private List<PassiveSpell> getSpells(ItemStack item) {
 		if (!materials.contains(item.getType())) return null;
 		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
@@ -1,0 +1,182 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Set;
+import java.util.Map;
+import java.util.List;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.ArrayList;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Arrow;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
+import org.bukkit.event.entity.ProjectileLaunchEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.metadata.FixedMetadataValue;
+
+import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.PassiveSpell;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+
+public class MissArrowListener extends PassiveListener {
+	
+	private Set<Material> materials = new HashSet<>();
+	private Map<MagicItemData, List<PassiveSpell>> types = new HashMap<>();
+	private List<PassiveSpell> allTypes = new ArrayList<>();
+    
+    @Override
+    public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
+		if (var == null || var.isEmpty()) {
+			allTypes.add(spell);
+			return;
+		}
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+			MagicItem magicItem = MagicItems.getMagicItemFromString(s);
+			MagicItemData itemData = null;
+			if (magicItem != null) itemData = magicItem.getMagicItemData();
+			if (itemData == null) continue;
+
+			List<PassiveSpell> list = types.computeIfAbsent(itemData, material -> new ArrayList<>());
+			list.add(spell);
+			materials.add(itemData.getType());
+		}
+    }
+    
+    private Player getPlayerAttacker(EntityDamageByEntityEvent event) {
+        Entity e = event.getDamager();
+        if (e instanceof Arrow) {
+            if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof Player) {
+                return (Player) ((Arrow) e).getShooter();
+            }
+        }
+        return null;
+    }
+    
+    @OverridePriority
+    @EventHandler
+    public void onHitEntity(EntityDamageByEntityEvent event) {
+        Player p = getPlayerAttacker(event);
+        if (p != null) {
+            if (event.getDamager() instanceof Arrow && event.getDamager().hasMetadata("mal-" + p.getUniqueId() + '-' + p.getName())
+                    && !event.getEntity().getMetadata("mal-" + p.getUniqueId() + '-' + p.getName()).isEmpty()) {
+                ((ArrowParticle) event.getDamager().getMetadata("mal-" + p.getUniqueId() + '-' + p.getName()).get(0).value()).setHitEntity(true);
+            }
+        }
+    }
+    
+    @OverridePriority
+    @EventHandler
+    public void onDamage(ProjectileHitEvent event) {
+        Player player = getPlayerAttacker(event);
+        if (player == null) {
+            return;
+        }
+        if (event.getEntity() instanceof Arrow && event.getEntity().hasMetadata("mal-" + player.getUniqueId() + '-' + player.getName())
+                && !event.getEntity().getMetadata("mal-" + player.getUniqueId() + '-' + player.getName()).isEmpty()) {
+            ArrowParticle arrowParticle = (ArrowParticle) event.getEntity().getMetadata("mal-" + player.getUniqueId() + '-' + player.getName()).get(0).value();
+
+            if (!arrowParticle.isHitEntity()) {
+                Spellbook spellbook = null;
+                if (!allTypes.isEmpty()) {
+                    spellbook = MagicSpells.getSpellbook(player);
+                    for (PassiveSpell spell : allTypes) {
+                        if (!spellbook.hasSpell(spell, false)) {
+                            continue;
+                        }
+                        boolean casted = spell.activate(player, event.getEntity().getLocation());
+                        if (!PassiveListener.cancelDefaultAction(spell, casted)) {
+                            continue;
+                        }
+                    }
+                }
+
+                if (!types.isEmpty()) {
+                    ItemStack item = player.getEquipment().getItemInMainHand();
+                    if (item != null && item.getType() != Material.AIR) {
+                        List<PassiveSpell> list = getSpells(item);
+                        if (list != null) {
+                            if (spellbook == null) {
+                                spellbook = MagicSpells.getSpellbook(player);
+                            }
+                            for (PassiveSpell spell : list) {
+
+                                if (!spellbook.hasSpell(spell, false)) {
+                                    continue;
+                                }
+                                boolean casted = spell.activate(player, event.getEntity().getLocation());
+                                if (!PassiveListener.cancelDefaultAction(spell, casted)) {
+                                    continue;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    
+    private Player getPlayerAttacker(ProjectileHitEvent event) {
+        Projectile e = event.getEntity();
+        if (e instanceof Arrow) {
+            if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof Player) {
+                return (Player) ((Arrow) e).getShooter();
+            }
+        }
+        return null;
+    }
+    
+	private List<PassiveSpell> getSpells(ItemStack item) {
+		if (!materials.contains(item.getType())) return null;
+		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+		if (itemData == null) return null;
+
+		for (Map.Entry<MagicItemData, List<PassiveSpell>> entry : types.entrySet()) {
+			if (entry.getKey().equals(itemData)) return entry.getValue();
+		}
+		return null;
+	}
+    
+    @EventHandler
+    public void shoot(ProjectileLaunchEvent event) {
+        if (event.getEntity() != null && event.getEntity().getShooter() != null
+                && event.getEntity().getShooter() instanceof Player && event.getEntity() instanceof Arrow) {
+            Player p = (Player) event.getEntity().getShooter();
+            ArrowParticle arrowParticle = new ArrowParticle((Arrow) event.getEntity(), p);
+            event.getEntity().setMetadata("mal-" + p.getUniqueId() + '-' + p.getName(), new FixedMetadataValue(MagicSpells.getInstance(), arrowParticle));
+        }
+    }
+    
+    class ArrowParticle {
+        private Player origCaster;
+        Arrow arrow;
+        private boolean hitEntity;
+        
+        ArrowParticle(Arrow arrow, Player origCaster) {
+            this.arrow = arrow;
+            this.origCaster = origCaster;
+        }
+        
+        public Player getOrigCaster() {
+            return origCaster;
+        }
+        
+        public boolean isHitEntity() {
+            return hitEntity;
+        }
+        
+        public void setHitEntity(boolean hitEntity) {
+            this.hitEntity = hitEntity;
+        }
+    }
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
@@ -71,6 +71,8 @@ public class PassiveTrigger {
 	public static Set<PassiveTrigger> INVENTORY_CLICK = addTriggers("inventoryclick", InventoryClickListener.class);
 	public static Set<PassiveTrigger> SPELL_SELECT = addTriggers("spellselect", SpellSelectListener.class);
 	public static Set<PassiveTrigger> POTION_EFFECT = addTriggers("potioneffect", PotionEffectListener.class);
+	public static Set<PassiveTrigger> HIT_ARROW = addTriggers("hitarrow", HitArrowListener.class);
+	public static Set<PassiveTrigger> MISS_ARROW = addTriggers("missarrow", MissArrowListener.class);
 	
 	// can't do priorities here
 	public static PassiveTrigger RESOURCE_PACK = addTrigger("resourcepack", ResourcePackListener.class);


### PR DESCRIPTION
The main improvement here is a configuration option to switch spell cycle mouse buttons when the player is holding a bow or a crossbow ("reverse-bow-cycle-buttons"), but also adds another configuration option to disable the spell cycle when the player is sneaking while holding a bow ("bow-cycle-spells-sneaking").

In addition there are HitArrowListener and MissArrowListener passive spell trigger implementations.