### PR TITLE
Spell filter support for passive triggers

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
@@ -1,14 +1,13 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.Set;
-import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
 import com.nisovin.magicspells.Spell.SpellCastState;
 import com.nisovin.magicspells.events.SpellCastEvent;
 import com.nisovin.magicspells.util.OverridePriority;
@@ -17,19 +16,43 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Optional trigger variable of comma separated list of internal spell names to accept
 public class SpellCastListener extends PassiveListener {
 
-	private final Set<String> spellNames = new HashSet<>();
+	private SpellFilter filter;
 
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
+		List<String> spells = new ArrayList<>();
+		List<String> deniedSpells = new ArrayList<>();
+		List<String> tagList = new ArrayList<>();
+		List<String> deniedTagList = new ArrayList<>();
+
 		String[] split = var.split(",");
 		for (String s : split) {
-			Spell sp = MagicSpells.getSpellByInternalName(s.trim());
-			if (sp == null) continue;
+			boolean denied = false;
+			s = s.trim();
 
-			spellNames.add(sp.getInternalName());
+			if (s.startsWith("!")) {
+				s = s.substring(1);
+				denied = true;
+			}
+
+			if (s.toLowerCase().startsWith("tag:")) {
+				if (denied) {
+					deniedTagList.add(s.substring(4));
+				} else {
+					tagList.add(s.substring(4));
+				}
+			} else {
+				if (denied) {
+					deniedSpells.add(s);
+				} else {
+					spells.add(s);
+				}
+			}
 		}
+
+		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
 	
 	@OverridePriority
@@ -41,11 +64,11 @@ public class SpellCastListener extends PassiveListener {
 		if (!canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
-		if (!spellNames.isEmpty() && !spellNames.contains(spell.getInternalName())) return;
+		if (!filter.check(spell)) return;
 
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (spell.equals(passiveSpell)) return;
-		boolean casted = passiveSpell.activate((Player) caster);
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
@@ -1,13 +1,13 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.Set;
-import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
 import com.nisovin.magicspells.Spell.PostCastAction;
 import com.nisovin.magicspells.Spell.SpellCastState;
 import com.nisovin.magicspells.util.OverridePriority;
@@ -17,19 +17,43 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Optional trigger variable of comma separated list of internal spell names to accept
 public class SpellCastedListener extends PassiveListener {
 
-	private final Set<String> spellNames = new HashSet<>();
-			
+	private SpellFilter filter;
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
+		List<String> spells = new ArrayList<>();
+		List<String> deniedSpells = new ArrayList<>();
+		List<String> tagList = new ArrayList<>();
+		List<String> deniedTagList = new ArrayList<>();
+
 		String[] split = var.split(",");
 		for (String s : split) {
-			Spell sp = MagicSpells.getSpellByInternalName(s.trim());
-			if (sp == null) continue;
+			boolean denied = false;
+			s = s.trim();
 
-			spellNames.add(sp.getInternalName());
+			if (s.startsWith("!")) {
+				s = s.substring(1);
+				denied = true;
+			}
+
+			if (s.toLowerCase().startsWith("tag:")) {
+				if (denied) {
+					deniedTagList.add(s.substring(4));
+				} else {
+					tagList.add(s.substring(4));
+				}
+			} else {
+				if (denied) {
+					deniedSpells.add(s);
+				} else {
+					spells.add(s);
+				}
+			}
 		}
+
+		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
 	
 	@OverridePriority
@@ -42,7 +66,7 @@ public class SpellCastedListener extends PassiveListener {
 		if (!canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
-		if (!spellNames.isEmpty() && !spellNames.contains(spell.getInternalName())) return;
+		if (!filter.check(spell)) return;
 
 		if (spell.equals(passiveSpell)) return;
 		passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetListener.java
@@ -1,13 +1,12 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.Set;
-import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 
-import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
@@ -15,19 +14,43 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Optional trigger variable of comma separated list of internal spell names to accept
 public class SpellTargetListener extends PassiveListener {
 
-	private final Set<String> spellNames = new HashSet<>();
+	private SpellFilter filter;
 
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
+		List<String> spells = new ArrayList<>();
+		List<String> deniedSpells = new ArrayList<>();
+		List<String> tagList = new ArrayList<>();
+		List<String> deniedTagList = new ArrayList<>();
+
 		String[] split = var.split(",");
 		for (String s : split) {
-			Spell sp = MagicSpells.getSpellByInternalName(s.trim());
-			if (sp == null) continue;
+			boolean denied = false;
+			s = s.trim();
 
-			spellNames.add(sp.getInternalName());
+			if (s.startsWith("!")) {
+				s = s.substring(1);
+				denied = true;
+			}
+
+			if (s.toLowerCase().startsWith("tag:")) {
+				if (denied) {
+					deniedTagList.add(s.substring(4));
+				} else {
+					tagList.add(s.substring(4));
+				}
+			} else {
+				if (denied) {
+					deniedSpells.add(s);
+				} else {
+					spells.add(s);
+				}
+			}
 		}
+
+		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
 	
 	@OverridePriority
@@ -36,7 +59,7 @@ public class SpellTargetListener extends PassiveListener {
 		LivingEntity caster = event.getCaster();
 		if (!hasSpell(caster)) return;
 		if (!canTrigger(caster)) return;
-		if (!spellNames.isEmpty() && !spellNames.contains(event.getSpell().getInternalName())) return;
+		if (!filter.check(event.getSpell())) return;
 
 		if (!isCancelStateOk(event.isCancelled())) return;
 		boolean casted = passiveSpell.activate(caster, event.getTarget());

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
@@ -1,13 +1,12 @@
 package com.nisovin.magicspells.spells.passive;
 
-import java.util.Set;
-import java.util.HashSet;
+import java.util.List;
+import java.util.ArrayList;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 
-import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
@@ -15,19 +14,43 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Optional trigger variable of comma separated list of internal spell names to accept
 public class SpellTargetedListener extends PassiveListener {
 
-	private final Set<String> spellNames = new HashSet<>();
+	private SpellFilter filter;
 
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
+		List<String> spells = new ArrayList<>();
+		List<String> deniedSpells = new ArrayList<>();
+		List<String> tagList = new ArrayList<>();
+		List<String> deniedTagList = new ArrayList<>();
+
 		String[] split = var.split(",");
 		for (String s : split) {
-			Spell sp = MagicSpells.getSpellByInternalName(s.trim());
-			if (sp == null) continue;
+			boolean denied = false;
+			s = s.trim();
 
-			spellNames.add(sp.getInternalName());
+			if (s.startsWith("!")) {
+				s = s.substring(1);
+				denied = true;
+			}
+
+			if (s.toLowerCase().startsWith("tag:")) {
+				if (denied) {
+					deniedTagList.add(s.substring(4));
+				} else {
+					tagList.add(s.substring(4));
+				}
+			} else {
+				if (denied) {
+					deniedSpells.add(s);
+				} else {
+					spells.add(s);
+				}
+			}
 		}
+
+		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
 	
 	@OverridePriority
@@ -36,8 +59,7 @@ public class SpellTargetedListener extends PassiveListener {
 		LivingEntity target = event.getTarget();
 		if (!hasSpell(target)) return;
 		if (!canTrigger(target)) return;
-
-		if (!spellNames.isEmpty() && !spellNames.contains(event.getSpell().getInternalName())) return;
+		if (!filter.check(event.getSpell())) return;
 
 		if (!isCancelStateOk(event.isCancelled())) return;
 		boolean casted = passiveSpell.activate(target, event.getCaster());


### PR DESCRIPTION
SpellFilter support for the `spellcast`, `spellcasted`, `spelltarget`, `spelltargeted` and `spellselect` passive triggers. Tags are prepended by `tag:` and blacklisted members are prepended by `!`.