### PR TITLE
Add volatile code handler for Paper

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -5,12 +5,14 @@ plugins {
 repositories {
     maven { url "https://repo.dmulloy2.net/nexus/repository/public/" }
     maven { url "https://repo.md-5.net/content/repositories/releases/" }
+    maven { url 'https://papermc.io/repo/repository/maven-public/' }
 }
 
 dependencies {
     shadow group: "org.apache.commons", name: "commons-math3", version: "3.0"
     shadow "com.github.Chronoken:EffectLib:4972666012"
     shadow "com.github.PaperMC:PaperLib:578a177643"
+    compile 'com.destroystokyo.paper:paper-api:1.16.1-R0.1-SNAPSHOT'
     compile ":spigot-1.16.1"
     implementation ":spigot-1.15"
     implementation ":spigot-1.14.4"

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/ManagerVolatile.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/ManagerVolatile.kt
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.volatilecode
 import org.bukkit.Bukkit
 
 import com.nisovin.magicspells.MagicSpells
+import io.papermc.lib.PaperLib
 
 object ManagerVolatile {
 
@@ -12,7 +13,12 @@ object ManagerVolatile {
             val volatileCode = Class.forName("com.nisovin.magicspells.volatilecode.$nmsPackage.VolatileCode${nmsPackage.replace("v", "")}")
 
             MagicSpells.log("Found volatile code handler for $nmsPackage.")
-            return volatileCode.newInstance() as VolatileCodeHandle
+            var volatileCodeHandle = volatileCode.newInstance() as VolatileCodeHandle;
+            if (PaperLib.isPaper()) {
+                MagicSpells.log("Detected Paper, hooking in for extra compatibility.")
+                volatileCodeHandle = VolatileCodePaper(volatileCodeHandle)
+            }
+            return volatileCodeHandle
         } catch (ex: Exception) {
             // No volatile code handler found
         }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
@@ -1,0 +1,154 @@
+package com.nisovin.magicspells.volatilecode
+
+import com.destroystokyo.paper.profile.PlayerProfile
+import com.destroystokyo.paper.profile.ProfileProperty
+import com.nisovin.magicspells.MagicSpells
+import org.bukkit.Bukkit
+import org.bukkit.Location
+import org.bukkit.OfflinePlayer
+import org.bukkit.entity.*
+import org.bukkit.inventory.ItemStack
+import org.bukkit.inventory.meta.ItemMeta
+import org.bukkit.inventory.meta.SkullMeta
+import org.bukkit.util.Vector
+import java.io.File
+import java.io.FileWriter
+import java.util.*
+import java.util.stream.Collectors
+
+class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHandle {
+
+    override fun creaturePathToLoc(creature: Creature, loc: Location, speed: Float) {
+        creature.pathfinder.moveTo(loc, speed.toDouble())
+    }
+
+    override fun getNBTString(item: ItemStack?, key: String?): String {
+        return parent.getNBTString(item, key)
+    }
+
+    override fun simulateTnt(target: Location, source: LivingEntity, explosionSize: Float, fire: Boolean): Boolean {
+        return parent.simulateTnt(target, source, explosionSize, fire)
+    }
+
+    override fun getCustomModelData(meta: ItemMeta?): Int {
+        return parent.getCustomModelData(meta)
+    }
+
+    override fun createExplosionByEntity(entity: Entity, location: Location, size: Float, fire: Boolean, breakBlocks: Boolean): Boolean {
+        return parent.createExplosionByEntity(entity, location, size, fire, breakBlocks)
+    }
+
+    override fun setTarget(entity: LivingEntity?, target: LivingEntity?) {
+        parent.setTarget(entity, target)
+    }
+
+    override fun addPotionGraphicalEffect(entity: LivingEntity, color: Int, duration: Int) {
+        parent.addPotionGraphicalEffect(entity, color, duration)
+    }
+
+    override fun getAbsorptionHearts(entity: LivingEntity): Double {
+        return parent.getAbsorptionHearts(entity)
+    }
+
+    override fun setTexture(meta: SkullMeta, texture: String, signature: String?) {
+        val profile = meta.playerProfile!!
+        setTexture(profile, texture, signature)
+        meta.playerProfile = profile
+    }
+
+    override fun setTexture(meta: SkullMeta, texture: String, signature: String, uuid: String?, offlinePlayer: OfflinePlayer) {
+        try {
+            val profile = Bukkit.createProfile(if (uuid != null) UUID.fromString(uuid) else null, offlinePlayer.name)
+            setTexture(profile, texture, signature)
+            meta.playerProfile = profile
+        } catch (e: SecurityException) {
+            MagicSpells.handleException(e)
+        } catch (e: IllegalArgumentException) {
+            MagicSpells.handleException(e)
+        } catch (e: IllegalAccessException) {
+            MagicSpells.handleException(e)
+        }
+    }
+
+    private fun setTexture(profile: PlayerProfile, texture: String, signature: String?): PlayerProfile {
+        if (signature == null || signature.isEmpty()) {
+            profile.setProperty(ProfileProperty("textures",  texture))
+        } else {
+            profile.setProperty(ProfileProperty("textures",  texture, signature))
+        }
+        return profile
+    }
+
+    override fun addAILookAtPlayer(entity: LivingEntity, range: Int) {
+        parent.addAILookAtPlayer(entity, range)
+    }
+
+    override fun setExperienceBar(player: Player, level: Int, percent: Float) {
+        parent.setExperienceBar(player, level, percent)
+    }
+
+    override fun saveSkinData(player: Player, name: String) {
+        val profile = player.playerProfile
+        println(profile.properties.toString())
+        val props = profile.properties.stream().filter { prop: ProfileProperty -> prop.name == "textures" }.collect(Collectors.toList())
+        for (prop in props) {
+            val skin = prop.value
+            val sig = prop.signature
+
+            val folder = File(MagicSpells.getInstance().dataFolder, "disguiseskins")
+            if (!folder.exists()) folder.mkdir()
+            val skinFile = File(folder, "$name.skin.txt")
+            val sigFile = File(folder, "$name.sig.txt")
+            try {
+                var writer = FileWriter(skinFile)
+                writer.write(skin)
+                writer.flush()
+                writer.close()
+                writer = FileWriter(sigFile)
+                writer.write(sig)
+                writer.flush()
+                writer.close()
+            } catch (e: Exception) {
+                e.printStackTrace()
+            }
+
+            break
+        }
+    }
+
+    override fun setClientVelocity(player: Player, velocity: Vector) {
+        parent.setClientVelocity(player, velocity)
+    }
+
+    override fun playDragonDeathEffect(location: Location) {
+        parent.playDragonDeathEffect(location)
+    }
+
+    override fun setCustomModelData(meta: ItemMeta?, data: Int) {
+        parent.setCustomModelData(meta, data)
+    }
+
+    override fun setSkin(player: Player, skin: String, signature: String) {
+        setTexture(player.playerProfile, skin, signature)
+    }
+
+    override fun sendFakeSlotUpdate(player: Player, slot: Int, item: ItemStack) {
+        parent.sendFakeSlotUpdate(player, slot, item)
+    }
+
+    override fun setKiller(entity: LivingEntity, killer: Player) {
+        entity.killer = killer
+    }
+
+    override fun setNBTString(item: ItemStack, key: String, value: String): ItemStack {
+        return parent.setNBTString(item, key, value)
+    }
+
+    override fun setFallingBlockHurtEntities(block: FallingBlock, damage: Float, max: Int) {
+        parent.setFallingBlockHurtEntities(block, damage, max)
+    }
+
+    override fun setAbsorptionHearts(entity: LivingEntity, double: Double) {
+        parent.setAbsorptionHearts(entity, double)
+    }
+}


### PR DESCRIPTION
Adds a volatile code handler for Paper to rely on API methods that Paper has to offer that Spigot does not have. Should allow for some volatile code methods to work across server updates for users using Paper. This is _only_ used if Paper is detected as the server software being ran, and falls-back to the current volatile code handler for anything not handled by Paper.