### PR TITLE
Decent amount of changes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PassiveTrigger.java
@@ -1,14 +1,12 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.HashMap;
-import java.util.HashSet;
-
+import com.nisovin.magicspells.MagicSpells;
 import org.bukkit.event.EventPriority;
 
-import com.nisovin.magicspells.MagicSpells;
-import org.bukkit.inventory.Inventory;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 public class PassiveTrigger {
 	
@@ -24,7 +22,7 @@ public class PassiveTrigger {
 		triggerPrioritySuffix.put(EventPriority.HIGHEST, "_highestpriority");
 		triggerPrioritySuffix.put(EventPriority.MONITOR, "_monitorpriority");
 	}
-	
+
 	public static Set<PassiveTrigger> TAKE_DAMAGE = addTriggers("takedamage", TakeDamageListener.class);
 	public static Set<PassiveTrigger> GIVE_DAMAGE = addTriggers("givedamage", GiveDamageListener.class);
 	public static Set<PassiveTrigger> FATAL_DAMAGE = addTriggers("fataldamage", FatalDamageListener.class);
@@ -82,6 +80,8 @@ public class PassiveTrigger {
 	
 	public static Set<PassiveTrigger> START_GLIDE = addTriggers("startglide", GlideListener.class);
 	public static Set<PassiveTrigger> STOP_GLIDE = addTriggers("stopglide", GlideListener.class);
+	public static Set<PassiveTrigger> START_SWIM = addTriggers("startswim", SwimListener.class);
+	public static Set<PassiveTrigger> STOP_SWIM = addTriggers("stopswim", SwimListener.class);
 	public static Set<PassiveTrigger> SIGN_BOOK = addTriggers("signbook", SignBookListener.class);
 	
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SwimListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SwimListener.java
@@ -1,0 +1,57 @@
+package com.nisovin.magicspells.spells.passive;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.spells.PassiveSpell;
+import com.nisovin.magicspells.util.OverridePriority;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.entity.EntityToggleSwimEvent;
+
+import java.util.ArrayList;
+import java.util.List;
+
+// No trigger variable is currently used
+public class SwimListener extends PassiveListener {
+
+	List<PassiveSpell> swim = null;
+	List<PassiveSpell> stopSwim = null;
+	
+	@Override
+	public void registerSpell(PassiveSpell spell, PassiveTrigger trigger, String var) {
+		if (PassiveTrigger.START_SWIM.contains(trigger)) {
+			if (swim == null) swim = new ArrayList<>();
+			swim.add(spell);
+		} else if (PassiveTrigger.STOP_SWIM.contains(trigger)) {
+			if (stopSwim == null) stopSwim = new ArrayList<>();
+			stopSwim.add(spell);
+		}
+	}
+	
+	@OverridePriority
+	@EventHandler
+	public void onSwim(EntityToggleSwimEvent event) {
+		Entity entity = event.getEntity();
+		if (!(entity instanceof Player)) return;
+		Player player = (Player) entity;
+		if (event.isSwimming()) {
+			if (swim != null) {
+				Spellbook spellbook = MagicSpells.getSpellbook(player);
+				for (PassiveSpell spell : swim) {
+					if (!spellbook.hasSpell(spell, false)) continue;
+					spell.activate(player);
+				}
+			}
+		} else {
+			if (stopSwim != null) {
+				Spellbook spellbook = MagicSpells.getSpellbook(player);
+				for (PassiveSpell spell : stopSwim) {
+					if (!spellbook.hasSpell(spell, false)) continue;
+					spell.activate(player);
+				}
+			}
+		}
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
@@ -1,0 +1,82 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.TargetInfo;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class TagEntitySpell extends TargetedSpell implements TargetedEntitySpell {
+
+	private String operation;
+	private String tag;
+	private String varTag;
+
+	public TagEntitySpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		tag = getConfigString("tag", null);
+		operation = getConfigString("operation", "add");
+
+	}
+
+	@Override
+	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
+		if (state == SpellCastState.NORMAL) {
+			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(livingEntity, power);
+			if (targetInfo == null) return noTarget(livingEntity);
+			LivingEntity target = targetInfo.getTarget();
+			if (target == null) return noTarget(livingEntity);
+			tag(livingEntity, target);
+			playSpellEffects(livingEntity, target);
+		}
+
+		return PostCastAction.HANDLE_NORMALLY;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		tag(caster, target);
+		playSpellEffects(caster, target);
+		return true;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		tag(target, target);
+		playSpellEffects(EffectPosition.TARGET, target);
+		return true;
+	}
+
+	private void tag(LivingEntity caster, LivingEntity target) {
+		switch (operation) {
+			case "add":
+			case "insert":
+				if (tag.contains("%") && caster instanceof Player) {
+					varTag = MagicSpells.doVariableReplacements((Player) caster, tag);
+					target.addScoreboardTag(varTag);
+				} else target.addScoreboardTag(tag);
+				break;
+			case "remove":
+			case "take":
+				if (tag.contains("%") && caster instanceof Player) {
+					varTag = MagicSpells.doVariableReplacements((Player) caster, tag);
+					target.removeScoreboardTag(varTag);
+				} else target.removeScoreboardTag(tag);
+				break;
+			case "clear":
+				Set<String> tags = new HashSet<>(target.getScoreboardTags());
+				tags.forEach(target::removeScoreboardTag);
+				break;
+			default:
+				MagicSpells.error("TagEntitySpell '" + internalName + "' has an invalid operation defined!");
+		}
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/SpecialVariables.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/SpecialVariables.java
@@ -1,10 +1,10 @@
 package com.nisovin.magicspells.variables;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.util.Collections;
-
 import com.nisovin.magicspells.variables.meta.*;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 
 // TODO look into GENERIC_FLYING_SPEED attribute
 // TODO look into GENERIC_MOVEMENT_SPEED attribute
@@ -48,6 +48,10 @@ public class SpecialVariables {
 		specialVariables.put("meta_bed_location_z", new BedCoordZVariable());
 		specialVariables.put("meta_altitude", new AltitudeVariable());
 		specialVariables.put("meta_absorption", new AbsorptionVariable());
+		specialVariables.put("meta_timestamp_days", new TimestampDaysVariable());
+		specialVariables.put("meta_timestamp_hours", new TimestampHoursVariable());
+		specialVariables.put("meta_timestamp_minutes", new TimestampMinutesVariable());
+		specialVariables.put("meta_timestamp_seconds", new TimestampSecondsVariable());
 
 		specialVariables.put("meta_attribute_generic_armor_base", new AttributeBaseValueVariable("GENERIC_ARMOR"));
 		specialVariables.put("meta_attribute_generic_armor_toughness_base", new AttributeBaseValueVariable("GENERIC_ARMOR_TOUGHNESS"));

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampDaysVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampDaysVariable.java
@@ -1,0 +1,16 @@
+package com.nisovin.magicspells.variables.meta;
+
+import com.nisovin.magicspells.variables.MetaVariable;
+
+import java.time.Instant;
+
+public class TimestampDaysVariable extends MetaVariable {
+
+    @Override
+    public double getValue(String player) {
+        Instant instant = Instant.now();
+        long mins = instant.getEpochSecond();
+        return Math.floor(mins/60/60/24);
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampHoursVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampHoursVariable.java
@@ -1,0 +1,16 @@
+package com.nisovin.magicspells.variables.meta;
+
+import com.nisovin.magicspells.variables.MetaVariable;
+
+import java.time.Instant;
+
+public class TimestampHoursVariable extends MetaVariable {
+
+    @Override
+    public double getValue(String player) {
+        Instant instant = Instant.now();
+        long mins = instant.getEpochSecond();
+        return Math.floor(mins/60/60);
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampMinutesVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampMinutesVariable.java
@@ -1,0 +1,16 @@
+package com.nisovin.magicspells.variables.meta;
+
+import com.nisovin.magicspells.variables.MetaVariable;
+
+import java.time.Instant;
+
+public class TimestampMinutesVariable extends MetaVariable {
+
+    @Override
+    public double getValue(String player) {
+        Instant instant = Instant.now();
+        long mins = instant.getEpochSecond();
+        return Math.floor(mins/60);
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampSecondsVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampSecondsVariable.java
@@ -1,0 +1,15 @@
+package com.nisovin.magicspells.variables.meta;
+
+import com.nisovin.magicspells.variables.MetaVariable;
+
+import java.time.Instant;
+
+public class TimestampSecondsVariable extends MetaVariable {
+
+    @Override
+    public double getValue(String player) {
+        Instant instant = Instant.now();
+        return instant.getEpochSecond();
+    }
+
+}


### PR DESCRIPTION
### Variables
- `meta_timestamp_days`
- `meta_timestamp_hours`
- `meta_timestamp_minutes`
- `meta_timestamp_seconds`

These special variables get the current timestamp and allow you to compare it later. This greatly increases the ability to measure time over long periods without ticking (even if the server goes offline or there is no players).

### Valid Targets
- `castermount`
- `casterpassenger`
- `mount`
- `passengers`
- `mobtarget`

You can now specifically target mounts and passengers as well as the **casters** mount or passenger. This should greatly increase functions for some RPG servers with healing spells that also want to heal your mount.

The `mobtarget` targeter allows a mob to specifically target its current target. While there are other methods of doing this in MS, this reduces spell count. Only works with mob casting of course.

### Spells
- `TagEntitySpell`

The TagEntitySpell is capable of inserting or withdrawing scoreboard tags from the targeted entity using `add` or `remove` operations which support variable replacement. You can also use `clear` to remove all tags present in the target.

### Passive Trigger
- `startswim`
- `stopswim`

Triggers on the beginning or end of the swim event. This is not able to be cancelled.