### PR TITLE
Small additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -443,6 +443,7 @@ public class MagicSpells extends JavaPlugin {
 		addPermission(pm, "command.profilereport", PermissionDefault.OP);
 		addPermission(pm, "command.debug", PermissionDefault.OP);
 		addPermission(pm, "command.magicxp", PermissionDefault.OP);
+		addPermission(pm, "command.cast.power", PermissionDefault.OP);
 		addPermission(pm, "command.cast.self", PermissionDefault.TRUE);
 		addPermission(pm, "command.cast.as", PermissionDefault.OP);
 		addPermission(pm, "command.cast.on", PermissionDefault.OP);

--- a/core/src/main/java/com/nisovin/magicspells/Perm.java
+++ b/core/src/main/java/com/nisovin/magicspells/Perm.java
@@ -42,6 +42,7 @@ public enum Perm {
 	COMMAND_PROFILE_REPORT("magicspells.command.profilereport"),
 	COMMAND_DEBUG("magicspells.command.debug"),
 	COMMAND_MAGICXP("magicspells.command.magicxp"),
+	COMMAND_CAST_POWER("magicspells.command.cast.power"),
 	COMMAND_CAST_SELF("magicspells.command.cast.self"),
 	COMMAND_CAST_AS("magicspells.command.cast.as"),
 	COMMAND_CAST_ON("magicspells.command.cast.on"),

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -110,6 +110,12 @@ public class MagicCommand extends BaseCommand {
 			if (!num.isEmpty()) completions.add(num);
 			return completions;
 		});
+		commandManager.getCommandCompletions().registerAsyncCompletion("power", context -> {
+			Player player = context.getPlayer();
+			if (player == null) return Collections.emptyList();
+			if (!Perm.COMMAND_CAST_POWER.has(player)) return Collections.emptyList();
+			return Collections.singleton("-p:");
+		});
 	}
 
 	private static Set<String> getSpellNames(Collection<Spell> spells) {
@@ -622,7 +628,7 @@ public class MagicCommand extends BaseCommand {
 
 		@Subcommand("self")
 		@CommandAlias("c|cast")
-		@CommandCompletion("@owned_spells -p: @nothing")
+		@CommandCompletion("@owned_spells @power @nothing")
 		@Syntax("<spell> [-p:(power)] [spellArgs]")
 		@Description("Cast a spell. (You can optionally define power: -p:1.0)")
 		@HelpPermission(permission = Perm.COMMAND_CAST_SELF)
@@ -686,7 +692,7 @@ public class MagicCommand extends BaseCommand {
 		}
 
 		@Subcommand("as")
-		@CommandCompletion("@players @spells -p: @nothing")
+		@CommandCompletion("@players @spells @power @nothing")
 		@Syntax("<player/UUID> <spell> (-p:[power]) [spellArgs]")
 		@Description("Force a player to cast a spell. (You can optionally define power: -p:1.0)")
 		@HelpPermission(permission = Perm.COMMAND_CAST_AS)

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -188,6 +188,14 @@ public class MagicCommand extends BaseCommand {
 		return spellArgs.toArray(new String[0]);
 	}
 
+	private static boolean hasPowerArg(String[] args) {
+		for (String string : args) {
+			if (!string.startsWith("-p:")) continue;
+			return true;
+		}
+		return false;
+	}
+
 	private static float getPowerFromArgs(String[] args) {
 		float power = 1F;
 		for (String string : args) {
@@ -199,8 +207,12 @@ public class MagicCommand extends BaseCommand {
 	}
 
 	private static boolean noPermission(CommandSender sender, Perm perm) {
+		return noPermission(sender, perm, "You do not have permission to perform this command.");
+	}
+
+	private static boolean noPermission(CommandSender sender, Perm perm, String error) {
 		if (perm.has(sender)) return false;
-		sender.sendMessage(Util.colorize("&4Error: You do not have permission to perform this command."));
+		sender.sendMessage(Util.colorize("&4Error: " + error));
 		return true;
 	}
 
@@ -627,6 +639,12 @@ public class MagicCommand extends BaseCommand {
 
 			Spell spell = getSpell(issuer, args[0]);
 			if (spell == null) return;
+
+			// Get spell power if the user has permission.
+			if (hasPowerArg(args)) {
+				boolean noPowerPerm = noPermission(issuer.getIssuer(), Perm.COMMAND_CAST_POWER,"You do not have permission to use the power parameter.");
+				if (noPowerPerm) return;
+			}
 			float power = getPowerFromArgs(args);
 			String[] spellArgs = getCustomArgs(args, 1);
 
@@ -680,6 +698,12 @@ public class MagicCommand extends BaseCommand {
 			if (target == null) throw new ConditionFailedException("Entity not found.");
 			Spell spell = getSpell(issuer, args[1]);
 			if (spell == null) return;
+
+			// Get spell power if the user has permission.
+			if (hasPowerArg(args)) {
+				boolean noPowerPerm = noPermission(issuer.getIssuer(), Perm.COMMAND_CAST_POWER,"You do not have permission to use the power parameter.");
+				if (noPowerPerm) return;
+			}
 			float power = getPowerFromArgs(args);
 			String[] spellArgs = getCustomArgs(args, 2);
 			spell.cast(target, power, spellArgs);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -61,6 +61,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 	private int groundHitRadius;
 	private int groundVerticalHitRadius;
 	private Set<Material> groundMaterials;
+	private Set<Material> disallowedGroundMaterials;
 
 	private double maxDuration;
 	private double maxDistanceSquared;
@@ -173,6 +174,16 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 			for (Material material : Material.values()) {
 				if (BlockUtils.isPathable(material)) continue;
 				groundMaterials.add(material);
+			}
+		}
+		disallowedGroundMaterials = new HashSet<>();
+		List<String> disallowedGroundMaterialNames = getConfigStringList("disallowed-ground-materials", null);
+		if (disallowedGroundMaterialNames != null) {
+			for (String str : disallowedGroundMaterialNames) {
+				Material material = Util.getMaterial(str);
+				if (material == null) continue;
+				if (!material.isBlock()) continue;
+				disallowedGroundMaterials.add(material);
 			}
 		}
 
@@ -453,6 +464,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		tracker.setGroundHorizontalHitRadius(groundHitRadius);
 		tracker.setGroundVerticalHitRadius(groundVerticalHitRadius);
 		tracker.setGroundMaterials(groundMaterials);
+		tracker.setDisallowedGroundMaterials(disallowedGroundMaterials);
 
 		tracker.setHugSurface(hugSurface);
 		tracker.setHeightFromSurface(heightFromSurface);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
@@ -39,7 +39,7 @@ public class VariableCastSpell extends InstantSpell {
 
 			Spell toCast = MagicSpells.getSpellByInternalName(value);
 			if (toCast == null) {
-				sendMessage(player, strDoesntContainSpell, args);
+				sendMessage(player, strDoesntContainSpell);
 				return PostCastAction.NO_MESSAGES;
 			}
 			toCast.cast(player, power, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
@@ -9,33 +9,35 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.InstantSpell;
 
 public class VariableCastSpell extends InstantSpell {
-	
-	private String variableName;
-	private String strDoesntContainSpell;
-	
+
+	private final String variableName;
+	private final String strDoesntContainSpell;
+
 	public VariableCastSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		variableName = getConfigString("variable-name", null);
 		strDoesntContainSpell = getConfigString("str-doesnt-contain-spell", "You do not have a valid spell in memory");
 	}
-	
+
 	@Override
 	public void initializeVariables() {
 		super.initializeVariables();
-		
+
 		if (MagicSpells.getVariableManager().getVariable(variableName) == null) {
 			MagicSpells.error("VariableCastSpell '" + internalName + "' has an invalid variable-name defined!");
 		}
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL && livingEntity instanceof Player) {
 			Player player = (Player) livingEntity;
+
 			if (variableName == null) return PostCastAction.HANDLE_NORMALLY;
-			String strValue = MagicSpells.getVariableManager().getVariable(variableName).getStringValue(player);
-			Spell toCast = MagicSpells.getSpellByInternalName(strValue);
+			String value = MagicSpells.getVariableManager().getVariable(variableName).getStringValue(player);
+
+			Spell toCast = MagicSpells.getSpellByInternalName(value);
 			if (toCast == null) {
 				sendMessage(player, strDoesntContainSpell, args);
 				return PostCastAction.NO_MESSAGES;
@@ -44,5 +46,5 @@ public class VariableCastSpell extends InstantSpell {
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
 
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
@@ -16,6 +17,7 @@ import com.nisovin.magicspells.events.MagicSpellsEntityRegainHealthEvent;
 public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	private final double healAmount;
+	private final int healPercent;
 
 	private final boolean checkPlugins;
 	private final boolean cancelIfFull;
@@ -28,6 +30,10 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 		super(config, spellName);
 
 		healAmount = getConfigFloat("heal-amount", 10);
+		healPercent = getConfigInt("heal-percent", 0);
+		if (healPercent < 0 || healPercent > 100) {
+			MagicSpells.error("HealSpell '" + internalName + "' uses heal-percent outside bounds 0-100.");
+		}
 
 		checkPlugins = getConfigBoolean("check-plugins", true);
 		cancelIfFull = getConfigBoolean("cancel-if-full", true);
@@ -72,7 +78,11 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	private boolean heal(LivingEntity livingEntity, LivingEntity target, float power) {
 		double health = target.getHealth();
-		double amount = healAmount * power;
+		double amount;
+		if (healPercent == 0) amount = healAmount * power;
+		else {
+			amount = (Util.getMaxHealth(livingEntity) - health) * (healPercent/100F);
+		}
 
 		if (checkPlugins) {
 			MagicSpellsEntityRegainHealthEvent event = new MagicSpellsEntityRegainHealthEvent(target, amount, RegainReason.CUSTOM);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
@@ -14,19 +14,19 @@ import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.events.MagicSpellsEntityRegainHealthEvent;
 
 public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
-	
-	private double healAmount;
 
-	private boolean checkPlugins;
-	private boolean cancelIfFull;
+	private final double healAmount;
 
-	private String strMaxHealth;
+	private final boolean checkPlugins;
+	private final boolean cancelIfFull;
 
-	private ValidTargetChecker checker;
+	private final String strMaxHealth;
+
+	private final ValidTargetChecker checker;
 
 	public HealSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		healAmount = getConfigFloat("heal-amount", 10);
 
 		checkPlugins = getConfigBoolean("check-plugins", true);
@@ -69,19 +69,19 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 	public ValidTargetChecker getValidTargetChecker() {
 		return checker;
 	}
-	
+
 	private boolean heal(LivingEntity livingEntity, LivingEntity target, float power) {
 		double health = target.getHealth();
-		double amt = healAmount * power;
+		double amount = healAmount * power;
 
 		if (checkPlugins) {
-			MagicSpellsEntityRegainHealthEvent evt = new MagicSpellsEntityRegainHealthEvent(target, amt, RegainReason.CUSTOM);
-			EventUtil.call(evt);
-			if (evt.isCancelled()) return false;
-			amt = evt.getAmount();
+			MagicSpellsEntityRegainHealthEvent event = new MagicSpellsEntityRegainHealthEvent(target, amount, RegainReason.CUSTOM);
+			EventUtil.call(event);
+			if (event.isCancelled()) return false;
+			amount = event.getAmount();
 		}
 
-		health += amt;
+		health += amount;
 		if (health > Util.getMaxHealth(target)) health = Util.getMaxHealth(target);
 		target.setHealth(health);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
@@ -32,6 +32,7 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 	private final int duration;
 	private final boolean stunMonitor;
 	private final boolean stunBody;
+	private final boolean useTargetLocation;
 
 	private final Listener listener;
 
@@ -42,6 +43,7 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 		duration = (int) ((getConfigInt("duration", 200) / 20) * TimeUtil.MILLISECONDS_PER_SECOND);
 		stunMonitor = getConfigBoolean("stun-monitor", true);
 		stunBody = getConfigBoolean("stun-body", true);
+		useTargetLocation = getConfigBoolean("use-target-location", true);
 
 		listener = new StunListener();
 		stunnedLivingEntities = new HashMap<>();
@@ -147,7 +149,7 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (!shouldStun) return;
 
 			if (info.until > System.currentTimeMillis()) {
-				event.setTo(info.targetLocation);
+				event.setTo(useTargetLocation ? info.targetLocation : from);
 				return;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ProjectileTracker.java
@@ -62,6 +62,7 @@ public class ProjectileTracker implements Runnable {
 	private ProjectileTracker tracker;
 	private ParticleProjectileSpell spell;
 	private Set<Material> groundMaterials;
+	private Set<Material> disallowedGroundMaterials;
 	private ValidTargetList targetList;
 	private ModifierSet projectileModifiers;
 	private Map<String, Subspell> interactionSpells;
@@ -360,7 +361,7 @@ public class ProjectileTracker implements Runnable {
 		} else nearBlocks = BlockUtils.getNearbyBlocks(currentLocation, groundHorizontalHitRadius, groundVerticalHitRadius);
 
 		for (Block b : nearBlocks) {
-			if (!groundMaterials.contains(b.getType())) continue;
+			if (!groundMaterials.contains(b.getType()) || disallowedGroundMaterials.contains(b.getType())) continue;
 			if (hitGround && groundSpell != null) {
 				Util.setLocationFacingFromVector(previousLocation, currentVelocity);
 				groundSpell.castAtLocation(caster, previousLocation, power);
@@ -722,6 +723,14 @@ public class ProjectileTracker implements Runnable {
 
 	public void setGroundMaterials(Set<Material> groundMaterials) {
 		this.groundMaterials = groundMaterials;
+	}
+
+	public Set<Material> getDisallowedGroundMaterials() {
+		return disallowedGroundMaterials;
+	}
+
+	public void setDisallowedGroundMaterials(Set<Material> disallowedGroundMaterials) {
+		this.disallowedGroundMaterials = disallowedGroundMaterials;
 	}
 
 	public ValidTargetList getTargetList() {

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/AltitudeVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/AltitudeVariable.java
@@ -13,10 +13,20 @@ public class AltitudeVariable extends MetaVariable {
     public double getValue(String player) {
         Player p = PlayerNameUtils.getPlayerExact(player);
         if (p == null) return 0;
+        World world = p.getWorld();
+        Location location = p.getLocation().clone().subtract(0,1,0);
+        int x = location.getBlockX();
+        int y = location.getBlockY();
+        int z = location.getBlockZ();
 
-        Location location = p.getLocation();
-        World world = location.getWorld();
-        if (world != null) return location.getY() - world.getHighestBlockYAt(location);
+        // Try to avoid looping through block below the player.
+        int highestPoint = world.getHighestBlockYAt(location);
+        if (highestPoint < y) return y - highestPoint;
+
+        for (int i = y; i > 0; i--) {
+            if (world.getBlockAt(x, i, z).getType().isAir()) continue;
+            return y - i;
+        }
         return 0;
     }
 


### PR DESCRIPTION
* Added `magicspells.command.cast.power` permission which allows users to use the power command parameter (`-p:`).
* Added `stun-monitor` and `stun-body` toggles to StunSpell.
* Added `use-target-location` to StunSpell which controls whether the target should be teleported to the location they were at when they were targeted (previous and default behaviour) or if the location they moved **from**.
* Added `disallowed-ground-materials` to ParticleProjectileSpell - the ground blocks the projectile should ignore.
* Added `heal-percent` to HealSpell.
* Fixed the null error which occurs when the VariableCastSpell is cast.
* Fixed altitude meta variable returning wrong values.