### PR TITLE
Bug Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -156,14 +156,22 @@ public class Subspell {
 		}
 
 		if (mode == CastMode.FULL && livingEntity != null) {
-			boolean success = false;
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, null);
-			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
-			EventUtil.call(spellTarget);
-			if (!spellTarget.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				success = ((TargetedEntitySpell) spell).castAtEntity(livingEntity, target, spellCast.getPower());
-				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			if (spellCast == null) return false;
+
+			boolean success = false;
+			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
+				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
+				EventUtil.call(spellTarget);
+
+				if (!spellTarget.isCancelled())
+					success = ((TargetedEntitySpell) spell).castAtEntity(livingEntity, target, spellCast.getPower());
+				else
+					return false;
 			}
+
+			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+
 			return success;
 		}
 
@@ -202,14 +210,22 @@ public class Subspell {
 		}
 
 		if (mode == CastMode.FULL && livingEntity != null) {
-			boolean success = false;
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, null);
-			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, livingEntity, target, power);
-			EventUtil.call(spellLocation);
-			if (!spellLocation.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				success = ((TargetedLocationSpell) spell).castAtLocation(livingEntity, target, spellCast.getPower());
-				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			if (spellCast == null) return false;
+
+			boolean success = false;
+			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
+				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, livingEntity, target, power);
+				EventUtil.call(spellLocation);
+
+				if (!spellLocation.isCancelled())
+					success = ((TargetedLocationSpell) spell).castAtLocation(livingEntity, target, spellCast.getPower());
+				else
+					return false;
 			}
+
+			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+
 			return success;
 		}
 
@@ -248,16 +264,24 @@ public class Subspell {
 		}
 
 		if (mode == CastMode.FULL && livingEntity != null) {
-			boolean success = false;
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, MagicSpells.NULL_ARGS);
-			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
-			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, livingEntity, from, power);
-			EventUtil.call(spellLocation);
-			EventUtil.call(spellTarget);
-			if (!spellLocation.isCancelled() && !spellTarget.isCancelled() && spellCast != null && spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(livingEntity, from, target, spellCast.getPower());
-				spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			if (spellCast == null) return false;
+
+			boolean success = false;
+			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
+				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
+				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, livingEntity, from, power);
+				EventUtil.call(spellLocation);
+				EventUtil.call(spellTarget);
+
+				if (!spellLocation.isCancelled() && !spellTarget.isCancelled())
+					success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(livingEntity, from, target, spellCast.getPower());
+				else
+					return false;
 			}
+
+			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+
 			return success;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -159,6 +159,7 @@ public class Subspell {
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, null);
 			if (spellCast == null) return false;
 
+			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
@@ -166,11 +167,11 @@ public class Subspell {
 
 				if (!spellTarget.isCancelled())
 					success = ((TargetedEntitySpell) spell).castAtEntity(livingEntity, target, spellCast.getPower());
-				else
-					return false;
+
+				if (!success) action = PostCastAction.ALREADY_HANDLED;
 			}
 
-			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			spell.postCast(spellCast, action);
 
 			return success;
 		}
@@ -213,6 +214,7 @@ public class Subspell {
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, null);
 			if (spellCast == null) return false;
 
+			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, livingEntity, target, power);
@@ -220,11 +222,11 @@ public class Subspell {
 
 				if (!spellLocation.isCancelled())
 					success = ((TargetedLocationSpell) spell).castAtLocation(livingEntity, target, spellCast.getPower());
-				else
-					return false;
+
+				if (!success) action = PostCastAction.ALREADY_HANDLED;
 			}
 
-			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			spell.postCast(spellCast, action);
 
 			return success;
 		}
@@ -267,6 +269,7 @@ public class Subspell {
 			SpellCastEvent spellCast = spell.preCast(livingEntity, power * subPower, MagicSpells.NULL_ARGS);
 			if (spellCast == null) return false;
 
+			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
 				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, livingEntity, target, power);
@@ -276,11 +279,11 @@ public class Subspell {
 
 				if (!spellLocation.isCancelled() && !spellTarget.isCancelled())
 					success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(livingEntity, from, target, spellCast.getPower());
-				else
-					return false;
+
+				if (!success) action = PostCastAction.ALREADY_HANDLED;
 			}
 
-			spell.postCast(spellCast, PostCastAction.HANDLE_NORMALLY);
+			spell.postCast(spellCast, action);
 
 			return success;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierSet.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierSet.java
@@ -88,7 +88,10 @@ public class ModifierSet {
 	public void apply(ManaChangeEvent event) {
 		for (Modifier modifier : modifiers) {
 			boolean cont = modifier.apply(event);
-			if (!cont) break;
+			if (!cont) {
+				if (modifier.getStrModifierFailed() != null) MagicSpells.sendMessage(modifier.getStrModifierFailed(), event.getPlayer(), MagicSpells.NULL_ARGS);
+				break;
+			}
 		}
 	}
 
@@ -105,14 +108,20 @@ public class ModifierSet {
 	public void apply(MagicSpellsGenericPlayerEvent event) {
 		for (Modifier modifier : modifiers) {
 			boolean cont = modifier.apply(event);
-			if (!cont) break;
+			if (!cont) {
+				if (modifier.getStrModifierFailed() != null) MagicSpells.sendMessage(modifier.getStrModifierFailed(), event.getPlayer(), MagicSpells.NULL_ARGS);
+				break;
+			}
 		}
 	}
 
 	public void apply(SpellTargetLocationEvent event) {
 		for (Modifier modifier : modifiers) {
 			boolean cont = modifier.apply(event);
-			if (!cont) break;
+			if (!cont) {
+				if (modifier.getStrModifierFailed() != null) MagicSpells.sendMessage(modifier.getStrModifierFailed(), event.getCaster(), MagicSpells.NULL_ARGS);
+				break;
+			}
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -8,10 +8,10 @@ import java.util.Collection;
 
 import org.bukkit.Material;
 import org.bukkit.inventory.ItemFlag;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.attribute.Attribute;
-import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.attribute.AttributeModifier;
 import org.bukkit.configuration.ConfigurationSection;
@@ -140,6 +140,13 @@ public class MagicItems {
 
 		itemStackCache.put(itemStack, data);
 		return data;
+	}
+
+	public static MagicItemData getMagicItemDataFromString(String str) {
+		if (str == null) return null;
+		if (magicItems.containsKey(str)) return magicItems.get(str).getMagicItemData();
+
+		return MagicItemDataParser.parseMagicItemData(str);
 	}
 
 	public static MagicItem getMagicItemFromString(String str) {


### PR DESCRIPTION
- `TakeDamageListener` now properly checks for magic items (previously would only check for damage causes).
- Support for damage causes in `GiveDamageListener`.
- Added `getMagicItemDataFromString(String)` to parse `MagicItemData` without creating an unused `MagicItem`.
- Messages sent for any `SpellCasteState` other than `SpellCasteState.NORMAL` did not send for targeted subspells on `CastMode.FULL`.
- Modifier fail messages now sent if specified for `ManaChangeEvent`, `MagicSpellsGenericPlayerEvent` and `SpellTargetLocationEvent`.