### PR TITLE
Custom Recipes and bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -69,9 +68,20 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		for (String optionName : optionKeys) {
 			String path = "options." + optionName + ".";
 
-			int slot = getConfigInt(path + "slot", -1);
-			if (slot < 0) {
-				MagicSpells.error("MenuSpell '" + internalName + "' has an invalid slot defined for: " + optionName);
+			List<Integer> slots = getConfigIntList(path + "slots", new ArrayList<>());
+			if (slots.isEmpty()) slots.add(getConfigInt(path + "slot", -1));
+
+			List<Integer> validSlots = new ArrayList<>();
+			for (int slot : slots) {
+				if (slot < 0 || slot > 53) {
+					MagicSpells.error("MenuSpell '" + internalName + "' a slot defined which is out of bounds for '" + optionName + "': " + slot);
+					continue;
+				}
+				validSlots.add(slot);
+				if (slot > maxSlot) maxSlot = slot;
+			}
+			if (validSlots.isEmpty()) {
+				MagicSpells.error("MenuSpell '" + internalName + "' has no slots defined for: " + optionName);
 				continue;
 			}
 
@@ -108,7 +118,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 			MenuOption option = new MenuOption();
 			option.menuOptionName = optionName;
-			option.slot = slot;
+			option.slots = validSlots;
 			option.item = item;
 			option.items = items;
 			option.spellName = getConfigString(path + "spell", "");
@@ -120,7 +130,6 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			option.modifierList = getConfigStringList(path + "modifiers", null);
 			option.stayOpen = getConfigBoolean(path + "stay-open", false);
 			options.put(optionName, option);
-			if (slot > maxSlot) maxSlot = slot;
 		}
 		size = (int) Math.ceil((maxSlot+1) / 9.0) * 9;
 		if (options.isEmpty()) MagicSpells.error("MenuSpell '" + spellName + "' has no menu options!");
@@ -226,10 +235,6 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		return item;
 	}
 
-	private String getTitle(Player player) {
-		return Util.doVarReplacementAndColorize(player, title);
-	}
-
 	private void open(final Player caster, Player opener, LivingEntity entityTarget, Location locTarget, final float power, final String[] args) {
 		if (delay < 0) {
 			openMenu(caster, opener, entityTarget, locTarget, power, args);
@@ -246,9 +251,10 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		if (requireEntityTarget && entityTarget != null) castEntityTarget.put(opener.getUniqueId(), entityTarget);
 		if (requireLocationTarget && locTarget != null) castLocTarget.put(opener.getUniqueId(), locTarget);
 
-		Inventory inv = Bukkit.createInventory(opener, size, getTitle(opener));
+		Inventory inv = Bukkit.createInventory(opener, size, internalName);
 		applyOptionsToInventory(opener, inv, args);
 		opener.openInventory(inv);
+		Util.setInventoryTitle(opener, title);
 
 		if (entityTarget != null && caster != null) {
 			playSpellEffects(caster, entityTarget);
@@ -262,15 +268,19 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	private void applyOptionsToInventory(Player opener, Inventory inv, String[] args) {
 		// Setup option items.
 		for (MenuOption option : options.values()) {
-			if (inv.getItem(option.slot) != null) continue;
+			// Check modifiers.
 			if (option.menuOptionModifiers != null) {
 				MagicSpellsGenericPlayerEvent event = new MagicSpellsGenericPlayerEvent(opener);
 				option.menuOptionModifiers.apply(event);
 				if (event.isCancelled()) continue;
 			}
+			// Select and finalise item to display.
 			ItemStack item = (option.item != null ? option.item : option.items.get(Util.getRandomInt(option.items.size()))).clone();
-			item = MagicSpells.getVolatileCodeHandler().setNBTString(item, "menuOption", option.menuOptionName);
-			inv.setItem(option.slot, translateItem(opener, args, item));
+			item = translateItem(opener, args, item);
+			// Set item for all defined slots.
+			for (int slot : option.slots) {
+				if (inv.getItem(slot) == null) inv.setItem(slot, item);
+			}
 		}
 		// Fill inventory.
 		if (filler == null) return;
@@ -300,9 +310,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	@EventHandler
 	public void onInvClick(InventoryClickEvent event) {
 		Player player = (Player) event.getWhoClicked();
-		String realTitle = ChatColor.stripColor(getTitle(player));
-		String currentTitle = ChatColor.stripColor(event.getView().getTitle());
-		if (!realTitle.equals(currentTitle)) return;
+		if (!event.getView().getTitle().equals(internalName)) return;
 		event.setCancelled(true);
 
 		String closeState = castSpells(player, event.getCurrentItem(), event.getClick());
@@ -318,9 +326,10 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			return;
 		}
 		// Reopen.
-		Inventory newInv = Bukkit.createInventory(player, event.getView().getTopInventory().getSize(), getTitle(player));
+		Inventory newInv = Bukkit.createInventory(player, event.getView().getTopInventory().getSize(), internalName);
 		applyOptionsToInventory(player, newInv, MagicSpells.NULL_ARGS);
 		player.openInventory(newInv);
+		Util.setInventoryTitle(player, title);
 	}
 
 	private String castSpells(Player player, ItemStack item, ClickType click) {
@@ -363,7 +372,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	private static class MenuOption {
 
 		private String menuOptionName;
-		private int slot;
+		private List<Integer> slots;
 		private ItemStack item;
 		private List<ItemStack> items;
 		private String spellName;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -118,8 +118,10 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 
 	@Override
 	public void turnOff() {
-		for (Block b : blocks.keySet()) {
-			b.setType(blocks.get(b));
+		if (replaceDuration > 0) {
+			for (Block b : blocks.keySet()) {
+				b.setType(blocks.get(b));
+			}
 		}
 
 		blocks.clear();

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -1,7 +1,10 @@
 package com.nisovin.magicspells.volatilecode;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.*;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.util.Vector;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
@@ -126,6 +129,29 @@ public class VolatileCodeDisabled implements VolatileCodeHandle {
 
 	@Override
 	public String getNBTString(ItemStack item, String key) {
+		// Need volatile code for this
+		return null;
+	}
+
+	@Override
+	public void setInventoryTitle(Player player, String title) {
+		// Need volatile code for this
+	}
+
+	@Override
+	public Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime) {
+		// Need volatile code for this
+		return null;
+	}
+
+	@Override
+	public Recipe createStonecutterRecipe(NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient) {
+		// Need volatile code for this
+		return null;
+	}
+
+	@Override
+	public Recipe createSmithingRecipe(NamespacedKey namespaceKey, ItemStack result, Material base, Material addition) {
 		// Need volatile code for this
 		return null;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -1,7 +1,10 @@
 package com.nisovin.magicspells.volatilecode;
 
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.*;
 import org.bukkit.Location;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.util.Vector;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.ItemStack;
@@ -53,4 +56,13 @@ public interface VolatileCodeHandle {
 	ItemStack setNBTString(ItemStack item, String key, String value);
 
 	String getNBTString(ItemStack item, String key);
+
+	void setInventoryTitle(Player player, String title);
+
+	Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime);
+
+	Recipe createStonecutterRecipe(NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient);
+
+	Recipe createSmithingRecipe(NamespacedKey namespaceKey, ItemStack result, Material base, Material addition);
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
@@ -1,20 +1,22 @@
 package com.nisovin.magicspells.volatilecode
 
-import com.destroystokyo.paper.profile.PlayerProfile
-import com.destroystokyo.paper.profile.ProfileProperty
-import com.nisovin.magicspells.MagicSpells
-import org.bukkit.Bukkit
-import org.bukkit.Location
-import org.bukkit.OfflinePlayer
+import java.util.*
+import java.io.File
+import java.io.FileWriter
+import java.util.stream.Collectors
+
+import org.bukkit.*
 import org.bukkit.entity.*
+import org.bukkit.util.Vector
+import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
-import org.bukkit.util.Vector
-import java.io.File
-import java.io.FileWriter
-import java.util.*
-import java.util.stream.Collectors
+
+import com.nisovin.magicspells.MagicSpells
+
+import com.destroystokyo.paper.profile.PlayerProfile
+import com.destroystokyo.paper.profile.ProfileProperty
 
 class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHandle {
 
@@ -150,5 +152,21 @@ class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHan
 
     override fun setAbsorptionHearts(entity: LivingEntity, double: Double) {
         parent.setAbsorptionHearts(entity, double)
+    }
+
+    override fun setInventoryTitle(player: Player?, title: String?) {
+        parent.setInventoryTitle(player, title)
+    }
+
+    override fun createCookingRecipe(type: String?, namespaceKey: NamespacedKey?, group: String?, result: ItemStack?, ingredient: Material?, experience: Float, cookingTime: Int): Recipe {
+        return parent.createCookingRecipe(type, namespaceKey, group, result, ingredient, experience, cookingTime)
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey?, group: String?, result: ItemStack?, ingredient: Material?): Recipe {
+        return parent.createStonecutterRecipe(namespaceKey, group, result, ingredient)
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey?, result: ItemStack?, base: Material?, addition: Material?): Recipe {
+        return parent.createSmithingRecipe(namespaceKey, result, base, addition)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
@@ -8,9 +8,12 @@ import java.lang.reflect.Field
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.entity.*
+import org.bukkit.Material
 import org.bukkit.util.Vector
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -295,4 +298,25 @@ class VolatileCode1_13_R2: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
     }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, "minecraft:chest", ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
+    }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe? {
+        return null
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe? {
+        return null
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
@@ -8,10 +8,13 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
+import org.bukkit.inventory.*
 import org.bukkit.util.Vector
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -299,4 +302,34 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
     }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
+    }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
@@ -8,10 +8,13 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
 import org.bukkit.util.Vector
+import org.bukkit.inventory.*
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -299,4 +302,34 @@ class VolatileCode1_15_R1: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
     }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
+    }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
@@ -8,14 +8,18 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
+import org.bukkit.inventory.*
 import org.bukkit.util.Vector
+import org.bukkit.NamespacedKey
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
 import org.bukkit.craftbukkit.v1_16_R1.entity.*
+import org.bukkit.persistence.PersistentDataType
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld
 import org.bukkit.event.entity.ExplosionPrimeEvent
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer
@@ -30,8 +34,6 @@ import com.mojang.authlib.GameProfile
 import com.mojang.authlib.properties.Property
 
 import net.minecraft.server.v1_16_R1.*
-import org.bukkit.NamespacedKey
-import org.bukkit.persistence.PersistentDataType
 
 private typealias nmsItemStack = net.minecraft.server.v1_16_R1.ItemStack
 
@@ -284,4 +286,34 @@ class VolatileCode1_16_R1: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String? {
         return item.itemMeta?.persistentDataContainer?.get(NamespacedKey(MagicSpells.plugin, key), PersistentDataType.STRING)
     }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
+    }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe {
+        return SmithingRecipe(namespaceKey, result, RecipeChoice.MaterialChoice(base), RecipeChoice.MaterialChoice(addition))
+    }
+
 }


### PR DESCRIPTION
The Menu spell `slots` property was added to set the defined item to all listed slots. It'll be prioritised over the `slot` property.

The Menu spell also had a long-term bug which was recently further exposed by accident. To set the scene, if two or multiple menu spells exist with the same title, all instances of their InventoryClick events would activate. If the item clicked has the same `options` key, it would trigger on all instances. The issue here was indentifying which menu's spell the item belongs to. Now I'm not particularly sure if this solution is good or not - in the real title I'm storing the internal spell name to help indentify the option item origin. I'm sending packets to update the menu title to the client.