### PR TITLE
Certain conditions don't work with 1.13+ materials

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemCondition.java
@@ -49,7 +49,7 @@ public class HasItemCondition extends Condition {
 					checkData = true;
 				}
 			} else {
-				material = Material.matchMaterial(var, true);
+				material = Material.matchMaterial(var);
 				checkData = false;
 			}
 			return true;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingCondition.java
@@ -53,7 +53,7 @@ public class HoldingCondition extends Condition {
 						checkData[i] = true;
 					}
 				} else {
-					ids[i] = Material.matchMaterial(vardata[i], true);
+					ids[i] = Material.matchMaterial(vardata[i]);
 					datas[i] = 0;
 					checkData[i] = false;
 				}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OffhandCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OffhandCondition.java
@@ -51,7 +51,7 @@ public class OffhandCondition extends Condition {
 						checkData[i] = true;
 					}
 				} else {
-					ids[i] = Material.matchMaterial(vardata[i], true);
+					ids[i] = Material.matchMaterial(vardata[i]);
 					datas[i] = 0;
 					checkData[i] = false;
 				}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingCondition.java
@@ -53,7 +53,7 @@ public class WearingCondition extends Condition {
 						checkData[i] = true;
 					}
 				} else {
-					ids[i] = Material.matchMaterial(vardata[i], true);
+					ids[i] = Material.matchMaterial(vardata[i]);
 					datas[i] = 0;
 					checkData[i] = false;
 				}


### PR DESCRIPTION
Certain conditions only check for legacy material names, which means they do not work with any of the materials added after the 1.13 update.