### PR TITLE
SlotSelectedCondition now properly initializes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SlotSelectedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SlotSelectedCondition.java
@@ -1,3 +1,4 @@
+
 package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Location;
@@ -12,11 +13,13 @@ public class SlotSelectedCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var == null || var.isEmpty()) return false;
+		if (var == null || var.length() < 2) return false;
+		if (!super.initialize(var)) return false;
+
 		try {
-			slot = Integer.parseInt(var);
-			return true;
-		} catch (NumberFormatException | NullPointerException nfe) {
+			slot = Integer.parseInt(var.substring(1));
+			return slot >= 0 && slot <= 8;
+		} catch (NumberFormatException nfe) {
 			return false;
 		}
 	}


### PR DESCRIPTION
SlotSelectedCondition doesn't currently initialize properly - doesn't call OperatorCondition initializer, attempts to parse the operator with the slot number, and never checks if the slot number is valid.