### PR TITLE
Bugfix & Refactor

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -12,6 +12,7 @@ repositories {
 dependencies {
     shadow group: "org.apache.commons", name: "commons-math3", version: "3.6.1"
     shadow "com.github.Chronoken:EffectLib:fdd144ae6b"
+    shadow "com.github.Xezard:XGlow:c886344de3"
     shadow "com.github.PaperMC:PaperLib:1c3c36b188"
     shadow "co.aikar:acf-paper:0.5.0-SNAPSHOT"
     shadow "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
@@ -35,6 +36,7 @@ shadowJar {
     setArchivesBaseName("MagicSpells")
     relocate("org.apache.commons.math3", "com.nisovin.magicspells.shaded.org.apache.commons")
     relocate("de.slikey.effectlib", "com.nisovin.magicspells.shaded.effectlib")
+    relocate("ru.xezard.glow", "com.nisovin.magicspells.shaded.xglow")
     relocate("kotlin", "com.nisovin.magicspells.shaded.kotlin")
     relocate("co.aikar.commands", "com.nisovin.magicspells.shaded.acf")
     relocate("co.aikar.locales", "com.nisovin.magicspells.shaded.locales")

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
@@ -1,8 +1,5 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
-import java.util.Set;
-import java.util.HashSet;
-
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
@@ -12,39 +9,34 @@ import com.nisovin.magicspells.castmodifiers.Condition;
 
 public class HasScoreboardTagCondition extends Condition {
 
-    private String var;
     private String tag;
-    private boolean isVar;
-    private Set<String> enttags = new HashSet<>();
 
     @Override
     public boolean initialize(String var) {
         if (var == null || var.isEmpty()) return false;
-        if (var.contains("%var:")) isVar = true;
-        this.var = var;
         tag = var;
         return true;
     }
 
     @Override
-    public boolean check(LivingEntity livingEntity) {
-        enttags = livingEntity.getScoreboardTags();
-        if (!(livingEntity instanceof Player)) return enttags.contains(tag);
-        if (isVar) tag = MagicSpells.doVariableReplacements((Player) livingEntity, var);
-        return enttags.contains(tag);
+    public boolean check(LivingEntity caster) {
+        return checkTags(caster);
     }
 
     @Override
-    public boolean check(LivingEntity livingEntity, LivingEntity target) {
-        enttags = target.getScoreboardTags();
-        if (!(target instanceof Player)) return enttags.contains(tag);
-        if (isVar) tag = MagicSpells.doVariableReplacements((Player) target, var);
-        return enttags.contains(tag);
+    public boolean check(LivingEntity caster, LivingEntity target) {
+        return checkTags(target);
     }
 
     @Override
     public boolean check(LivingEntity livingEntity, Location location) {
         return false;
+    }
+
+    private boolean checkTags(LivingEntity entity) {
+        String localTag = tag;
+        if (entity instanceof Player && localTag.contains("%")) localTag = MagicSpells.doVariableReplacements((Player) entity, localTag);
+        return entity.getScoreboardTags().contains(localTag);
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.block.data.BlockData;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
@@ -25,7 +26,7 @@ import com.nisovin.magicspells.events.MagicSpellsBlockPlaceEvent;
 
 public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell {
 
-	private Map<Block, Material> blocks;
+	private Map<Block, BlockData> blocks;
 
 	private boolean replaceAll;
 	private List<Material> replace;
@@ -123,7 +124,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 	public void turnOff() {
 		if (replaceDuration > 0) {
 			for (Block b : blocks.keySet()) {
-				b.setType(blocks.get(b));
+				b.setBlockData(blocks.get(b));
 			}
 		}
 
@@ -170,7 +171,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 
 						if (replaceBlacklist.contains(block.getType())) continue;
 
-						blocks.put(block, block.getType());
+						blocks.put(block, block.getBlockData());
 						Block finalBlock = block;
 						BlockState previousState = block.getState();
 
@@ -181,7 +182,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 							Player player = (Player) caster;
 							Block against = target.clone().add(target.getDirection()).getBlock();
 							if (block.equals(against)) against = block.getRelative(BlockFace.DOWN);
-							MagicSpellsBlockPlaceEvent event = new MagicSpellsBlockPlaceEvent(block, previousState, against, player.getEquipment().getItemInMainHand(), player, true);
+							MagicSpellsBlockPlaceEvent event = new MagicSpellsBlockPlaceEvent(block, previousState, against, player.getInventory().getItemInMainHand(), player, true);
 							EventUtil.call(event);
 							if (event.isCancelled()) {
 								previousState.update(true);
@@ -193,14 +194,14 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 						// Break block.
 						if (replaceDuration > 0) {
 							MagicSpells.scheduleDelayedTask(() -> {
-								Material previousMat = blocks.remove(finalBlock);
-								if (previousMat == null) return;
+								BlockData previous = blocks.remove(finalBlock);
+								if (previous == null) return;
 								if (checkPlugins && caster instanceof Player) {
 									MagicSpellsBlockBreakEvent event = new MagicSpellsBlockBreakEvent(finalBlock, (Player) caster);
 									EventUtil.call(event);
 									if (event.isCancelled()) return;
 								}
-								finalBlock.setType(previousMat);
+								finalBlock.setBlockData(previous);
 								playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, finalBlock.getLocation());
 							}, replaceDuration);
 						}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.destroystokyo.paper.entity.ai.MobGoals;
-import com.nisovin.magicspells.util.ai.LookAtEntityGoal;
+
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.Material;
@@ -37,6 +37,7 @@ import com.nisovin.magicspells.util.EntityData;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.ai.LookAtEntityGoal;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
@@ -1,0 +1,137 @@
+package com.nisovin.magicspells.spells.targeted.ext;
+
+import java.util.*;
+
+import org.bukkit.Bukkit;
+import org.bukkit.ChatColor;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
+import ru.xezard.glow.data.glow.Glow;
+
+import org.apache.commons.lang.RandomStringUtils;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
+
+// NOTE: ProtocolLib is required for this spell class.
+public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
+
+	private final Map<UUID, Glow> glowingEntities;
+
+	private final boolean toggle;
+	private final int duration;
+	private final boolean clientSide;
+	private final boolean async;
+	private final int updatePeriod;
+	private final List<ChatColor> colors;
+
+	public GlowSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+		glowingEntities = new HashMap<>();
+
+		toggle = getConfigBoolean("toggle", false);
+		duration = getConfigInt("duration", 0);
+		clientSide = getConfigBoolean("client-side", false);
+		async = getConfigBoolean("async", true);
+		updatePeriod = getConfigInt("update-period", 0);
+
+		colors = new ArrayList<>();
+		List<String> colorNames = getConfigStringList("colors", null);
+		if (colorNames == null || colorNames.isEmpty()) {
+			colorNames = new ArrayList<>();
+			colorNames.add(getConfigString("color", "white"));
+		}
+		for (String colorName : colorNames) {
+			colorName = colorName.trim().replaceAll(" ", "_").toUpperCase();
+			try {
+				colors.add(ChatColor.valueOf(colorName));
+			} catch (IllegalArgumentException e) {
+				MagicSpells.log("GlowSpell '" + internalName + "' has an invalid color defined': " + colorName);
+			}
+		}
+
+	}
+
+	@Override
+	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
+		if (state == SpellCastState.NORMAL && livingEntity instanceof Player) {
+			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(livingEntity, power);
+			if (targetInfo == null) return noTarget(livingEntity);
+			LivingEntity target = targetInfo.getTarget();
+
+			sendMessages(livingEntity, target);
+			glow(livingEntity, target, targetInfo.getPower());
+			return PostCastAction.NO_MESSAGES;
+		}
+		return PostCastAction.HANDLE_NORMALLY;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		if (!validTargetList.canTarget(caster, target)) return false;
+		glow(caster, target, power);
+		return true;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		if (!validTargetList.canTarget(target)) return false;
+		glow(null, target, power);
+		return true;
+	}
+
+	@Override
+	public void turnOff() {
+		glowingEntities.values().forEach(Glow::destroy);
+		glowingEntities.clear();
+	}
+
+	private boolean isGlowing(LivingEntity entity) {
+		return glowingEntities.containsKey(entity.getUniqueId());
+	}
+
+	private void glow(LivingEntity caster, LivingEntity target, float power) {
+		int duration = Math.round(this.duration * power);
+		UUID uuid = target.getUniqueId();
+
+		// Handle reapply and toggle.
+		if (isGlowing(target)) {
+			glowingEntities.remove(uuid).destroy();
+			if (toggle) return;
+		}
+
+		Glow glow = Glow.builder()
+				.plugin(MagicSpells.getInstance())
+				// We should name the team something random, but within name length bounds.
+				.name(RandomStringUtils.random(16, true, true))
+				// From config
+				.asyncAnimation(async)
+				.updatePeriod(updatePeriod)
+				.animatedColor(colors)
+				.build();
+		glow.addHolders(target);
+		if (clientSide && caster instanceof Player) glow.display((Player) caster);
+		else glow.display(Bukkit.getOnlinePlayers());
+
+		glowingEntities.put(uuid, glow);
+		if (duration > 0) {
+			MagicSpells.scheduleDelayedTask(() -> {
+				// Safeguard
+				if (glow.getViewers().isEmpty()) return;
+				glow.destroy();
+				glowingEntities.remove(uuid);
+			}, duration);
+		}
+
+		// Play effects.
+		if (caster != null) playSpellEffects(caster, target);
+		else playSpellEffects(EffectPosition.TARGET, target);
+		playSpellEffectsBuff(target, entity -> entity instanceof LivingEntity && isGlowing((LivingEntity) entity));
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -15,10 +15,10 @@ import java.util.function.Predicate;
 import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.*;
-import org.bukkit.entity.Entity;
 import org.bukkit.inventory.*;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.potion.PotionEffect;
@@ -26,18 +26,19 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.inventory.meta.SkullMeta;
 
+import org.jetbrains.annotations.Nullable;
+
+import org.apache.commons.math3.util.FastMath;
+
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
+
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.CastUtil.CastMode;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.handlers.PotionEffectHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-
-import com.destroystokyo.paper.profile.PlayerProfile;
-import com.destroystokyo.paper.profile.ProfileProperty;
-
-import org.apache.commons.math3.util.FastMath;
-import org.jetbrains.annotations.Nullable;
 
 public class Util {
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ai/LookAtEntityGoal.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ai/LookAtEntityGoal.java
@@ -1,20 +1,23 @@
 package com.nisovin.magicspells.util.ai;
 
-import com.destroystokyo.paper.entity.ai.Goal;
-import com.destroystokyo.paper.entity.ai.GoalKey;
-import com.destroystokyo.paper.entity.ai.GoalType;
-import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.Util;
+import org.bukkit.entity.Mob;
 import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Mob;
+
 import org.jetbrains.annotations.NotNull;
 
+import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
+
 import java.util.EnumSet;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.function.Predicate;
+import java.util.concurrent.ThreadLocalRandom;
+
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
 
 public class LookAtEntityGoal implements Goal<Mob> {
     private final Mob mob;


### PR DESCRIPTION
* Fixed variable replacement on `hasscoreboardtag` modifier condition (var).
* Destroy spell calls block break events.
* Replace spell will now store BlockData instead of Material.
* Added Glow Spell (Targeted Entity Spell, `.targeted.ext.GlowSpell`):
  * `toggle` - (Boolean, false)
  * `duration` - (Integer, 0) - In server ticks. 0 defines everlasting duration.
  * `client-side` - (Boolean, false)
  * `async` - (Boolean, true)
  * `update-period` - (Integer, 10) - In server ticks. Defines update interval of colors. Should be greater than 0 for multiple colors.
  * `colors` - (String list, white) - Should be a list of Chat Colors, but you could list just one.
* The `jump` passive trigger is now cancellable. Note the disclaimer:
> Cancelling this event causes the entity to be teleported back to the location they jumped from. This may cause unintended effects such as velocity being reset for the entity. The effect of the player's jump attempt is not visible to other players, but it is visible to the player doing the jump action.