### PR TITLE
Cast mode and time fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -162,7 +162,7 @@ public class Subspell {
 			EventUtil.call(spellTarget);
 			if (!spellTarget.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				success = ((TargetedEntitySpell) spell).castAtEntity(livingEntity, target, spellCast.getPower());
-				spell.postCast(spellCast, success ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED);
+				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
 			}
 			return success;
 		}
@@ -208,7 +208,7 @@ public class Subspell {
 			EventUtil.call(spellLocation);
 			if (!spellLocation.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				success = ((TargetedLocationSpell) spell).castAtLocation(livingEntity, target, spellCast.getPower());
-				spell.postCast(spellCast, success ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED);
+				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
 			}
 			return success;
 		}
@@ -256,7 +256,7 @@ public class Subspell {
 			EventUtil.call(spellTarget);
 			if (!spellLocation.isCancelled() && !spellTarget.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(livingEntity, from, target, spellCast.getPower());
-				spell.postCast(spellCast, success ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED);
+				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
 			}
 			return success;
 		}
@@ -282,5 +282,5 @@ public class Subspell {
 
 		return ret;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
@@ -64,7 +64,7 @@ public class SpellCastListener extends PassiveListener {
 		if (!canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
-		if (!filter.check(spell)) return;
+		if (filter != null && !filter.check(spell)) return;
 
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (spell.equals(passiveSpell)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
@@ -66,7 +66,7 @@ public class SpellCastedListener extends PassiveListener {
 		if (!canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
-		if (!filter.check(spell)) return;
+		if (filter != null && !filter.check(spell)) return;
 
 		if (spell.equals(passiveSpell)) return;
 		passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
@@ -58,8 +58,7 @@ public class SpellSelectListener extends PassiveListener {
 		if (!(event.getCaster() instanceof Player)) return;
 		Player player = (Player) event.getCaster();
 		if (!hasSpell(player)) return;
-		if (!filter.check(event.getSpell())) return;
-
+		if (filter != null && !filter.check(event.getSpell())) return;
 
 		passiveSpell.activate(player);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
@@ -59,7 +59,7 @@ public class SpellTargetedListener extends PassiveListener {
 		LivingEntity target = event.getTarget();
 		if (!hasSpell(target)) return;
 		if (!canTrigger(target)) return;
-		if (!filter.check(event.getSpell())) return;
+		if (filter != null && !filter.check(event.getSpell())) return;
 
 		if (!isCancelStateOk(event.isCancelled())) return;
 		boolean casted = passiveSpell.activate(target, event.getCaster());


### PR DESCRIPTION
- Messages for invalid spell cast states are now sent when using a cast mode of full.
- Delayed spell casts using `cast-time` now:
  - No longer send interrupt messages when the spell has already casted.
  - Properly unregister event listeners when interrupted in all cases.
  - Interrupt when a player moves.
- Spell filters on `spellcast`, `spellcasted`, `spelltarget`, `spelltargeted` and `spellselect` passive triggers should no longer produce an error when the filter is empty.