### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Perm.java
+++ b/core/src/main/java/com/nisovin/magicspells/Perm.java
@@ -44,7 +44,7 @@ public enum Perm {
 	COMMAND_MAGICXP("magicspells.command.magicxp"),
 	COMMAND_CAST_POWER("magicspells.command.cast.power"),
 	COMMAND_CAST_SELF("magicspells.command.cast.self"),
-	COMMAND_CAST_SELF_HELPER("magicspells.command.cast.self.helper¸"),
+	COMMAND_CAST_SELF_HELPER("magicspells.command.cast.self.helper"),
 	COMMAND_CAST_AS("magicspells.command.cast.as"),
 	COMMAND_CAST_ON("magicspells.command.cast.on"),
 	COMMAND_CAST_AT("magicspells.command.cast.at"),

--- a/core/src/main/java/com/nisovin/magicspells/Perm.java
+++ b/core/src/main/java/com/nisovin/magicspells/Perm.java
@@ -44,6 +44,7 @@ public enum Perm {
 	COMMAND_MAGICXP("magicspells.command.magicxp"),
 	COMMAND_CAST_POWER("magicspells.command.cast.power"),
 	COMMAND_CAST_SELF("magicspells.command.cast.self"),
+	COMMAND_CAST_SELF_HELPER("magicspells.command.cast.self.helper¸"),
 	COMMAND_CAST_AS("magicspells.command.cast.as"),
 	COMMAND_CAST_ON("magicspells.command.cast.on"),
 	COMMAND_CAST_AT("magicspells.command.cast.at"),

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1629,10 +1629,6 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		MagicSpells.registerEvents(listener);
 	}
 
-	protected void unregisterEvents() {
-		unregisterEvents(this);
-	}
-
 	protected void unregisterEvents(Listener listener) {
 		HandlerList.unregisterAll(listener);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/InRegionCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/InRegionCondition.java
@@ -13,22 +13,19 @@ import com.sk89q.worldedit.bukkit.BukkitAdapter;
 import com.sk89q.worldguard.bukkit.WorldGuardPlugin;
 import com.sk89q.worldguard.protection.managers.RegionManager;
 import com.sk89q.worldguard.protection.regions.ProtectedRegion;
-import com.sk89q.worldguard.protection.regions.RegionContainer;
 
 public class InRegionCondition extends Condition {
 
-	private WorldGuardPlugin worldGuard;
 	private String worldName;
 	private String regionName;
-	private ProtectedRegion region;
-	
+
 	@Override
 	public boolean initialize(String var) {
 		if (var == null) return false;
-		
-		worldGuard = (WorldGuardPlugin) CompatBasics.getPlugin("WorldGuard");
+
+		WorldGuardPlugin worldGuard = (WorldGuardPlugin) CompatBasics.getPlugin("WorldGuard");
 		if (worldGuard == null || !worldGuard.isEnabled()) return false;
-		
+
 		String[] split = var.split(":");
 		if (split.length == 2) {
 			worldName = split[0];
@@ -50,24 +47,14 @@ public class InRegionCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, Location location) {
-		if (region == null) {
-			World world = Bukkit.getWorld(worldName);
+		World world = Bukkit.getWorld(worldName);
+		if (world == null) return false;
+		if (world != location.getWorld()) return false;
 
-			if (world == null) return false;
-			if (!world.equals(location.getWorld())) return false;
-
-			com.sk89q.worldedit.world.World aWorld = BukkitAdapter.adapt(world);
-
-			RegionContainer regionContainer = WorldGuard.getInstance().getPlatform().getRegionContainer();
-			RegionManager regionManager = regionContainer.get(aWorld);
-
-			if (regionManager == null) return false;
-			region = regionManager.getRegion(regionName);
-		}
-
-		if (region == null) return false;
-
-		return region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+		RegionManager regionManager = WorldGuard.getInstance().getPlatform().getRegionContainer().get(BukkitAdapter.adapt(world));
+		if (regionManager == null) return false;
+		ProtectedRegion region = regionManager.getRegion(regionName);
+		return region != null && region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -13,6 +13,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.command.CommandSender;
+import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.command.ConsoleCommandSender;
 
 import co.aikar.commands.*;
@@ -686,7 +687,9 @@ public class MagicCommand extends BaseCommand {
 			if (sender instanceof LivingEntity) {
 				LivingEntity livingEntity = (LivingEntity) sender;
 				if (!spell.canCastByCommand()) return;
-				if (!spell.isValidItemForCastCommand(livingEntity.getActiveItem())) return;
+				EntityEquipment equipment = livingEntity.getEquipment();
+				if (equipment == null) return;
+				if (!spell.isValidItemForCastCommand(equipment.getItemInMainHand())) return;
 				spell.cast(livingEntity, power, spellArgs);
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -671,7 +671,7 @@ public class MagicCommand extends BaseCommand {
 					MagicSpells.sendMessage(MagicSpells.getTextColor() + "You cannot cast this spell by commands.", player, null);
 					return;
 				}
-				if ((!spell.isHelperSpell() && !MagicSpells.getSpellbook(player).hasSpell(spell))) {
+				if (spell.isHelperSpell() && !Perm.COMMAND_CAST_SELF_HELPER.has(player) || !MagicSpells.getSpellbook(player).hasSpell(spell)) {
 					MagicSpells.sendMessage(MagicSpells.getTextColor() + MagicSpells.getStrUnknownSpell(), player, null);
 					return;
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -7,7 +7,7 @@ import java.util.UUID;
 import java.util.HashMap;
 import java.util.HashSet;
 
-import org.bukkit.Location;
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -67,6 +67,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected boolean cancelOnTakeDamage;
 	protected boolean cancelOnGiveDamage;
 	protected boolean cancelOnChangeWorld;
+	protected boolean cancelAffectsTarget;
 	protected boolean powerAffectsDuration;
 
 	private final boolean endSpellFromTarget;
@@ -112,6 +113,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		cancelOnTakeDamage = getConfigBoolean("cancel-on-take-damage", false);
 		cancelOnGiveDamage = getConfigBoolean("cancel-on-give-damage", false);
 		cancelOnChangeWorld = getConfigBoolean("cancel-on-change-world", false);
+		cancelAffectsTarget = getConfigBoolean("cancel-affects-target", true);
 		powerAffectsDuration = getConfigBoolean("power-affects-duration", true);
 
 		endSpellFromTarget = getConfigBoolean("end-spell-from-target", true);
@@ -189,9 +191,8 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 			target = targetInfo.getTarget();
 			power = targetInfo.getPower();
-		} else {
-			target = livingEntity;
 		}
+		else target = livingEntity;
 
 		PostCastAction action = activate(livingEntity, target, power, args, state == SpellCastState.NORMAL);
 		if (targeted && action == PostCastAction.HANDLE_NORMALLY) {
@@ -432,28 +433,57 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		return targeted;
 	}
 
+	private LivingEntity getWhoToCancel(LivingEntity livingEntity) {
+		// If the target was affected by the event, cancel them.
+		if (!targeted || cancelAffectsTarget) return isActiveAndNotExpired(livingEntity) ? livingEntity : null;
+
+		// targeted && !cancelAffectsTarget
+		// If the caster was affected by the event, cancel the target if they have the buff.
+
+		for (Map.Entry<UUID, LivingEntity> entry : lastCaster.entrySet()) {
+			// Check if the entity is the caster of this entry.
+			if (!entry.getValue().getUniqueId().equals(livingEntity.getUniqueId())) continue;
+
+			Entity entity = Bukkit.getEntity(entry.getKey());
+			if (!(entity instanceof LivingEntity)) return null;
+			LivingEntity target = (LivingEntity) entity;
+			return isActiveAndNotExpired(target) ? target : null;
+		}
+
+		return null;
+	}
+
 	public class DamageListener implements Listener {
 
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 		public void onEntityDamage(EntityDamageEvent e) {
-			Entity entity = e.getEntity();
-			if (!cancelOnTakeDamage) return;
-			if (entity instanceof LivingEntity && isActiveAndNotExpired((LivingEntity) entity)) {
-				turnOff((LivingEntity) entity);
+			if (cancelOnTakeDamage) {
+				Entity entity = e.getEntity();
+				if (!(entity instanceof LivingEntity)) return;
+				LivingEntity target = getWhoToCancel((LivingEntity) entity);
+				if (target == null) return;
+				turnOff(target);
 				return;
 			}
 
-			if (!(e instanceof EntityDamageByEntityEvent)) return;
+			if (cancelOnGiveDamage) {
+				if (!(e instanceof EntityDamageByEntityEvent)) return;
+				EntityDamageByEntityEvent evt = (EntityDamageByEntityEvent) e;
 
-			EntityDamageByEntityEvent evt = (EntityDamageByEntityEvent) e;
-			Entity damager = evt.getDamager();
-			if (damager instanceof LivingEntity && isActiveAndNotExpired((LivingEntity) damager)) {
-				turnOff((LivingEntity) damager);
-				return;
-			}
-			if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof LivingEntity) {
-				LivingEntity shooter = (LivingEntity) ((Projectile) damager).getShooter();
-				if (isActiveAndNotExpired(shooter)) turnOff(shooter);
+				Entity damager = evt.getDamager();
+				if (!(damager instanceof LivingEntity)) return;
+
+				LivingEntity target = getWhoToCancel((LivingEntity) damager);
+				if (target != null) {
+					turnOff(target);
+					return;
+				}
+
+				if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof LivingEntity) {
+					LivingEntity newTarget = getWhoToCancel((LivingEntity) ((Projectile) damager).getShooter());
+					if (newTarget == null) return;
+					turnOff(newTarget);
+				}
 			}
 		}
 
@@ -463,9 +493,9 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 		@EventHandler
 		public void onEntityDeath(EntityDeathEvent event) {
-			LivingEntity entity = event.getEntity();
+			LivingEntity entity = getWhoToCancel(event.getEntity());
+			if (entity == null) return;
 			if (entity instanceof Player) return;
-			if (!isActiveAndNotExpired(entity)) return;
 			turnOff(entity);
 		}
 
@@ -475,9 +505,9 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 		@EventHandler
 		public void onPlayerDeath(PlayerDeathEvent event) {
-			Player pl = event.getEntity();
-			if (!isActiveAndNotExpired(pl)) return;
-			turnOff(pl);
+			LivingEntity player = getWhoToCancel(event.getEntity());
+			if (player == null) return;
+			turnOff(player);
 		}
 
 	}
@@ -485,18 +515,12 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	public class TeleportListener implements Listener {
 
 		@EventHandler(priority=EventPriority.LOWEST, ignoreCancelled=true)
-		public void onTeleport(EntityTeleportEvent e) {
-			if (!(e.getEntity() instanceof LivingEntity)) return;
-			LivingEntity entity = (LivingEntity) e.getEntity();
-			if (!isActiveAndNotExpired(entity)) return;
-
-			Location locationFrom = e.getFrom();
-			Location locationTo = e.getTo();
-
-			if (LocationUtil.differentWorldDistanceGreaterThan(locationFrom, locationTo, 5)) {
-				turnOff(entity);
-			}
-
+		public void onTeleport(EntityTeleportEvent event) {
+			if (!(event.getEntity() instanceof LivingEntity)) return;
+			LivingEntity entity = getWhoToCancel((LivingEntity) event.getEntity());
+			if (entity == null) return;
+			if (!LocationUtil.differentWorldDistanceGreaterThan(event.getFrom(), event.getTo(), 5)) return;
+			turnOff(entity);
 		}
 
 	}
@@ -504,9 +528,10 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	public class ChangeWorldListener implements Listener {
 
 		@EventHandler(priority=EventPriority.LOWEST)
-		public void onChangeWorld(PlayerChangedWorldEvent e) {
-			Player pl = e.getPlayer();
-			if (isActiveAndNotExpired(pl)) turnOff(pl);
+		public void onChangeWorld(PlayerChangedWorldEvent event) {
+			LivingEntity player = getWhoToCancel(event.getPlayer());
+			if (player == null) return;
+			turnOff(player);
 		}
 
 	}
@@ -514,11 +539,13 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	public class SpellCastListener implements Listener {
 
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
-		public void onSpellCast(SpellCastEvent e) {
-			if (thisSpell == e.getSpell()) return;
-			if (e.getSpellCastState() != SpellCastState.NORMAL) return;
-			if (!isActiveAndNotExpired(e.getCaster())) return;
-			if (filter.check(e.getSpell())) turnOff(e.getCaster());
+		public void onSpellCast(SpellCastEvent event) {
+			if (thisSpell == event.getSpell()) return;
+			if (event.getSpellCastState() != SpellCastState.NORMAL) return;
+			LivingEntity entity = getWhoToCancel(event.getCaster());
+			if (entity == null) return;
+			if (filter.check(event.getSpell())) return;
+			turnOff(entity);
 		}
 
 	}
@@ -526,9 +553,10 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	public class QuitListener implements Listener {
 
 		@EventHandler(priority=EventPriority.MONITOR)
-		public void onQuit(PlayerQuitEvent e) {
-			Player pl = e.getPlayer();
-			if (isActiveAndNotExpired(pl)) turnOff(pl);
+		public void onQuit(PlayerQuitEvent event) {
+			LivingEntity player = getWhoToCancel(event.getPlayer());
+			if (player == null) return;
+			turnOff(player);
 		}
 
 	}
@@ -536,9 +564,10 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	public class JoinListener implements Listener {
 
 		@EventHandler
-		public void onJoin(PlayerJoinEvent e) {
-			Player pl = e.getPlayer();
-			if (isActiveAndNotExpired(pl)) turnOff(pl);
+		public void onJoin(PlayerJoinEvent event) {
+			LivingEntity player = getWhoToCancel(event.getPlayer());
+			if (player == null) return;
+			turnOff(player);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -69,6 +69,8 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected boolean cancelOnChangeWorld;
 	protected boolean powerAffectsDuration;
 
+	private final boolean endSpellFromTarget;
+
 	protected String strFade;
 	protected String spellOnEndName;
 	protected String spellOnCostName;
@@ -111,6 +113,8 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		cancelOnGiveDamage = getConfigBoolean("cancel-on-give-damage", false);
 		cancelOnChangeWorld = getConfigBoolean("cancel-on-change-world", false);
 		powerAffectsDuration = getConfigBoolean("power-affects-duration", true);
+
+		endSpellFromTarget = getConfigBoolean("end-spell-from-target", true);
 
 		strFade = getConfigString("str-fade", "");
 		spellOnEndName = getConfigString("spell-on-end", "");
@@ -391,7 +395,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		cancelEffects(EffectPosition.CASTER, entity.getUniqueId().toString());
 		stopEffects(entity);
 
-		if (spellOnEnd != null) spellOnEnd.cast(entity, 1f);
+		if (spellOnEnd != null) spellOnEnd.cast(endSpellFromTarget ? entity : getLastCaster(entity), 1f);
 		sendMessage(strFade, entity, null);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -398,6 +398,8 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 		if (spellOnEnd != null) spellOnEnd.cast(endSpellFromTarget ? entity : getLastCaster(entity), 1f);
 		sendMessage(strFade, entity, null);
+
+		lastCaster.remove(entity.getUniqueId());
 	}
 
 	public void stopEffects(LivingEntity livingEntity) {
@@ -441,6 +443,8 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		// If the caster was affected by the event, cancel the target if they have the buff.
 
 		for (Map.Entry<UUID, LivingEntity> entry : lastCaster.entrySet()) {
+			if (entry == null) continue;
+
 			// Check if the entity is the caster of this entry.
 			if (!entry.getValue().getUniqueId().equals(livingEntity.getUniqueId())) continue;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -102,6 +102,7 @@ public class PassiveSpell extends Spell {
 			listener.turnOff();
 			HandlerList.unregisterAll(listener);
 		}
+		passiveListeners.clear();
 	}
 
 	public void initializeListeners() {
@@ -138,6 +139,7 @@ public class PassiveSpell extends Spell {
 			listener.setEventPriority(priority);
 			listener.initialize(args);
 			MagicSpells.registerEvents(listener, priority);
+			passiveListeners.add(listener);
 			trigCount++;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -30,23 +30,23 @@ public class PassiveSpell extends Spell {
 	private final Random random = new Random();
 
 	private final List<PassiveListener> passiveListeners;
+	private final List<String> triggers;
+	private final List<String> spellNames;
 	private List<Subspell> spells;
-	private List<String> triggers;
-	private List<String> spellNames;
 
-	private ValidTargetList triggerList;
+	private final ValidTargetList targetList;
 
-	private int delay;
+	private final int delay;
 
-	private float chance;
+	private final float chance;
 
 	private boolean disabled = false;
-	private boolean ignoreCancelled;
-	private boolean castWithoutTarget;
-	private boolean sendFailureMessages;
-	private boolean cancelDefaultAction;
-	private boolean requireCancelledEvent;
-	private boolean cancelDefaultActionWhenCastFails;
+	private final boolean ignoreCancelled;
+	private final boolean castWithoutTarget;
+	private final boolean sendFailureMessages;
+	private final boolean cancelDefaultAction;
+	private final boolean requireCancelledEvent;
+	private final boolean cancelDefaultActionWhenCastFails;
 
 	public PassiveSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -59,8 +59,8 @@ public class PassiveSpell extends Spell {
 		if (config.isList("spells." + internalName + '.' + "can-trigger")) {
 			List<String> defaultTargets = getConfigStringList("can-trigger", null);
 			if (defaultTargets.isEmpty()) defaultTargets.add("players");
-			triggerList = new ValidTargetList(this, defaultTargets);
-		} else triggerList = new ValidTargetList(this, getConfigString("can-trigger", "players"));
+			targetList = new ValidTargetList(this, defaultTargets);
+		} else targetList = new ValidTargetList(this, getConfigString("can-trigger", "players"));
 
 		delay = getConfigInt("delay", -1);
 
@@ -152,8 +152,8 @@ public class PassiveSpell extends Spell {
 		return spells;
 	}
 
-	public ValidTargetList getTriggerList() {
-		return triggerList;
+	public ValidTargetList getTargetList() {
+		return targetList;
 	}
 
 	public boolean cancelDefaultAction() {
@@ -236,7 +236,7 @@ public class PassiveSpell extends Spell {
 	// DEBUG INFO: level 3, target cancelled (UL)
 	// DEBUG INFO: level 3, passive spell cancelled
 	private boolean activateSpells(LivingEntity caster, LivingEntity target, Location location, float basePower) {
-		if (!triggerList.canTarget(caster, true)) return false;
+		if (!targetList.canTarget(caster, true)) return false;
 		SpellCastState state = getCastState(caster);
 		if (caster instanceof Player) {
 			MagicSpells.debug(3, "Activating passive spell '" + name + "' for player " + caster.getName() + " (state: " + state + ')');

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -34,7 +34,7 @@ public class PassiveSpell extends Spell {
 	private final List<String> spellNames;
 	private List<Subspell> spells;
 
-	private final ValidTargetList targetList;
+	private final ValidTargetList triggerList;
 
 	private final int delay;
 
@@ -59,8 +59,8 @@ public class PassiveSpell extends Spell {
 		if (config.isList("spells." + internalName + '.' + "can-trigger")) {
 			List<String> defaultTargets = getConfigStringList("can-trigger", null);
 			if (defaultTargets.isEmpty()) defaultTargets.add("players");
-			targetList = new ValidTargetList(this, defaultTargets);
-		} else targetList = new ValidTargetList(this, getConfigString("can-trigger", "players"));
+			triggerList = new ValidTargetList(this, defaultTargets);
+		} else triggerList = new ValidTargetList(this, getConfigString("can-trigger", "players"));
 
 		delay = getConfigInt("delay", -1);
 
@@ -154,8 +154,8 @@ public class PassiveSpell extends Spell {
 		return spells;
 	}
 
-	public ValidTargetList getTargetList() {
-		return targetList;
+	public ValidTargetList getTriggerList() {
+		return triggerList;
 	}
 
 	public boolean cancelDefaultAction() {
@@ -238,7 +238,7 @@ public class PassiveSpell extends Spell {
 	// DEBUG INFO: level 3, target cancelled (UL)
 	// DEBUG INFO: level 3, passive spell cancelled
 	private boolean activateSpells(LivingEntity caster, LivingEntity target, Location location, float basePower) {
-		if (!targetList.canTarget(caster, true)) return false;
+		if (!triggerList.canTarget(caster, true)) return false;
 		SpellCastState state = getCastState(caster);
 		if (caster instanceof Player) {
 			MagicSpells.debug(3, "Activating passive spell '" + name + "' for player " + caster.getName() + " (state: " + state + ')');

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
@@ -44,15 +44,10 @@ public class TicksListener extends PassiveListener {
 			// ignored
 		}
 
-		for (Player player : Bukkit.getOnlinePlayers()) {
-			if (!player.isValid()) continue;
-			if (!hasSpell(player)) continue;
-			if (!canTrigger(player)) continue;
-			ticker.add(player);
-		}
-
 		for (World world : Bukkit.getWorlds()) {
 			for (LivingEntity livingEntity : world.getLivingEntities()) {
+				if (!livingEntity.isValid()) continue;
+				if (livingEntity instanceof Player && !hasSpell(livingEntity)) continue;
 				if (!canTrigger(livingEntity)) continue;
 				ticker.add(livingEntity);
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
@@ -31,11 +31,11 @@ public abstract class PassiveListener implements Listener {
 	}
 
 	public boolean canTrigger(LivingEntity livingEntity) {
-		return passiveSpell.getTargetList().canTarget(livingEntity, true);
+		return passiveSpell.getTriggerList().canTarget(livingEntity, true);
 	}
 
 	public boolean canTrigger(LivingEntity livingEntity, boolean ignoreGameMode) {
-		return passiveSpell.getTargetList().canTarget(livingEntity, ignoreGameMode);
+		return passiveSpell.getTriggerList().canTarget(livingEntity, ignoreGameMode);
 	}
 		
 	public boolean cancelDefaultAction(boolean casted) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
@@ -31,11 +31,11 @@ public abstract class PassiveListener implements Listener {
 	}
 
 	public boolean canTrigger(LivingEntity livingEntity) {
-		return passiveSpell.getTriggerList().canTarget(livingEntity, true);
+		return passiveSpell.getTargetList().canTarget(livingEntity, true);
 	}
 
 	public boolean canTrigger(LivingEntity livingEntity, boolean ignoreGameMode) {
-		return passiveSpell.getTriggerList().canTarget(livingEntity, ignoreGameMode);
+		return passiveSpell.getTargetList().canTarget(livingEntity, ignoreGameMode);
 	}
 		
 	public boolean cancelDefaultAction(boolean casted) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseInventorySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseInventorySpell.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
@@ -19,7 +20,14 @@ public class CloseInventorySpell extends TargetedSpell implements TargetedEntity
 
 	@Override
 	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL) close(livingEntity);
+		if (state == SpellCastState.NORMAL) {
+			TargetInfo<Player> targetInfo = getTargetedPlayer(livingEntity, power);
+			if (targetInfo == null) return noTarget(livingEntity);
+			Player target = targetInfo.getTarget();
+			if (target == null) return noTarget(livingEntity);
+			close(target);
+			playSpellEffects(livingEntity, target);
+		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
@@ -33,11 +41,15 @@ public class CloseInventorySpell extends TargetedSpell implements TargetedEntity
 		return close(target);
 	}
 
-	private boolean close(LivingEntity livingEntity) {
-		if (!(livingEntity instanceof Player)) return false;
-		Player player = (Player) livingEntity;
-		if (delay > 0) MagicSpells.scheduleDelayedTask(player::closeInventory, delay);
-		else player.closeInventory();
+	private boolean close(LivingEntity target) {
+		if (!(target instanceof Player)) return false;
+		close((Player) target);
 		return true;
 	}
+
+	private void close(Player target) {
+		if (delay > 0) MagicSpells.scheduleDelayedTask(target::closeInventory, delay);
+		else target.closeInventory();
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
@@ -1,22 +1,21 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.spelleffects.EffectPosition;
-import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.TargetInfo;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
-
-import java.util.HashSet;
 import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class TagEntitySpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private String operation;
-	private String tag;
-	private String varTag;
+	private final String operation;
+	private final String tag;
 
 	public TagEntitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -55,20 +54,18 @@ public class TagEntitySpell extends TargetedSpell implements TargetedEntitySpell
 	}
 
 	private void tag(LivingEntity caster, LivingEntity target) {
+		String varTag = tag;
+		if (caster instanceof Player && varTag.contains("%")) {
+			varTag = MagicSpells.doVariableReplacements((Player) caster, varTag);
+		}
 		switch (operation) {
 			case "add":
 			case "insert":
-				if (tag.contains("%") && caster instanceof Player) {
-					varTag = MagicSpells.doVariableReplacements((Player) caster, tag);
-					target.addScoreboardTag(varTag);
-				} else target.addScoreboardTag(tag);
+				target.addScoreboardTag(varTag);
 				break;
 			case "remove":
 			case "take":
-				if (tag.contains("%") && caster instanceof Player) {
-					varTag = MagicSpells.doVariableReplacements((Player) caster, tag);
-					target.removeScoreboardTag(varTag);
-				} else target.removeScoreboardTag(tag);
+				target.removeScoreboardTag(varTag);
 				break;
 			case "clear":
 				Set<String> tags = new HashSet<>(target.getScoreboardTags());


### PR DESCRIPTION
* Fixed `inregion` modifier condition. (by @niblexis)
* Added `end-spell-from-target` to Buff spell (boolean, `true`) - defines who casts the end spell.
* Added `cancel-affects-target` to Buff spell (boolean, `true`) - defines who should be the cause of the cancel events for the target's spell to cancel. When true, if the target is the cause of the cancel events, their buff will end. When false, if the caster is the cause, the target's buff will end.
* Fixed `cancel-on-give-damage` not working unless `cancel-on-take-damage` is also enabled.
* Made buff spell cancel events work with entities and players.
* Added `magicspells.command.cast.self.helper` permission node - allows casting helper spells without needing the spells.
* Fixed targeting on CloseInventory spell.
* Fixed targeting for players in scoreboard teams when friendly fire is off.
* Added configuration debugging to spell effects.
* Fixed duplicate `ticks` passive spells being activated for players.