### PR TITLE
Implement caching for `getMagicItemDataFromItemStack`

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -34,6 +34,7 @@ import com.google.common.collect.HashMultimap;
 public class MagicItems {
 
 	private static final Map<String, MagicItem> magicItems = new HashMap<>();
+	private static final Map<ItemStack, MagicItemData> itemStackCache = new HashMap<>();
 
 	public static Map<String, MagicItem> getMagicItems() {
 		return magicItems;
@@ -67,9 +68,13 @@ public class MagicItems {
 	}
 
 	public static MagicItemData getMagicItemDataFromItemStack(ItemStack itemStack) {
-		MagicItemData data = new MagicItemData();
 		if (itemStack == null || BlockUtils.isAir(itemStack.getType())) return null;
 
+		MagicItemData cached = itemStackCache.get(itemStack);
+		// We can do this because itemStackCache doesn't have any null values
+		if (cached != null) return cached;
+
+		MagicItemData data = new MagicItemData();
 		ItemMeta meta = itemStack.getItemMeta();
 
 		// type
@@ -133,6 +138,7 @@ public class MagicItems {
 		// patterns
 		data = BannerHandler.process(itemStack, data);
 
+		itemStackCache.put(itemStack, data);
 		return data;
 	}
 


### PR DESCRIPTION
This most noticeably improves the runtime for spells that trigger modifiers that check for items in quick succession.

I'm not sure if we want to cache the other related methods or if we want to have some sort of expiry, but this is a start.