### PR TITLE
Custom Recipes and bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -36,21 +36,16 @@ import org.bukkit.permissions.Permission;
 import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.configuration.ConfigurationSection;
 
-import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.handlers.*;
 import com.nisovin.magicspells.listeners.*;
-import com.nisovin.magicspells.util.Metrics;
-import com.nisovin.magicspells.util.TxtUtil;
-import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.mana.ManaSystem;
 import com.nisovin.magicspells.mana.ManaHandler;
-import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.commands.XpCommand;
 import com.nisovin.magicspells.spells.PassiveSpell;
 import com.nisovin.magicspells.commands.ManaCommand;
 import com.nisovin.magicspells.commands.CastCommand;
 import com.nisovin.magicspells.util.compat.EventUtil;
-import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.prompt.PromptType;
 import com.nisovin.magicspells.events.SpellLearnEvent;
 import com.nisovin.magicspells.util.compat.CompatBasics;
@@ -1293,6 +1288,10 @@ public class MagicSpells extends JavaPlugin {
 		// Turn off spells
 		for (Spell spell : spells.values()) {
 			spell.turnOff();
+		}
+		// Clear spell animations.
+		for (SpellAnimation animation : SpellAnimation.getAnimations()) {
+			animation.stop();
 		}
 		PassiveSpell.resetManager();
 

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -37,6 +37,7 @@ import org.bukkit.permissions.PermissionDefault;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.handlers.*;
 import com.nisovin.magicspells.listeners.*;
 import com.nisovin.magicspells.util.Metrics;
 import com.nisovin.magicspells.util.TxtUtil;
@@ -48,13 +49,10 @@ import com.nisovin.magicspells.commands.XpCommand;
 import com.nisovin.magicspells.spells.PassiveSpell;
 import com.nisovin.magicspells.commands.ManaCommand;
 import com.nisovin.magicspells.commands.CastCommand;
-import com.nisovin.magicspells.handlers.MoneyHandler;
-import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.prompt.PromptType;
 import com.nisovin.magicspells.events.SpellLearnEvent;
-import com.nisovin.magicspells.handlers.MagicXpHandler;
 import com.nisovin.magicspells.util.compat.CompatBasics;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
@@ -62,7 +60,6 @@ import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.variables.VariableManager;
 import com.nisovin.magicspells.util.managers.BuffManager;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
-import com.nisovin.magicspells.handlers.LifeLengthTracker;
 import com.nisovin.magicspells.util.managers.BossBarManager;
 import com.nisovin.magicspells.volatilecode.ManagerVolatile;
 import com.nisovin.magicspells.events.MagicSpellsLoadedEvent;
@@ -390,6 +387,19 @@ public class MagicSpells extends JavaPlugin {
 		}
 		variableManager = new VariableManager(this, varSec);
 		log("..." + variableManager.count() + " variables loaded");
+
+		// Load crafting recipes.
+		RecipeHandler.clearRecipes();
+		log("Loading recipes...");
+		if (config.contains(path + "recipes") && config.isSection(path + "recipes")) {
+			ConfigurationSection recipeSec = config.getSection(path + "recipes");
+			for (String recipeKey : recipeSec.getKeys(false)) {
+				ConfigurationSection recipe = recipeSec.getConfigurationSection(recipeKey);
+				if (recipe == null) continue;
+				RecipeHandler.create(recipe);
+			}
+		}
+		log("..." + RecipeHandler.getRecipes().size() + " recepies loaded");
 
 		// Load spells
 		log("Loading spells...");

--- a/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
@@ -1,0 +1,189 @@
+package com.nisovin.magicspells.handlers;
+
+import java.util.*;
+
+import org.bukkit.*;
+import org.bukkit.inventory.*;
+import org.bukkit.event.Listener;
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+
+public class RecipeHandler implements Listener {
+
+    private static final Map<String, Recipe> recipes = new HashMap<>();
+
+    public static void create(ConfigurationSection config) {
+        String type = config.getString("type", "shaped");
+        if (type == null) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'type' defined.");
+            return;
+        }
+        type = type.toLowerCase();
+
+        String itemString = config.getString("result");
+        if (itemString == null || itemString.isEmpty()) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'result' item defined.");
+            return;
+        }
+        MagicItem magicItem = MagicItems.getMagicItemFromString(itemString);
+        if (magicItem == null) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'result' item defined.");
+            return;
+        }
+        ItemStack result = magicItem.getItemStack();
+
+        int quantity = config.getInt("quantity", 1);
+        if (quantity > 1) result.setAmount(quantity);
+
+        String group = config.getString("group");
+        if (group == null) group = "";
+
+        String namespaceKeyString = config.getString("namespace-key");
+        if (namespaceKeyString == null || namespaceKeyString.isEmpty()) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'namespace-key' defined.");
+            return;
+        }
+        NamespacedKey namespaceKey;
+        try {
+            namespaceKey = new NamespacedKey(MagicSpells.plugin, namespaceKeyString.toLowerCase());
+        }
+        catch (IllegalArgumentException e) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'namespace-key' defined: " + namespaceKeyString);
+            MagicSpells.handleException(e);
+            return;
+        }
+
+        Recipe recipe = null;
+        switch (type) {
+            case "shaped":
+                recipe = createShapedRecipe(config, namespaceKey, result, group);
+                break;
+
+            case "shapeless":
+                recipe = createShapelessRecipe(config, namespaceKey, result, group);
+                break;
+
+            case "furnace":
+                recipe = createFurnaceRecipe(config, namespaceKey, result, group);
+                break;
+
+            default:
+                MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'type' defined.");
+                break;
+        }
+        if (recipe == null) return;
+
+        Bukkit.addRecipe(recipe);
+        recipes.put(config.getName(), recipe);
+    }
+
+    public static Map<String, Recipe> getRecipes() {
+        return recipes;
+    }
+
+    private static Recipe createShapedRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
+        ShapedRecipe recipe = new ShapedRecipe(namespaceKey, result);
+        recipe.setGroup(group);
+
+        List<String> shape = config.getStringList("shape");
+        if (shape.isEmpty()) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'shape' defined.");
+            return null;
+        }
+        try {
+            recipe.shape(shape.toArray(new String[0]));
+        }
+        catch (IllegalArgumentException e) {
+            MagicSpells.handleException(e);
+            return null;
+        }
+
+        // Validate ingredients.
+        ConfigurationSection shapedIngredients = config.getConfigurationSection("ingredients");
+        if (shapedIngredients == null) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has no 'ingredients' defined.");
+            return null;
+        }
+        for (String ingredientKey : shapedIngredients.getKeys(false)) {
+            if (ingredientKey.length() != 1) {
+                MagicSpells.error("Recipe '" + config.getName() + "' has an invalid ingredient key defined: " + ingredientKey);
+                return null;
+            }
+            Material ingredient = getMaterial(shapedIngredients.getString(ingredientKey), "Recipe '" + config.getName() + "' has an invalid 'ingredient' defined under key '" + ingredientKey + "'.");
+            if (ingredient == null) return null;
+            recipe.setIngredient(ingredientKey.charAt(0), ingredient);
+        }
+
+        return recipe;
+    }
+
+    private static Recipe createShapelessRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
+        ShapelessRecipe recipe = new ShapelessRecipe(namespaceKey, result);
+        recipe.setGroup(group);
+
+        // Validate ingredients.
+        List<String> shapelessIngredients = config.getStringList("ingredients");
+        if (shapelessIngredients.isEmpty()) {
+            MagicSpells.error("Recipe '" + config.getName() + "' has no 'ingredients' defined.");
+            return null;
+        }
+        for (String ingredientString : shapelessIngredients) {
+            Material ingredient = getMaterial(ingredientString, "Recipe '" + config.getName() + "' has an invalid ingredient defined: " + ingredientString);
+            if (ingredient == null) return null;
+            recipe.addIngredient(ingredient);
+        }
+
+        return recipe;
+    }
+
+    private static Recipe createFurnaceRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
+        Material ingredient = getMaterial(config.getString("ingredient"), "Recipe '" + config.getName() + "' has an invalid 'ingredient' defined.");
+        if (ingredient == null) return null;
+
+        float experience = (float) config.getDouble("experience", 0);
+        int cookingTime = config.getInt("cooking-time", 0);
+
+        FurnaceRecipe recipe = new FurnaceRecipe(namespaceKey, result, ingredient, experience, cookingTime);
+        recipe.setGroup(group);
+        return recipe;
+    }
+
+    public static void clearRecipes() {
+        List<Recipe> recipeBackup = new ArrayList<>();
+
+        // Collect recipes.
+        Iterator<Recipe> iterator = Bukkit.recipeIterator();
+        while (iterator.hasNext()) {
+            recipeBackup.add(iterator.next());
+        }
+
+        Bukkit.clearRecipes();
+
+        // Add back old recipes.
+        for (Recipe recipe : recipeBackup) {
+            // Filter out MS recipes.
+            if (recipe instanceof Keyed && ((Keyed) recipe).getKey().getNamespace().equals("magicspells")) continue;
+            Bukkit.addRecipe(recipe);
+        }
+    }
+
+    private static Material getMaterial(String materialName, String errorMsg) {
+        if (materialName == null || materialName.isEmpty()) {
+            MagicSpells.error(errorMsg);
+            return null;
+        }
+        Material material = null;
+        try {
+            material = Material.getMaterial(materialName.toUpperCase());
+        }
+        catch (IllegalArgumentException ignored) {}
+        if (material == null) {
+            MagicSpells.error(errorMsg);
+            return null;
+        }
+        return material;
+    }
+}

--- a/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
@@ -66,8 +66,15 @@ public class RecipeHandler implements Listener {
                 recipe = createShapelessRecipe(config, namespaceKey, result, group);
                 break;
 
+            case "smoking":
+            case "campfire":
+            case "blasting":
             case "furnace":
-                recipe = createFurnaceRecipe(config, namespaceKey, result, group);
+                recipe = createCookingRecipe(config, type, namespaceKey, result, group);
+                break;
+
+            case "stonecutting":
+                recipe = createStoneCuttingRecipe(config, namespaceKey, result, group);
                 break;
 
             default:
@@ -139,15 +146,29 @@ public class RecipeHandler implements Listener {
         return recipe;
     }
 
-    private static Recipe createFurnaceRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
+    private static Recipe createCookingRecipe(ConfigurationSection config, String type, NamespacedKey namespaceKey, ItemStack result, String group) {
         Material ingredient = getMaterial(config.getString("ingredient"), "Recipe '" + config.getName() + "' has an invalid 'ingredient' defined.");
         if (ingredient == null) return null;
 
         float experience = (float) config.getDouble("experience", 0);
         int cookingTime = config.getInt("cooking-time", 0);
 
-        FurnaceRecipe recipe = new FurnaceRecipe(namespaceKey, result, ingredient, experience, cookingTime);
-        recipe.setGroup(group);
+        if (type.equals("furnace")) {
+            FurnaceRecipe recipe = new FurnaceRecipe(namespaceKey, result, ingredient, experience, cookingTime);
+            recipe.setGroup(group);
+            return recipe;
+        }
+        // Check volatile types.
+        Recipe recipe = MagicSpells.getVolatileCodeHandler().createCookingRecipe(type, namespaceKey, group, result, ingredient, experience, cookingTime);
+        if (recipe == null) MagicSpells.error("Recipe type '" + type + "' on recipe '" + config.getName() + "' is unsupported on this version of spigot.");
+        return recipe;
+    }
+
+    private static Recipe createStoneCuttingRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
+        Material ingredient = getMaterial(config.getString("ingredient"), "Recipe '" + config.getName() + "' has an invalid 'ingredient' defined.");
+        if (ingredient == null) return null;
+        Recipe recipe = MagicSpells.getVolatileCodeHandler().createStonecutterRecipe(namespaceKey, group, result, ingredient);
+        if (recipe == null) MagicSpells.error("Recipe type 'stonecutting' on recipe '" + config.getName() + "' is unsupported on this version of spigot.");
         return recipe;
     }
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/BossBarEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/BossBarEffect.java
@@ -33,7 +33,7 @@ public class BossBarEffect extends SpellEffect {
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		namespaceKey = config.getString("namespace-key");
-		title = Util.colorize(config.getString("title", ""));
+		title = config.getString("title", "");
 		color = config.getString("color", "red");
 		style = config.getString("style", "solid");
 		strVar = config.getString("variable", "");
@@ -82,12 +82,13 @@ public class BossBarEffect extends SpellEffect {
 
 	private void createBar(Player player) {
 		Bar bar = MagicSpells.getBossBarManager().getBar(player, namespaceKey);
+		String newTitle = Util.doVarReplacementAndColorize(player, title);
 		if (variable == null) {
-			bar.set(title, progress, barStyle, barColor);
+			bar.set(newTitle, progress, barStyle, barColor);
 		}
 		else {
 			double diff = variable.getValue(player) / maxValue;
-			if (diff > 0 && diff < 1) bar.set(title, diff, barStyle, barColor);
+			if (diff > 0 && diff < 1) bar.set(newTitle, diff, barStyle, barColor);
 		}
 		if (duration > 0) MagicSpells.scheduleDelayedTask(bar::remove, duration);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/BossBarEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/BossBarEffect.java
@@ -13,7 +13,7 @@ import com.nisovin.magicspells.util.managers.BossBarManager.Bar;
 
 public class BossBarEffect extends SpellEffect {
 
-	private String namespace;
+	private String namespaceKey;
 	private String title;
 	private String color;
 	private String style;
@@ -32,7 +32,7 @@ public class BossBarEffect extends SpellEffect {
 
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
-		namespace = config.getString("namespace");
+		namespaceKey = config.getString("namespace-key");
 		title = Util.colorize(config.getString("title", ""));
 		color = config.getString("color", "red");
 		style = config.getString("style", "solid");
@@ -44,8 +44,8 @@ public class BossBarEffect extends SpellEffect {
 			MagicSpells.error("Wrong variable defined! '" + strVar + "'");
 		}
 
-		if (namespace != null && !MagicSpells.getBossBarManager().isNameSpace(namespace)) {
-			MagicSpells.error("Wrong namespace defined! '" + namespace + "'");
+		if (namespaceKey != null && !MagicSpells.getBossBarManager().isNameSpaceKey(namespaceKey)) {
+			MagicSpells.error("Wrong namespace-key defined! '" + namespaceKey + "'");
 		}
 
 		try {
@@ -81,14 +81,13 @@ public class BossBarEffect extends SpellEffect {
 	}
 
 	private void createBar(Player player) {
-		Bar bar = MagicSpells.getBossBarManager().getBar(player, namespace);
-		String ttl = MagicSpells.doVariableReplacements(player, title);
+		Bar bar = MagicSpells.getBossBarManager().getBar(player, namespaceKey);
 		if (variable == null) {
-			bar.set(ttl, progress, barStyle, barColor);
+			bar.set(title, progress, barStyle, barColor);
 		}
 		else {
 			double diff = variable.getValue(player) / maxValue;
-			if (diff > 0 && diff < 1) bar.set(ttl, diff, barStyle, barColor);
+			if (diff > 0 && diff < 1) bar.set(title, diff, barStyle, barColor);
 		}
 		if (duration > 0) MagicSpells.scheduleDelayedTask(bar::remove, duration);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/NovaEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/NovaEffect.java
@@ -192,7 +192,7 @@ public class NovaEffect extends SpellEffect {
 		}
 
 		@Override
-		protected void stop() {
+		public void stop() {
 			super.stop();
 
 			for (Block b : blocks) {
@@ -311,7 +311,7 @@ public class NovaEffect extends SpellEffect {
 		}
 
 		@Override
-		protected void stop() {
+		public void stop() {
 			super.stop();
 
 			for (Block b : blocks) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.ChatColor;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -236,10 +235,6 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		return item;
 	}
 
-	private String getTitle(Player player) {
-		return Util.doVarReplacementAndColorize(player, title);
-	}
-
 	private void open(final Player caster, Player opener, LivingEntity entityTarget, Location locTarget, final float power, final String[] args) {
 		if (delay < 0) {
 			openMenu(caster, opener, entityTarget, locTarget, power, args);
@@ -256,9 +251,10 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		if (requireEntityTarget && entityTarget != null) castEntityTarget.put(opener.getUniqueId(), entityTarget);
 		if (requireLocationTarget && locTarget != null) castLocTarget.put(opener.getUniqueId(), locTarget);
 
-		Inventory inv = Bukkit.createInventory(opener, size, getTitle(opener));
+		Inventory inv = Bukkit.createInventory(opener, size, internalName);
 		applyOptionsToInventory(opener, inv, args);
 		opener.openInventory(inv);
+		Util.setInventoryTitle(opener, title);
 
 		if (entityTarget != null && caster != null) {
 			playSpellEffects(caster, entityTarget);
@@ -315,9 +311,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	@EventHandler
 	public void onInvClick(InventoryClickEvent event) {
 		Player player = (Player) event.getWhoClicked();
-		String realTitle = ChatColor.stripColor(getTitle(player));
-		String currentTitle = ChatColor.stripColor(event.getView().getTitle());
-		if (!realTitle.equals(currentTitle)) return;
+		if (!event.getView().getTitle().equals(internalName)) return;
 		event.setCancelled(true);
 
 		String closeState = castSpells(player, event.getCurrentItem(), event.getClick());
@@ -333,9 +327,10 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			return;
 		}
 		// Reopen.
-		Inventory newInv = Bukkit.createInventory(player, event.getView().getTopInventory().getSize(), getTitle(player));
+		Inventory newInv = Bukkit.createInventory(player, event.getView().getTopInventory().getSize(), internalName);
 		applyOptionsToInventory(player, newInv, MagicSpells.NULL_ARGS);
 		player.openInventory(newInv);
+		Util.setInventoryTitle(player, title);
 	}
 
 	private String castSpells(Player player, ItemStack item, ClickType click) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -1,14 +1,9 @@
 package com.nisovin.magicspells.spells;
 
-import com.nisovin.magicspells.Subspell;
-import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.TargetInfo;
-import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.castmodifiers.ModifierSet;
+import java.util.*;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
-import org.bukkit.ChatColor;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -22,7 +17,11 @@ import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
-import java.util.*;
+import com.nisovin.magicspells.Subspell;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.castmodifiers.ModifierSet;
 
 public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpell {
 
@@ -159,7 +158,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
         if(radius > 0) players.removeIf(player -> opener.getLocation().distance(player.getLocation()) > radius);
 
         int size = (int) Math.ceil((players.size()+1) / 9.0) * 9;
-        Inventory inv = Bukkit.createInventory(opener, size, translate(opener, null, title));
+        Inventory inv = Bukkit.createInventory(opener, size, internalName);
 
         for(int i = 0; i < players.size(); i++) {
             ItemStack head = new ItemStack(Material.PLAYER_HEAD);
@@ -177,6 +176,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
             inv.setItem(i, head);
         }
         opener.openInventory(inv);
+        Util.setInventoryTitle(opener, title);
     }
 
     @EventHandler
@@ -187,9 +187,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
     @EventHandler
     public void onItemClick(InventoryClickEvent event) {
         Player player = (Player) event.getWhoClicked();
-        String currentTitle = ChatColor.stripColor(event.getView().getTitle());
-        String newTitle = ChatColor.stripColor(translate(player, null, title));
-        if(!currentTitle.equals(newTitle)) return;
+        if (!event.getView().getTitle().equals(internalName)) return;
         event.setCancelled(true);
         ItemStack item = event.getCurrentItem();
         if(item == null) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -26,6 +26,7 @@ import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 import com.nisovin.magicspells.events.MagicSpellsBlockPlaceEvent;
+import com.nisovin.magicspells.events.MagicSpellsBlockBreakEvent;
 
 public class MaterializeSpell extends TargetedSpell implements TargetedLocationSpell {
 
@@ -333,8 +334,13 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 			MagicSpells.scheduleDelayedTask(() -> {
 				if (materials.contains(block.getType())) {
 					blocks.remove(block);
-					block.setType(Material.AIR);
 					playSpellEffects(EffectPosition.DELAYED, block.getLocation());
+					if (checkPlugins && player != null) {
+						MagicSpellsBlockBreakEvent event = new MagicSpellsBlockBreakEvent(block, player);
+						EventUtil.call(event);
+						if (event.isCancelled()) return;
+					}
+					block.setType(Material.AIR);
 					playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation());
 					if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
@@ -150,12 +150,12 @@ public class ParseSpell extends TargetedSpell implements TargetedEntitySpell {
 
 				StringBuilder found = new StringBuilder();
 				while (matcher.find()) {
-					// If there's an intended return value, exit here, because this passed.
 					if (!parseTo.isEmpty()) {
-						found.append(parseTo);
+						// If there is replacement text, replace and exit.
+						found = new StringBuilder(receivedValue.replaceAll(regexPattern.pattern(), parseTo));
 						break;
 					}
-					// Otherwise, collect all matched text and return it.
+					// Otherwise, collect found text.
 					found.append(matcher.group());
 				}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -118,8 +118,10 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 
 	@Override
 	public void turnOff() {
-		for (Block b : blocks.keySet()) {
-			b.setType(blocks.get(b));
+		if (replaceDuration > 0) {
+			for (Block b : blocks.keySet()) {
+				b.setType(blocks.get(b));
+			}
 		}
 
 		blocks.clear();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -188,6 +188,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 								return false;
 							}
 						}
+						playSpellEffects(EffectPosition.SPECIAL, finalBlock.getLocation());
 
 						// Break block.
 						if (replaceDuration > 0) {
@@ -200,6 +201,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 									if (event.isCancelled()) return;
 								}
 								finalBlock.setType(previousMat);
+								playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, finalBlock.getLocation());
 							}, replaceDuration);
 						}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/MagicConfig.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MagicConfig.java
@@ -122,6 +122,12 @@ public class MagicConfig {
 					for (String itemKey : spellConfig.getConfigurationSection("variables").getKeys(false)) {
 						sec.set(itemKey, spellConfig.get("variables." + itemKey));
 					}
+				} else if (key.equals("recipes")) {
+					ConfigurationSection sec = mainConfig.getConfigurationSection("general.recipes");
+					if (sec == null) sec = mainConfig.createSection("general.recipes");
+					for (String itemKey : spellConfig.getConfigurationSection("recipes").getKeys(false)) {
+						sec.set(itemKey, spellConfig.get("recipes." + itemKey));
+					}
 				} else if (key.equals("modifiers")) {
 					ConfigurationSection sec = mainConfig.getConfigurationSection("general.modifiers");
 					if (sec == null) sec = mainConfig.createSection("general.modifiers");

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
@@ -1,21 +1,26 @@
 package com.nisovin.magicspells.util;
 
+import java.util.Set;
+import java.util.HashSet;
+
 import com.nisovin.magicspells.MagicSpells;
 
 /**
- * This class represents a spell animation. It facilitates creating a spell effect that happens over a period of time, 
+ * This class represents a spell animation. It facilitates creating a spell effect that happens over a period of time,
  * without having to worry about stopping and starting scheduled tasks.
- * 
+ *
  * @author nisovin
  *
  */
 public abstract class SpellAnimation implements Runnable {
 
+	private static Set<SpellAnimation> animations = new HashSet<>();
+
 	private int taskId;
 	private int delay;
 	private int interval;
 	private int tick;
-	
+
 	/**
 	 * Create a new spell animation with the specified interval and no delay. It will not auto start.
 	 * @param interval the animation interval, in server ticks (animation speed)
@@ -23,7 +28,7 @@ public abstract class SpellAnimation implements Runnable {
 	public SpellAnimation(int interval) {
 		this(0, interval, false);
 	}
-	
+
 	/**
 	 * Create a new spell animation with the specified interval and no delay.
 	 * @param interval the animation interval, in server ticks (animation speed)
@@ -32,7 +37,7 @@ public abstract class SpellAnimation implements Runnable {
 	public SpellAnimation(int interval, boolean autoStart) {
 		this(0, interval, autoStart);
 	}
-	
+
 	/**
 	 * Create a new spell animation with the specified interval and delay. It will not auto start.
 	 * @param delay the delay before the animation begins, in server ticks
@@ -41,7 +46,7 @@ public abstract class SpellAnimation implements Runnable {
 	public SpellAnimation(int delay, int interval) {
 		this(delay, interval, false);
 	}
-	
+
 	/**
 	 * Create a new spell animation with the specified interval and delay.
 	 * @param delay the delay before the animation begins, in server ticks
@@ -52,32 +57,41 @@ public abstract class SpellAnimation implements Runnable {
 		this.delay = delay;
 		this.interval = interval;
 		this.tick = -1;
+		animations.add(this);
 		if (autoStart) play();
 	}
-	
+
 	/**
 	 * Start the spell animation.
 	 */
 	public void play() {
 		taskId = MagicSpells.scheduleRepeatingTask(this, delay, interval);
 	}
-	
+
 	/**
 	 * Stop the spell animation.
 	 */
-	protected void stop() {
+	public void stop() {
 		MagicSpells.cancelTask(taskId);
+		animations.remove(this);
 	}
-	
+
 	/**
 	 * This method is called every time the animation ticks (with the interval defined in the constructor).
 	 * @param tick the current tick number, starting with 0
 	 */
 	protected abstract void onTick(int tick);
-	
+
 	@Override
 	public final void run() {
 		onTick(++tick);
 	}
-	
+
+	/**
+	 * Returns all existing animations.
+	 * @return Current animations.
+	 */
+	public static Set<SpellAnimation> getAnimations() {
+		return animations;
+	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -692,4 +692,9 @@ public class Util {
 		}
 	}
 
+	public static void setInventoryTitle(Player player, String title) {
+		title = doVarReplacementAndColorize(player, title);
+		MagicSpells.getVolatileCodeHandler().setInventoryTitle(player, title);
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
@@ -16,39 +16,39 @@ import com.nisovin.magicspells.MagicSpells;
 
 public class BossBarManager {
 
-	private final Pattern VALID_NAMESPACE = Pattern.compile("[a-z0-9._-]+");
+	private final Pattern VALID_NAMESPACE_KEY = Pattern.compile("[a-z0-9._-]+");
 
-	private final String NAMESPACE_DEFAULT = "ms_default";
-	private final String NAMESPACE_VARIABLE = "ms_variable";
+	private final String NAMESPACE_KEY_DEFAULT = "ms_default";
+	private final String NAMESPACE_KEY_VARIABLE = "ms_variable";
 
 	private final Set<Bar> bars = new HashSet<>();
 
-	public String getNamespaceVariable() {
-		return NAMESPACE_VARIABLE;
+	public String getNamespaceKeyVariable() {
+		return NAMESPACE_KEY_VARIABLE;
 	}
 
-	public boolean isNameSpace(String namespace) {
-		return VALID_NAMESPACE.matcher(namespace).matches();
+	public boolean isNameSpaceKey(String namespaceKey) {
+		return VALID_NAMESPACE_KEY.matcher(namespaceKey).matches();
 	}
 
-	private NamespacedKey createNamespace(String namespace) {
-		return new NamespacedKey(MagicSpells.plugin, namespace);
+	private NamespacedKey createNamespaceKey(String namespaceKey) {
+		return new NamespacedKey(MagicSpells.plugin, namespaceKey);
 	}
 
-	public Bar getBar(Player player, String namespace) {
-		if (namespace == null || namespace.isEmpty()) namespace = NAMESPACE_DEFAULT;
+	public Bar getBar(Player player, String namespaceKey) {
+		if (namespaceKey == null || namespaceKey.isEmpty()) namespaceKey = NAMESPACE_KEY_DEFAULT;
 		// Check if the bar exists.
 		Bar finalBar = null;
 		for (Bar bar : bars) {
-			if (bar.player.equals(player) && bar.namespace.equals(namespace)) {
+			if (bar.player.equals(player) && bar.namespaceKey.equals(namespaceKey)) {
 				finalBar = bar;
 				break;
 			}
 		}
 		// If it doesn't, create it.
 		if (finalBar == null) {
-			BossBar bossBar = Bukkit.createBossBar(createNamespace(namespace), "", BarColor.WHITE, BarStyle.SOLID);
-			finalBar = new Bar(bossBar, player, namespace);
+			BossBar bossBar = Bukkit.createBossBar(createNamespaceKey(namespaceKey), "", BarColor.WHITE, BarStyle.SOLID);
+			finalBar = new Bar(bossBar, player, namespaceKey);
 			bars.add(finalBar);
 		}
 		return finalBar;
@@ -62,12 +62,12 @@ public class BossBarManager {
 	public class Bar {
 		final BossBar bossbar;
 		final Player player;
-		final String namespace;
+		final String namespaceKey;
 
-		Bar(BossBar bossbar, Player player, String namespace) {
+		Bar(BossBar bossbar, Player player, String namespaceKey) {
 			this.bossbar = bossbar;
 			this.player = player;
-			this.namespace = namespace;
+			this.namespaceKey = namespaceKey;
 		}
 
 		public void set(String title, double progress, BarStyle style, BarColor color) {
@@ -84,7 +84,7 @@ public class BossBarManager {
 
 		public void deleteBossbar() {
 			bossbar.removeAll();
-			Bukkit.removeBossBar(createNamespace(namespace));
+			Bukkit.removeBossBar(createNamespaceKey(namespaceKey));
 		}
 
 		public void remove() {

--- a/core/src/main/java/com/nisovin/magicspells/variables/Variable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/Variable.java
@@ -18,13 +18,13 @@ public abstract class Variable {
 	protected String bossbarTitle;
 	protected BarStyle bossbarStyle;
 	protected BarColor bossbarColor;
-	protected String bossbarNamespace;
+	protected String bossbarNamespaceKey;
 
 	public Variable() {
 		// No op
 	}
-	
-	public final void init(double defaultValue, double minValue, double maxValue, boolean permanent, Objective objective, boolean expBar, String bossbarTitle, BarStyle bossbarStyle, BarColor bossbarColor, String bossbarNamespace) {
+
+	public final void init(double defaultValue, double minValue, double maxValue, boolean permanent, Objective objective, boolean expBar, String bossbarTitle, BarStyle bossbarStyle, BarColor bossbarColor, String bossbarNamespaceKey) {
 		this.defaultValue = defaultValue;
 		this.defaultStringValue = defaultValue + "";
 		this.minValue = minValue;
@@ -35,49 +35,49 @@ public abstract class Variable {
 		this.bossbarTitle = bossbarTitle;
 		this.bossbarStyle = bossbarStyle;
 		this.bossbarColor = bossbarColor;
-		this.bossbarNamespace = bossbarNamespace;
+		this.bossbarNamespaceKey = bossbarNamespaceKey;
 		init();
 	}
-	
+
 	protected void init() {
 		// No op
 	}
-	
+
 	public final void set(Player player, double amount) {
 		set(player.getName(), amount);
 	}
-	
+
 	public void parseAndSet(Player player, String textValue) {
 		parseAndSet(player.getName(), textValue);
 	}
-	
+
 	public abstract void set(String player, double amount);
-	
+
 	public void parseAndSet(String player, String textValue) {
 		set(player, Double.parseDouble(textValue));
 	}
-	
+
 	public double getValue(Player player) {
 		if (player == null) return getValue("");
 		return getValue(player.getName());
 	}
-	
+
 	public abstract double getValue(String player);
-	
+
 	public final void reset(Player player) {
 		reset(player.getName());
 	}
-	
+
 	public abstract void reset(String player);
-	
+
 	public void loadExtraData(ConfigurationSection section) {
 		// No op from here, but subclasses may add behavior
 	}
-	
+
 	public String getStringValue(Player player) {
 		return getStringValue(player.getName());
 	}
-	
+
 	public String getStringValue(String player) {
 		return getValue(player) + "";
 	}

--- a/core/src/main/java/com/nisovin/magicspells/variables/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/VariableManager.java
@@ -77,7 +77,7 @@ public class VariableManager implements Listener {
 				String bossbarTitle = null;
 				BarStyle bossbarStyle = null;
 				BarColor bossbarColor = null;
-				String bossBarNamespace = null;
+				String bossBarNamespaceKey = null;
 				// Reserve preceded handling.
 				if (section.isString(var + ".boss-bar")) bossbarTitle = section.getString(var + ".boss-bar");
 				else {
@@ -102,17 +102,17 @@ public class VariableManager implements Listener {
 								MagicSpells.error("Variable '" + var + "' has an invalid bossbar color defined: '" + color + "'");
 							}
 						}
-						bossBarNamespace = bossBar.getString("namespace");
-						if (!MagicSpells.getBossBarManager().isNameSpace(bossBarNamespace)) {
-							MagicSpells.error("Variable '" + var + "' has an invalid bossbar namespace defined: '" + bossBarNamespace + "'");
+						bossBarNamespaceKey = bossBar.getString("namespace-key");
+						if (!MagicSpells.getBossBarManager().isNameSpaceKey(bossBarNamespaceKey)) {
+							MagicSpells.error("Variable '" + var + "' has an invalid bossbar namespace-key defined: '" + bossBarNamespaceKey + "'");
 						}
 					}
 				}
 				if (bossbarStyle == null) bossbarStyle = BarStyle.SOLID;
 				if (bossbarColor == null) bossbarColor = BarColor.PURPLE;
-				if (bossBarNamespace == null || bossBarNamespace.isEmpty()) bossBarNamespace = MagicSpells.getBossBarManager().getNamespaceVariable();
+				if (bossBarNamespaceKey == null || bossBarNamespaceKey.isEmpty()) bossBarNamespaceKey = MagicSpells.getBossBarManager().getNamespaceKeyVariable();
 
-				variable.init(def, min, max, perm, objective, expBar, bossbarTitle, bossbarStyle, bossbarColor, bossBarNamespace);
+				variable.init(def, min, max, perm, objective, expBar, bossbarTitle, bossbarStyle, bossbarColor, bossBarNamespaceKey);
 				variable.loadExtraData(varSection);
 				variables.put(var, variable);
 				MagicSpells.debug(2, "Loaded variable " + var);
@@ -228,10 +228,10 @@ public class VariableManager implements Listener {
 		if (var.bossbarTitle == null) return;
 		if (var instanceof GlobalVariable) {
 			double pct = var.getValue("") / var.maxValue;
-			Util.forEachPlayerOnline(p -> MagicSpells.getBossBarManager().getBar(p, var.bossbarNamespace).set(var.bossbarTitle, pct, var.bossbarStyle, var.bossbarColor));
+			Util.forEachPlayerOnline(p -> MagicSpells.getBossBarManager().getBar(p, var.bossbarNamespaceKey).set(var.bossbarTitle, pct, var.bossbarStyle, var.bossbarColor));
 		} else if (var instanceof PlayerVariable) {
 			Player p = PlayerNameUtils.getPlayerExact(player);
-			if (p != null) MagicSpells.getBossBarManager().getBar(p, var.bossbarNamespace).set(var.bossbarTitle, var.getValue(p) / var.maxValue, var.bossbarStyle, var.bossbarColor);
+			if (p != null) MagicSpells.getBossBarManager().getBar(p, var.bossbarNamespaceKey).set(var.bossbarTitle, var.getValue(p) / var.maxValue, var.bossbarStyle, var.bossbarColor);
 		}
 	}
 
@@ -385,7 +385,7 @@ public class VariableManager implements Listener {
 	private void loadBossBars(Player player) {
 		for (Variable var : variables.values()) {
 			if (var.bossbarTitle == null) continue;
-			MagicSpells.getBossBarManager().getBar(player, var.bossbarNamespace).set(var.bossbarTitle, var.getValue(player) / var.maxValue, var.bossbarStyle, var.bossbarColor);
+			MagicSpells.getBossBarManager().getBar(player, var.bossbarNamespaceKey).set(var.bossbarTitle, var.getValue(player) / var.maxValue, var.bossbarStyle, var.bossbarColor);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -1,9 +1,12 @@
 package com.nisovin.magicspells.volatilecode;
 
 import org.bukkit.Location;
+import org.bukkit.Material;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -11,7 +14,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 public class VolatileCodeDisabled implements VolatileCodeHandle {
 
 	public VolatileCodeDisabled() {
-		
+
 	}
 
 	@Override
@@ -134,4 +137,23 @@ public class VolatileCodeDisabled implements VolatileCodeHandle {
 	public void setInventoryTitle(Player player, String title) {
 		// Need volatile code for this
 	}
+
+	@Override
+	public Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime) {
+		// Need volatile code for this
+		return null;
+	}
+
+	@Override
+	public Recipe createStonecutterRecipe(NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient) {
+		// Need volatile code for this
+		return null;
+	}
+
+	@Override
+	public Recipe createSmithingRecipe(NamespacedKey namespaceKey, ItemStack result, Material base, Material addition) {
+		// Need volatile code for this
+		return null;
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -130,4 +130,8 @@ public class VolatileCodeDisabled implements VolatileCodeHandle {
 		return null;
 	}
 
+	@Override
+	public void setInventoryTitle(Player player, String title) {
+		// Need volatile code for this
+	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -1,23 +1,26 @@
 package com.nisovin.magicspells.volatilecode;
 
+import org.bukkit.Material;
 import org.bukkit.entity.*;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.OfflinePlayer;
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 
 public interface VolatileCodeHandle {
-	
+
 	void addPotionGraphicalEffect(LivingEntity entity, int color, int duration);
 
 	void creaturePathToLoc(Creature creature, Location loc, float speed);
-	
+
 	void sendFakeSlotUpdate(Player player, int slot, ItemStack item);
 
 	boolean simulateTnt(Location target, LivingEntity source, float explosionSize, boolean fire);
-	
+
 	boolean createExplosionByEntity(Entity entity, Location location, float size, boolean fire, boolean breakBlocks);
 
 	void setExperienceBar(Player player, int level, float percent);
@@ -31,11 +34,11 @@ public interface VolatileCodeHandle {
 	void playDragonDeathEffect(Location location);
 
 	void addAILookAtPlayer(LivingEntity entity, int range);
-	
+
 	void saveSkinData(Player player, String name);
 
 	void setClientVelocity(Player player, Vector velocity);
-	
+
 	double getAbsorptionHearts(LivingEntity entity);
 
 	void setAbsorptionHearts(LivingEntity entity, double Double);
@@ -55,4 +58,11 @@ public interface VolatileCodeHandle {
 	String getNBTString(ItemStack item, String key);
 
 	void setInventoryTitle(Player player, String title);
+
+	Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime);
+
+	Recipe createStonecutterRecipe(NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient);
+
+	Recipe createSmithingRecipe(NamespacedKey namespaceKey, ItemStack result, Material base, Material addition);
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -53,4 +53,6 @@ public interface VolatileCodeHandle {
 	ItemStack setNBTString(ItemStack item, String key, String value);
 
 	String getNBTString(ItemStack item, String key);
+
+	void setInventoryTitle(Player player, String title);
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
@@ -5,11 +5,10 @@ import java.io.File
 import java.io.FileWriter
 import java.util.stream.Collectors
 
-import org.bukkit.Bukkit
-import org.bukkit.Location
+import org.bukkit.*
 import org.bukkit.entity.*
 import org.bukkit.util.Vector
-import org.bukkit.OfflinePlayer
+import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -157,5 +156,17 @@ class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHan
 
     override fun setInventoryTitle(player: Player, title: String) {
         parent.setInventoryTitle(player, title)
+    }
+
+    override fun createCookingRecipe(type: String?, namespaceKey: NamespacedKey?, group: String?, result: ItemStack?, ingredient: Material?, experience: Float, cookingTime: Int): Recipe {
+        return parent.createCookingRecipe(type, namespaceKey, group, result, ingredient, experience, cookingTime)
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey?, group: String?, result: ItemStack?, ingredient: Material?): Recipe {
+        return parent.createStonecutterRecipe(namespaceKey, group, result, ingredient)
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey?, result: ItemStack?, base: Material?, addition: Material?): Recipe {
+        return parent.createSmithingRecipe(namespaceKey, result, base, addition)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
@@ -1,20 +1,23 @@
 package com.nisovin.magicspells.volatilecode
 
-import com.destroystokyo.paper.profile.PlayerProfile
-import com.destroystokyo.paper.profile.ProfileProperty
-import com.nisovin.magicspells.MagicSpells
+import java.util.*
+import java.io.File
+import java.io.FileWriter
+import java.util.stream.Collectors
+
 import org.bukkit.Bukkit
 import org.bukkit.Location
-import org.bukkit.OfflinePlayer
 import org.bukkit.entity.*
+import org.bukkit.util.Vector
+import org.bukkit.OfflinePlayer
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
-import org.bukkit.util.Vector
-import java.io.File
-import java.io.FileWriter
-import java.util.*
-import java.util.stream.Collectors
+
+import com.nisovin.magicspells.MagicSpells
+
+import com.destroystokyo.paper.profile.PlayerProfile
+import com.destroystokyo.paper.profile.ProfileProperty
 
 class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHandle {
 
@@ -150,5 +153,9 @@ class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHan
 
     override fun setAbsorptionHearts(entity: LivingEntity, double: Double) {
         parent.setAbsorptionHearts(entity, double)
+    }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        parent.setInventoryTitle(player, title)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodePaper.kt
@@ -24,7 +24,7 @@ class VolatileCodePaper(private val parent: VolatileCodeHandle): VolatileCodeHan
         creature.pathfinder.moveTo(loc, speed.toDouble())
     }
 
-    override fun getNBTString(item: ItemStack?, key: String?): String {
+    override fun getNBTString(item: ItemStack, key: String): String? {
         return parent.getNBTString(item, key)
     }
 

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
@@ -8,9 +8,12 @@ import java.lang.reflect.Field
 import org.bukkit.Bukkit
 import org.bukkit.Location
 import org.bukkit.entity.*
+import org.bukkit.Material
 import org.bukkit.util.Vector
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
+import org.bukkit.inventory.Recipe
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -67,7 +70,6 @@ class VolatileCode1_13_R2: VolatileCodeHandle {
         /*final EntityLiving el = ((CraftLivingEntity)entity).getHandle();
         final DataWatcher dw = el.getDataWatcher();
         dw.watch(7, Integer.valueOf(color));
-
         if (duration > 0) {
             MagicSpells.scheduleDelayedTask(new Runnable() {
                 public void run() {
@@ -303,4 +305,17 @@ class VolatileCode1_13_R2: VolatileCodeHandle {
         entityPlayer.playerConnection.sendPacket(packet)
         entityPlayer.updateInventory(container)
     }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe? {
+        return null
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe? {
+        return null
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_13_R2/VolatileCode1_13_R2.kt
@@ -295,4 +295,12 @@ class VolatileCode1_13_R2: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
     }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, "minecraft:chest", ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
+    }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
@@ -8,10 +8,13 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
+import org.bukkit.inventory.*
 import org.bukkit.util.Vector
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -66,7 +69,6 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
         /*final EntityLiving el = ((CraftLivingEntity)entity).getHandle();
         final DataWatcher dw = el.getDataWatcher();
         dw.watch(7, Integer.valueOf(color));
-
         if (duration > 0) {
             MagicSpells.scheduleDelayedTask(new Runnable() {
                 public void run() {
@@ -298,7 +300,7 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
     }
-    
+
     override fun setInventoryTitle(player: Player, title: String) {
         val entityPlayer = (player as CraftPlayer).handle
         val container = entityPlayer.activeContainer
@@ -306,4 +308,26 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
         entityPlayer.playerConnection.sendPacket(packet)
         entityPlayer.updateInventory(container)
     }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_14_R1/VolatileCode1_14_R1.kt
@@ -33,7 +33,6 @@ import com.mojang.authlib.GameProfile
 import com.mojang.authlib.properties.Property
 
 import net.minecraft.server.v1_14_R1.*
-import net.minecraft.server.v1_14_R1.NBTTagCompound
 
 private typealias nmsItemStack = net.minecraft.server.v1_14_R1.ItemStack
 
@@ -298,5 +297,13 @@ class VolatileCode1_14_R1: VolatileCodeHandle {
 
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
+    }
+    
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
@@ -8,10 +8,13 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
 import org.bukkit.util.Vector
+import org.bukkit.inventory.*
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -66,7 +69,6 @@ class VolatileCode1_15_R1: VolatileCodeHandle {
         /*final EntityLiving el = ((CraftLivingEntity)entity).getHandle();
         final DataWatcher dw = el.getDataWatcher();
         dw.watch(7, Integer.valueOf(color));
-
         if (duration > 0) {
             MagicSpells.scheduleDelayedTask(new Runnable() {
                 public void run() {
@@ -306,4 +308,26 @@ class VolatileCode1_15_R1: VolatileCodeHandle {
         entityPlayer.playerConnection.sendPacket(packet)
         entityPlayer.updateInventory(container)
     }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe? {
+        return null
+    }
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_15_R1/VolatileCode1_15_R1.kt
@@ -33,7 +33,6 @@ import com.mojang.authlib.GameProfile
 import com.mojang.authlib.properties.Property
 
 import net.minecraft.server.v1_15_R1.*
-import net.minecraft.server.v1_15_R1.NBTTagCompound
 
 private typealias nmsItemStack = net.minecraft.server.v1_15_R1.ItemStack
 
@@ -298,5 +297,13 @@ class VolatileCode1_15_R1: VolatileCodeHandle {
 
     override fun getNBTString(item: ItemStack, key: String): String {
         return getNBTTag(item).getString(key)
+    }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
@@ -12,10 +12,12 @@ import org.bukkit.entity.*
 import org.bukkit.util.Vector
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
+import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
 import org.bukkit.craftbukkit.v1_16_R1.entity.*
+import org.bukkit.persistence.PersistentDataType
 import org.bukkit.craftbukkit.v1_16_R1.CraftWorld
 import org.bukkit.event.entity.ExplosionPrimeEvent
 import org.bukkit.craftbukkit.v1_16_R1.CraftServer
@@ -30,8 +32,6 @@ import com.mojang.authlib.GameProfile
 import com.mojang.authlib.properties.Property
 
 import net.minecraft.server.v1_16_R1.*
-import org.bukkit.NamespacedKey
-import org.bukkit.persistence.PersistentDataType
 
 private typealias nmsItemStack = net.minecraft.server.v1_16_R1.ItemStack
 
@@ -283,5 +283,13 @@ class VolatileCode1_16_R1: VolatileCodeHandle {
 
     override fun getNBTString(item: ItemStack, key: String): String? {
         return item.itemMeta?.persistentDataContainer?.get(NamespacedKey(MagicSpells.plugin, key), PersistentDataType.STRING)
+    }
+
+    override fun setInventoryTitle(player: Player, title: String) {
+        val entityPlayer = (player as CraftPlayer).handle
+        val container = entityPlayer.activeContainer
+        val packet = PacketPlayOutOpenWindow(container.windowId, container.type, ChatMessage(title))
+        entityPlayer.playerConnection.sendPacket(packet)
+        entityPlayer.updateInventory(container)
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_16_R1/VolatileCode1_16_R1.kt
@@ -8,11 +8,13 @@ import java.lang.reflect.Field
 
 import org.bukkit.Bukkit
 import org.bukkit.Location
+import org.bukkit.Material
 import org.bukkit.entity.*
+import org.bukkit.inventory.*
 import org.bukkit.util.Vector
+import org.bukkit.NamespacedKey
 import org.bukkit.entity.Entity
 import org.bukkit.OfflinePlayer
-import org.bukkit.NamespacedKey
 import org.bukkit.inventory.ItemStack
 import org.bukkit.inventory.meta.ItemMeta
 import org.bukkit.inventory.meta.SkullMeta
@@ -63,7 +65,6 @@ class VolatileCode1_16_R1: VolatileCodeHandle {
         /*final EntityLiving el = ((CraftLivingEntity)entity).getHandle();
         final DataWatcher dw = el.getDataWatcher();
         dw.watch(7, Integer.valueOf(color));
-
         if (duration > 0) {
             MagicSpells.scheduleDelayedTask(new Runnable() {
                 public void run() {
@@ -292,4 +293,26 @@ class VolatileCode1_16_R1: VolatileCodeHandle {
         entityPlayer.playerConnection.sendPacket(packet)
         entityPlayer.updateInventory(container)
     }
+
+    override fun createCookingRecipe(type: String, namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material, experience: Float, cookingTime: Int): Recipe {
+        var recipe : Recipe? = null
+        when (type) {
+            "smoking" -> recipe = SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "campfire" -> recipe = CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+            "blasting" -> recipe = BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime)
+        }
+        (recipe as CookingRecipe<*>).group = group
+        return recipe
+    }
+
+    override fun createStonecutterRecipe(namespaceKey: NamespacedKey, group: String, result: ItemStack, ingredient: Material): Recipe {
+        val recipe = StonecuttingRecipe(namespaceKey, result, ingredient)
+        recipe.group = group
+        return recipe
+    }
+
+    override fun createSmithingRecipe(namespaceKey: NamespacedKey, result: ItemStack, base: Material, addition: Material): Recipe {
+        return SmithingRecipe(namespaceKey, result, RecipeChoice.MaterialChoice(base), RecipeChoice.MaterialChoice(addition))
+    }
+
 }


### PR DESCRIPTION
The Menu spell `slots` property was added to set the defined item to all listed slots. It'll be prioritised over the `slot` property.

The Menu spell also had a long-term bug which was recently further exposed by accident. To set the scene, if two or multiple menu spells exist with the same title, all instances of their InventoryClick events would activate. If the item clicked has the same `options` key, it would trigger on all instances. The issue here was indentifying which menu's spell the item belongs to. Now I'm not particularly sure if this solution is good or not - in the real title I'm storing the internal spell name to help indentify the option item origin. I'm sending packets to update the menu title to the client.