### PR TITLE
MagicItem Changes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -491,13 +492,13 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 						default:
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 
-							MagicItem magicItem = MagicItems.getMagicItemFromString(data[0]);
-							if (magicItem == null) {
+							MagicItemData itemData = MagicItems.getMagicItemDataFromString(data[0]);
+							if (itemData == null) {
 								MagicSpells.error("Failed to process cost value for " + internalName + " spell: " + costVal);
 								continue;
 							}
 
-							reagents.addItem(new SpellReagents.ReagentItem(magicItem, amt));
+							reagents.addItem(new SpellReagents.ReagentItem(itemData, amt));
 							break;
 					}
 				} catch (Exception e) {

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells;
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
-import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Material;
@@ -63,6 +62,7 @@ import com.nisovin.magicspells.util.ValidTargetChecker;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.util.managers.VariableManager;
 import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 import com.nisovin.magicspells.spelleffects.trackers.EffectTracker;

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -497,14 +497,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 								continue;
 							}
 
-							ItemStack item = magicItem.getItemStack();
-							if (item == null) {
-								MagicSpells.error("Failed to process cost value for " + internalName + " spell: " + costVal);
-								continue;
-							}
-
-							item.setAmount(amt);
-							reagents.addItem(new SpellReagents.ReagentItem(item, amt));
+							reagents.addItem(new SpellReagents.ReagentItem(magicItem, amt));
 							break;
 					}
 				} catch (Exception e) {
@@ -995,7 +988,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		if (!requireCastItemOnCommand || castItems == null) return true;
 		if (item == null && castItems.length == 1 && BlockUtils.isAir(castItems[0].getType())) return true;
 		for (CastItem castItem : castItems) {
-			if (castItem.equals(item)) return true;
+			if (castItem.equals(new CastItem(item))) return true;
 		}
 		return false;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ChestContainsCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ChestContainsCondition.java
@@ -10,7 +10,6 @@ import com.nisovin.magicspells.util.BlockUtils;
 import com.nisovin.magicspells.util.MagicLocation;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -28,10 +27,7 @@ public class ChestContainsCondition extends Condition {
 			String[] vars = var.split(",");
 			location = new MagicLocation(vars[0], Integer.parseInt(vars[1]), Integer.parseInt(vars[2]), Integer.parseInt(vars[3]));
 
-			MagicItem magicItem = MagicItems.getMagicItemFromString(vars[4]);
-			if (magicItem == null) return false;
-
-			itemData = magicItem.getMagicItemData();
+			itemData = MagicItems.getMagicItemDataFromString(vars[4].trim());
 			return itemData != null;
 		} catch (Exception e) {
 			DebugHandler.debugGeneral(e);
@@ -65,7 +61,7 @@ public class ChestContainsCondition extends Condition {
 		for (ItemStack item : items) {
 			MagicItemData data = MagicItems.getMagicItemDataFromItemStack(item);
 			if (data == null) continue;
-			if (data.equals(itemData)) return true;
+			if (itemData.matches(data)) return true;
 		}
 
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Location;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.Inventory;
@@ -12,7 +11,6 @@ import org.bukkit.inventory.EntityEquipment;
 import com.nisovin.magicspells.util.InventoryUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
@@ -20,9 +18,6 @@ import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
 public class HasItemAmountCondition extends OperatorCondition {
 
 	private MagicItemData itemData;
-
-	private ItemStack item;
-
 	private int amount;
 	
 	@Override
@@ -40,20 +35,12 @@ public class HasItemAmountCondition extends OperatorCondition {
 		}
 
 		try {
-			MagicItem magicItem = MagicItems.getMagicItemFromString(args[1]);
-			if (magicItem == null) return false;
-
-			item = magicItem.getItemStack();
-			if (item == null) return false;
-
-			itemData = magicItem.getMagicItemData();
-			if (itemData == null) return false;
+			itemData = MagicItems.getMagicItemDataFromString(args[1]);
+			return itemData != null;
 		} catch (Exception e) {
 			DebugHandler.debugGeneral(e);
 			return false;
 		}
-
-		return true;
 	}
 
 	@Override
@@ -70,15 +57,8 @@ public class HasItemAmountCondition extends OperatorCondition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, Location location) {
-		Block target = location.getBlock();
-		if (target == null) return false;
-		
-		BlockState targetState = target.getState();
-		if (targetState == null) return false;
-		
-		if (targetState instanceof InventoryHolder) return check(((InventoryHolder) targetState).getInventory());
-		
-		return false;
+		BlockState targetState = location.getBlock().getState();
+		return targetState instanceof InventoryHolder && check(((InventoryHolder) targetState).getInventory());
 	}
 
 	private boolean check(Inventory inventory) {
@@ -112,9 +92,8 @@ public class HasItemAmountCondition extends OperatorCondition {
 
 		MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(item);
 		if (magicItemData == null) return false;
-		if (!magicItemData.equals(itemData)) return false;
 
-		return true;
+		return itemData.matches(magicItemData);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
@@ -61,6 +61,9 @@ public class HasItemAmountCondition extends OperatorCondition {
 		for (ItemStack i : inventory.getContents()) {
 			if (!isSimilar(i)) continue;
 			c += i.getAmount();
+
+			if (moreThan && c > amount) return true;
+			if (lessThan && c >= amount) return false;
 		}
 
 		if (equals) return c == amount;
@@ -74,6 +77,9 @@ public class HasItemAmountCondition extends OperatorCondition {
 		for (ItemStack i : InventoryUtil.getEquipmentItems(entityEquipment)) {
 			if (!isSimilar(i)) continue;
 			c += i.getAmount();
+
+			if (moreThan && c > amount) return true;
+			if (lessThan && c >= amount) return false;
 		}
 
 		if (equals) return c == amount;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
@@ -34,13 +34,8 @@ public class HasItemAmountCondition extends OperatorCondition {
 			return false;
 		}
 
-		try {
-			itemData = MagicItems.getMagicItemDataFromString(args[1]);
-			return itemData != null;
-		} catch (Exception e) {
-			DebugHandler.debugGeneral(e);
-			return false;
-		}
+		itemData = MagicItems.getMagicItemDataFromString(args[1]);
+		return itemData != null;
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemPreciseCondition.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Location;
-import org.bukkit.block.Block;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.Inventory;
@@ -11,7 +10,6 @@ import org.bukkit.inventory.EntityEquipment;
 
 import com.nisovin.magicspells.util.InventoryUtil;
 import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -22,11 +20,8 @@ public class HasItemPreciseCondition extends Condition {
 	
 	@Override
 	public boolean initialize(String var) {
-		MagicItem magicItem = MagicItems.getMagicItemFromString(var.trim());
-		if (magicItem == null) return false;
-
-		itemData = magicItem.getMagicItemData();
-		return true;
+		itemData = MagicItems.getMagicItemDataFromString(var);
+		return itemData != null;
 	}
 
 	@Override
@@ -43,11 +38,7 @@ public class HasItemPreciseCondition extends Condition {
 	
 	@Override
 	public boolean check(LivingEntity livingEntity, Location location) {
-		Block target = location.getBlock();
-		if (target == null) return false;
-		
-		BlockState targetState = target.getState();
-		if (targetState == null) return false;
+		BlockState targetState = location.getBlock().getState();
 		return targetState instanceof InventoryHolder && check(((InventoryHolder) targetState).getInventory());
 	}
 
@@ -58,7 +49,7 @@ public class HasItemPreciseCondition extends Condition {
 		for (ItemStack itemStack : inventory.getContents()) {
 			MagicItemData data = MagicItems.getMagicItemDataFromItemStack(itemStack);
 			if (data == null) continue;
-			if (data.equals(itemData)) found = true;
+			if (itemData.matches(data)) found = true;
 		}
 
 		return found;
@@ -71,7 +62,7 @@ public class HasItemPreciseCondition extends Condition {
 		for (ItemStack itemStack : InventoryUtil.getEquipmentItems(entityEquipment)) {
 			MagicItemData data = MagicItems.getMagicItemDataFromItemStack(itemStack);
 			if (data == null) continue;
-			if (data.equals(itemData)) found = true;
+			if (itemData.matches(data)) found = true;
 		}
 
 		return found;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemPreciseCondition.java
@@ -45,27 +45,25 @@ public class HasItemPreciseCondition extends Condition {
 	private boolean check(Inventory inventory) {
 		if (inventory == null) return false;
 
-		boolean found = false;
 		for (ItemStack itemStack : inventory.getContents()) {
 			MagicItemData data = MagicItems.getMagicItemDataFromItemStack(itemStack);
 			if (data == null) continue;
-			if (itemData.matches(data)) found = true;
+			if (itemData.matches(data)) return true;
 		}
 
-		return found;
+		return false;
 	}
 
 	private boolean check(EntityEquipment entityEquipment) {
 		if (entityEquipment == null) return false;
 
-		boolean found = false;
 		for (ItemStack itemStack : InventoryUtil.getEquipmentItems(entityEquipment)) {
 			MagicItemData data = MagicItems.getMagicItemDataFromItemStack(itemStack);
 			if (data == null) continue;
-			if (itemData.matches(data)) found = true;
+			if (itemData.matches(data)) return true;
 		}
 
-		return found;
+		return false;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingPreciseCondition.java
@@ -28,8 +28,8 @@ public class HoldingPreciseCondition extends Condition {
 	
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		EntityEquipment equip = target.getEquipment();
-		return equip != null && check(equip.getItemInMainHand());
+		EntityEquipment eq = target.getEquipment();
+		return eq != null && check(eq.getItemInMainHand());
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoldingPreciseCondition.java
@@ -6,7 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.EntityEquipment;
 
 import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -17,17 +16,14 @@ public class HoldingPreciseCondition extends Condition {
 	
 	@Override
 	public boolean initialize(String var) {
-		MagicItem magicItem = MagicItems.getMagicItemFromString(var.trim());
-		if (magicItem == null) return false;
-
-		itemData = magicItem.getMagicItemData();
-		return true;
+		itemData = MagicItems.getMagicItemDataFromString(var);
+		return itemData != null;
 	}
 
 	@Override
 	public boolean check(LivingEntity livingEntity) {
-		ItemStack item = livingEntity.getEquipment().getItemInMainHand();
-		return check(item);
+		EntityEquipment eq = livingEntity.getEquipment();
+		return eq != null && check(eq.getItemInMainHand());
 	}
 	
 	@Override
@@ -45,7 +41,7 @@ public class HoldingPreciseCondition extends Condition {
 		MagicItemData data = MagicItems.getMagicItemDataFromItemStack(item);
 		if (data == null) return false;
 
-		return data.equals(itemData);
+		return itemData.matches(data);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
@@ -24,14 +24,15 @@ public class HoveringWithCondition extends Condition {
 	@Override
 	public boolean check(LivingEntity livingEntity) {
 		if (!(livingEntity instanceof Player)) return false;
+
 		Player player = (Player) livingEntity;
-		ItemStack itemStack = player.getOpenInventory().getCursor();
-		if (itemStack == null) return false;
+		ItemStack itemCursor = player.getOpenInventory().getCursor();
+		if (itemCursor == null) return false;
 
-		MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(itemStack);
-		if (magicItemData == null) return false;
+		MagicItemData cursorData = MagicItems.getMagicItemDataFromItemStack(itemCursor);
+		if (cursorData == null) return false;
 
-		return itemData.matches(magicItemData);
+		return itemData.matches(cursorData);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
@@ -6,7 +6,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -18,16 +17,8 @@ public class HoveringWithCondition extends Condition {
 	public boolean initialize(String var) {
 		if (var == null || var.isEmpty()) return false;
 
-		MagicItem magicItem = MagicItems.getMagicItemFromString(var);
-		if (magicItem == null) return false;
-
-		ItemStack itemStack = magicItem.getItemStack();
-		if (itemStack == null) return false;
-
-		itemData = magicItem.getMagicItemData();
-		if (itemData == null) return false;
-
-		return true;
+		itemData = MagicItems.getMagicItemDataFromString(var);
+		return itemData != null;
 	}
 
 	@Override
@@ -40,7 +31,7 @@ public class HoveringWithCondition extends Condition {
 		MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(itemStack);
 		if (magicItemData == null) return false;
 
-		return magicItemData.equals(itemData);
+		return itemData.matches(magicItemData);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingPreciseCondition.java
@@ -6,7 +6,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.EntityEquipment;
 
 import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -16,11 +15,8 @@ public class WearingPreciseCondition extends Condition {
 	
 	@Override
 	public boolean initialize(String var) {
-		MagicItem magicItem = MagicItems.getMagicItemFromString(var.trim());
-		if (magicItem == null) return false;
-
-		itemData = magicItem.getMagicItemData();
-		return true;
+		itemData = MagicItems.getMagicItemDataFromString(var);
+		return itemData != null;
 	}
 	
 	@Override
@@ -48,7 +44,7 @@ public class WearingPreciseCondition extends Condition {
 		MagicItemData data = MagicItems.getMagicItemDataFromItemStack(item);
 		if (data == null) return false;
 
-		return data.equals(itemData);
+		return itemData.matches(data);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingPreciseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingPreciseCondition.java
@@ -26,13 +26,13 @@ public class WearingPreciseCondition extends Condition {
 	
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		EntityEquipment equip = target.getEquipment();
-		if (equip == null) return false;
+		EntityEquipment eq = target.getEquipment();
+		if (eq == null) return false;
 
-		if (check(equip.getHelmet())) return true;
-		if (check(equip.getChestplate())) return true;
-		if (check(equip.getLeggings())) return true;
-		return check(equip.getBoots());
+		if (check(eq.getHelmet())) return true;
+		if (check(eq.getChestplate())) return true;
+		if (check(eq.getLeggings())) return true;
+		return check(eq.getBoots());
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
@@ -59,8 +59,6 @@ public class DanceCastListener implements Listener {
 
 		String path = "general.";
 
-//		MagicItem magicItem = MagicItems.getMagicItemFromString(config.getString(path + "dance-cast-item", "MUSIC_DISC_13"));
-//		if (magicItem != null) danceCastWand = new CastItem(magicItem.getItemStack());
 		danceCastWand = new CastItem(config.getString(path + "dance-cast-item", "MUSIC_DISC_13"));
 		if (!danceCastWand.isTypeValid()) danceCastWand = null;
 

--- a/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
@@ -23,8 +23,6 @@ import com.nisovin.magicspells.util.PlayerNameUtils;
 import com.nisovin.magicspells.Spell.PostCastAction;
 import com.nisovin.magicspells.Spell.SpellCastState;
 import com.nisovin.magicspells.Spell.SpellCastResult;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
-import com.nisovin.magicspells.util.magicitems.MagicItems;
 
 public class DanceCastListener implements Listener {
 	
@@ -61,8 +59,10 @@ public class DanceCastListener implements Listener {
 
 		String path = "general.";
 
-		MagicItem magicItem = MagicItems.getMagicItemFromString(config.getString(path + "dance-cast-item", "MUSIC_DISC_13"));
-		if (magicItem != null) danceCastWand = new CastItem(magicItem.getItemStack());
+//		MagicItem magicItem = MagicItems.getMagicItemFromString(config.getString(path + "dance-cast-item", "MUSIC_DISC_13"));
+//		if (magicItem != null) danceCastWand = new CastItem(magicItem.getItemStack());
+		danceCastWand = new CastItem(config.getString(path + "dance-cast-item", "MUSIC_DISC_13"));
+		if (!danceCastWand.isTypeValid()) danceCastWand = null;
 
 		duration = config.getInt(path + "dance-cast-duration", 200);
 		dynamicCasting = config.getBoolean(path + "dance-cast-dynamic", false);
@@ -121,7 +121,7 @@ public class DanceCastListener implements Listener {
 	public void onInteract(PlayerInteractEvent event) {
 		if (!event.hasItem()) return;
 		if (danceCastWand == null) return;
-		if (!danceCastWand.equals(event.getItem())) return;
+		if (!danceCastWand.equals(new CastItem(event.getItem()))) return;
 		
 		Action action = event.getAction();
 		Player player = event.getPlayer();

--- a/core/src/main/java/com/nisovin/magicspells/spells/OffhandCooldownSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/OffhandCooldownSpell.java
@@ -15,13 +15,11 @@ import com.nisovin.magicspells.util.TimeUtil;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
-import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
 public class OffhandCooldownSpell extends InstantSpell {
 
 	private List<Player> players = new ArrayList<>();
 
-	private MagicItemData itemData;
 
 	private ItemStack item;
 
@@ -33,16 +31,10 @@ public class OffhandCooldownSpell extends InstantSpell {
 
 		if (isConfigString("item")) {
 			MagicItem magicItem = MagicItems.getMagicItemFromString(getConfigString("item", "stone"));
-			if (magicItem != null) {
-				item = magicItem.getItemStack();
-				itemData = magicItem.getMagicItemData();
-			}
+			if (magicItem != null) item = magicItem.getItemStack();
 		} else if (isConfigSection("item")) {
 			MagicItem magicItem = MagicItems.getMagicItemFromSection(getConfigSection("item"));
-			if (magicItem != null) {
-				item = magicItem.getItemStack();
-				itemData = magicItem.getMagicItemData();
-			}
+			if (magicItem != null) item = magicItem.getItemStack();
 		}
 
 		spellToCheckName = getConfigString("spell", "");
@@ -54,7 +46,7 @@ public class OffhandCooldownSpell extends InstantSpell {
 
 		spellToCheck = MagicSpells.getSpellByInternalName(spellToCheckName);
 
-		if (spellToCheck == null || item == null || itemData == null) return;
+		if (spellToCheck == null || item == null) return;
 		
 		MagicSpells.scheduleRepeatingTask(() -> {
 			Iterator<Player> iter = players.iterator();
@@ -71,11 +63,12 @@ public class OffhandCooldownSpell extends InstantSpell {
 				PlayerInventory inventory = pl.getInventory();
 				ItemStack off = inventory.getItemInOffHand();
 
-				MagicItemData offItemData = MagicItems.getMagicItemDataFromItemStack(off);
-				if (offItemData == null) continue;
+				if (!off.isSimilar(item)) {
+					off = item.clone();
+					inventory.setItemInOffHand(off);
+				}
 
 				off.setAmount(amt);
-				if (!offItemData.equals(itemData)) inventory.setItemInOffHand(item.clone());
 			}
 		}, TimeUtil.TICKS_PER_SECOND, TimeUtil.TICKS_PER_SECOND);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -27,8 +27,8 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.spells.CommandSpell;
 import com.nisovin.magicspells.util.SpellReagents;
+import com.nisovin.magicspells.spells.CommandSpell;
 
 public class ScrollSpell extends CommandSpell {
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -221,9 +221,11 @@ public class ScrollSpell extends CommandSpell {
 			lore.add(Util.colorize(strScrollSubtext.replace("%s", spell.getName()).replace("%u", (uses >= 0 ? uses + "" : "many"))));
 			meta.setLore(lore);
 		}
+
+		ItemUtil.addFakeEnchantment(meta);
+
 		item.setItemMeta(meta);
 		Util.setLoreData(item, internalName + ':' + spell.getInternalName() + (uses > 0 ? "," + uses : ""));
-		item = ItemUtil.addFakeEnchantment(item);
 		return item;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureSpell.java
@@ -609,7 +609,7 @@ public class ConjureSpell extends InstantSpell implements TargetedEntitySpell, T
 		@EventHandler(priority = EventPriority.LOWEST)
 		private void onRightClick(PlayerInteractEvent event) {
 			if (!event.hasItem()) return;
-			ItemStack item = event.getPlayer().getEquipment().getItemInMainHand();
+			ItemStack item = event.getItem();
 			ExpirationResult result = updateExpiresLineIfNeeded(item);
 			if (result == ExpirationResult.EXPIRED) {
 				event.getPlayer().getEquipment().setItemInMainHand(null);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
@@ -13,7 +13,6 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.handlers.DebugHandler;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
@@ -38,7 +37,7 @@ public class UnconjureSpell extends InstantSpell {
 
 		for (String itemString : itemNames) {
 			UnconjuredItem unconjuredItem = new UnconjuredItem(itemString);
-			if (unconjuredItem.magicItem == null) {
+			if (unconjuredItem.magicItemData == null) {
 				MagicSpells.error("UnconjureSpell '" + internalName + "' has an invalid magic item specified: " + itemString);
 				continue;
 			}
@@ -79,9 +78,8 @@ public class UnconjureSpell extends InstantSpell {
 	private boolean filterItems(ItemStack[] oldItems) {
 		boolean stop = false;
 		for (UnconjuredItem unconjuredItem : items) {
-			if (unconjuredItem.magicItem == null) continue;
-			MagicItemData unconjuredItemData = unconjuredItem.magicItem.getMagicItemData();
-			if (unconjuredItemData == null) continue;
+			if (unconjuredItem.magicItemData == null) continue;
+			MagicItemData unconjuredItemData = unconjuredItem.magicItemData;
 
 			// Only look for an ItemStack with specified quantity.
 			if (unconjuredItem.hasSpecialQuantity) {
@@ -123,13 +121,13 @@ public class UnconjureSpell extends InstantSpell {
 	private static class UnconjuredItem {
 
 		private boolean hasSpecialQuantity = false;
-		private MagicItem magicItem;
+		private MagicItemData magicItemData;
 		private int amount;
 
 		public UnconjuredItem(String itemString) {
 			String[] splits = itemString.split(" ");
-			MagicItem magicItem = MagicItems.getMagicItemFromString(splits[0]);
-			if (magicItem == null || splits.length == 1) return;
+			magicItemData = MagicItems.getMagicItemDataFromString(splits[0]);
+			if (magicItemData == null || splits.length == 1) return;
 
 			try {
 				amount = Integer.parseInt(splits[1]);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.PlayerInventory;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
@@ -37,8 +38,8 @@ public class UnconjureSpell extends InstantSpell {
 
 		for (String itemString : itemNames) {
 			UnconjuredItem unconjuredItem = new UnconjuredItem(itemString);
-			if (unconjuredItem.item == null) {
-				MagicSpells.error("UnconjureSpell '" + internalName + "' has an invalid item specified: " + itemString);
+			if (unconjuredItem.magicItem == null) {
+				MagicSpells.error("UnconjureSpell '" + internalName + "' has an invalid magic item specified: " + itemString);
 				continue;
 			}
 			items.add(unconjuredItem);
@@ -78,8 +79,8 @@ public class UnconjureSpell extends InstantSpell {
 	private boolean filterItems(ItemStack[] oldItems) {
 		boolean stop = false;
 		for (UnconjuredItem unconjuredItem : items) {
-			if (unconjuredItem.item == null) continue;
-			MagicItemData unconjuredItemData = MagicItems.getMagicItemDataFromItemStack(unconjuredItem.item);
+			if (unconjuredItem.magicItem == null) continue;
+			MagicItemData unconjuredItemData = unconjuredItem.magicItem.getMagicItemData();
 			if (unconjuredItemData == null) continue;
 
 			// Only look for an ItemStack with specified quantity.
@@ -88,8 +89,8 @@ public class UnconjureSpell extends InstantSpell {
 					if (oldItems[i] == null) continue;
 					MagicItemData oldItemData = MagicItems.getMagicItemDataFromItemStack(oldItems[i]);
 					if (oldItemData == null) continue;
-					if (!unconjuredItemData.equals(oldItemData)) continue;
-					if (unconjuredItem.item.getAmount() != oldItems[i].getAmount()) continue;
+					if (!unconjuredItemData.matches(oldItemData)) continue;
+					if (unconjuredItem.amount != oldItems[i].getAmount()) continue;
 					oldItems[i] = null;
 					// True is only returned if the search is for an item with specific
 					// quantity. If the item is found, this won't search for the item in
@@ -104,7 +105,7 @@ public class UnconjureSpell extends InstantSpell {
 					if (oldItems[i] == null) continue;
 					MagicItemData oldItemData = MagicItems.getMagicItemDataFromItemStack(oldItems[i]);
 					if (oldItemData == null) continue;
-					if (unconjuredItemData.equals(oldItemData)) oldItems[i] = null;
+					if (unconjuredItemData.matches(oldItemData)) oldItems[i] = null;
 				}
 			}
 		}
@@ -121,22 +122,21 @@ public class UnconjureSpell extends InstantSpell {
 
 	private static class UnconjuredItem {
 
-		private ItemStack item;
 		private boolean hasSpecialQuantity = false;
+		private MagicItem magicItem;
+		private int amount;
 
 		public UnconjuredItem(String itemString) {
 			String[] splits = itemString.split(" ");
 			MagicItem magicItem = MagicItems.getMagicItemFromString(splits[0]);
-			if (magicItem == null) return;
+			if (magicItem == null || splits.length == 1) return;
 
-			item = magicItem.getItemStack();
-			// If it's null, then stop. The item won't make
-			// it to the list anyway.
-			if (item == null) return;
-
-			if (splits.length == 1) return;
-			item.setAmount(Integer.parseInt(splits[1]));
-			hasSpecialQuantity = true;
+			try {
+				amount = Integer.parseInt(splits[1]);
+				hasSpecialQuantity = true;
+			} catch (NumberFormatException e) {
+				DebugHandler.debugNumberFormat(e);
+			}
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
@@ -3,12 +3,12 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
-import com.nisovin.magicspells.MagicSpells;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
@@ -10,7 +10,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 
 import com.nisovin.magicspells.util.OverridePriority;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
@@ -3,12 +3,12 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
-import com.nisovin.magicspells.MagicSpells;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
@@ -59,7 +59,7 @@ public class HotbarSelectListener extends PassiveListener {
 
 	private boolean contains(MagicItemData itemData) {
 		for (MagicItemData data : items) {
-			if (data.equals(itemData)) return true;
+			if (data.matches(itemData)) return true;
 		}
 		return false;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
+import com.nisovin.magicspells.MagicSpells;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
@@ -22,31 +23,39 @@ public class HotbarSelectListener extends PassiveListener {
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
-		MagicItemData itemData = null;
-		MagicItem magicItem = MagicItems.getMagicItemFromString(var.trim());
-		if (magicItem != null) itemData = magicItem.getMagicItemData();
-		if (itemData == null) return;
 
-		items.add(itemData);
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in hotbarselect trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
+
+			items.add(itemData);
+		}
 	}
 	
 	@OverridePriority
 	@EventHandler
 	public void onPlayerScroll(PlayerItemHeldEvent event) {
-		Player player = event.getPlayer();
-		ItemStack item = player.getInventory().getItem(event.getNewSlot());
-		if (item == null || item.getType().isAir()) return;
-
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-		if (itemData == null) return;
-		if (!items.isEmpty() && !contains(itemData)) return;
-
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		if (!items.isEmpty()) {
+			ItemStack item = caster.getInventory().getItem(event.getNewSlot());
+			if (item == null) return;
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
+		}
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 	private boolean contains(MagicItemData itemData) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
@@ -10,7 +10,6 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 
 import com.nisovin.magicspells.util.OverridePriority;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
@@ -1,94 +1,83 @@
 package com.nisovin.magicspells.spells.passive;
 
-import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.inventory.InventoryAction;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class InventoryClickListener extends PassiveListener {
 
-	private MagicClick click;
+	MagicItemData itemCurrent = null;
+	MagicItemData itemCursor = null;
+	InventoryAction action = null;
 
 	@Override
 	public void initialize(String var) {
-		InventoryAction action = null;
-		ItemStack itemCurrent = null;
-		ItemStack itemCursor = null;
-		if (var != null && !var.isEmpty()) {
-			String[] splits = var.split(" ");
-			if (!splits[0].equals("null")) action = InventoryAction.valueOf(splits[0].toUpperCase());
-			if (splits.length > 1 && !splits[1].equals("null")) {
-				MagicItem magicItem = MagicItems.getMagicItemFromString(splits[1]);
-				if (magicItem != null) itemCurrent = magicItem.getItemStack();
-			}
-			if (splits.length > 2) {
-				MagicItem magicItem = MagicItems.getMagicItemFromString(splits[2]);
-				if (magicItem != null) itemCursor = magicItem.getItemStack();
+		if (var == null || var.isEmpty()) return;
+
+		String[] splits = var.split("\\|");
+
+		if (!splits[0].equals("null")) action = InventoryAction.valueOf(splits[0].toUpperCase());
+
+		if (splits.length > 1 && !splits[1].isEmpty() && !splits[1].equals("null")) {
+			itemCurrent = MagicItems.getMagicItemDataFromString(splits[1]);
+
+			if (itemCurrent == null) {
+				MagicSpells.error("Invalid magic item '" + splits[1] + "' in inventoryclick trigger on passive spell '" + passiveSpell.getInternalName() + "'");
 			}
 		}
-		click = new MagicClick(action, itemCurrent, itemCursor);
+
+		if (splits.length > 2 && !splits[2].isEmpty() && !splits[2].equals("null")) {
+			itemCursor = MagicItems.getMagicItemDataFromString(splits[2]);
+
+			if (itemCursor == null) {
+				MagicSpells.error("Invalid magic item '" + splits[2] + "' in inventoryclick trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+			}
+		}
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onInvClick(InventoryClickEvent event) {
-		Player player = Bukkit.getPlayer(event.getWhoClicked().getUniqueId());
-		if (player == null) return;
-		if (!hasSpell(player)) return;
+		if (!(event.getWhoClicked() instanceof Player)) return;
+
+		Player player = (Player) event.getWhoClicked();
+		if (!hasSpell(player) || !canTrigger(player)) return;
 
 		// Valid action, but not used.
-		if (click.action != null && !event.getAction().equals(click.action)) return;
+		if (action != null && !event.getAction().equals(action)) return;
 
 		// Valid clicked item, but not used.
-		if (click.itemCurrent != null) {
+		if (itemCurrent != null) {
 			ItemStack item = event.getCurrentItem();
 			if (item == null) return;
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
 			if (itemData == null) return;
 
-			MagicItemData currentItemData = MagicItems.getMagicItemDataFromItemStack(click.itemCurrent);
-			if (currentItemData == null) return;
-			if (!currentItemData.equals(itemData)) return;
+			if (!itemCurrent.matches(itemData)) return;
 		}
+
 		// Valid cursor item, but not used.
-		if (click.itemCursor != null) {
+		if (itemCursor != null) {
 			ItemStack item = event.getCursor();
 			if (item == null) return;
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
 			if (itemData == null) return;
 
-			MagicItemData cursorItemData = MagicItems.getMagicItemDataFromItemStack(click.itemCursor);
-			if (cursorItemData == null) return;
-			if (!itemData.equals(cursorItemData)) return;
+			if (!itemCursor.matches(itemData)) return;
 		}
 
 		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
-	}
-
-	private static class MagicClick {
-
-		private InventoryAction action;
-		private ItemStack itemCurrent;
-		private ItemStack itemCursor;
-
-		private MagicClick(InventoryAction action, ItemStack itemCurrent, ItemStack itemCursor) {
-			this.action = action;
-			this.itemCurrent = itemCurrent;
-			this.itemCursor = itemCursor;
-		}
-
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
@@ -22,7 +22,7 @@ public class InventoryClickListener extends PassiveListener {
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
-		String[] splits = var.split("\\|");
+		String[] splits = var.split(" ");
 
 		if (!splits[0].equals("null")) action = InventoryAction.valueOf(splits[0].toUpperCase());
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -16,7 +16,7 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.NAME;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.NAME;
 
 // Trigger variable of a comma separated list of items to accept
 public class RightClickItemListener extends PassiveListener {
@@ -34,8 +34,8 @@ public class RightClickItemListener extends PassiveListener {
 			MagicItemData itemData = null;
 			if (magicItem != null) itemData = magicItem.getMagicItemData();
 			if (itemData == null) continue;
-			if (itemData.hasItemAttribute(NAME))
-				itemData.setItemAttribute(NAME, Util.decolorize((String) itemData.getItemAttribute(NAME)));
+			if (itemData.hasAttribute(NAME))
+				itemData.setAttribute(NAME, Util.decolorize((String) itemData.getAttribute(NAME)));
 
 			items.add(itemData);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -3,8 +3,8 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
-import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -3,22 +3,22 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.Event;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.player.PlayerInteractEvent;
 
-import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.NAME;
 
-// Trigger variable of a comma separated list of items to accept
+// Trigger variable of a pipe separated list of items to accept
 public class RightClickItemListener extends PassiveListener {
 
 	private final Set<MagicItemData> items = new HashSet<>();
@@ -26,16 +26,16 @@ public class RightClickItemListener extends PassiveListener {
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
-		
+
 		String[] split = var.split("\\|");
 		for (String s : split) {
 			s = s.trim();
-			MagicItem magicItem = MagicItems.getMagicItemFromString(s);
-			MagicItemData itemData = null;
-			if (magicItem != null) itemData = magicItem.getMagicItemData();
-			if (itemData == null) continue;
-			if (itemData.hasAttribute(NAME))
-				itemData.setAttribute(NAME, Util.decolorize((String) itemData.getAttribute(NAME)));
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in rightclickitem trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
 			items.add(itemData);
 		}
@@ -45,24 +45,27 @@ public class RightClickItemListener extends PassiveListener {
 	@EventHandler
 	public void onRightClick(PlayerInteractEvent event) {
 		if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+		if (!isCancelStateOk(isCancelled(event))) return;
 		if (!event.hasItem()) return;
 
-		ItemStack item = event.getItem();
-		if (item == null || item.getType().isAir()) return;
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-		if (itemData == null) return;
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
 
-		if (!items.isEmpty() && !contains(itemData)) return;
+		if (!items.isEmpty()) {
+			ItemStack item = event.getItem();
+			if (item == null) return;
 
-		if (!hasSpell(event.getPlayer())) return;
-		if (!isCancelStateOk(isCancelled(event))) return;
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
+		}
+
 		boolean casted = passiveSpell.activate(event.getPlayer());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 	private boolean contains(MagicItemData itemData) {
 		for (MagicItemData data : items) {
-			if (data.equals(itemData)) return true;
+			if (data.matches(itemData)) return true;
 		}
 		return false;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -16,8 +16,6 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.NAME;
-
 // Trigger variable of a pipe separated list of items to accept
 public class RightClickItemListener extends PassiveListener {
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -16,6 +16,8 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.NAME;
+
 // Trigger variable of a comma separated list of items to accept
 public class RightClickItemListener extends PassiveListener {
 
@@ -32,7 +34,8 @@ public class RightClickItemListener extends PassiveListener {
 			MagicItemData itemData = null;
 			if (magicItem != null) itemData = magicItem.getMagicItemData();
 			if (itemData == null) continue;
-			if (itemData.getName() != null) itemData.setName(Util.decolorize(itemData.getName()));
+			if (itemData.hasItemAttribute(NAME))
+				itemData.setItemAttribute(NAME, Util.decolorize((String) itemData.getItemAttribute(NAME)));
 
 			items.add(itemData);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -32,10 +32,10 @@ public class AttributeUtil {
 			attributeNameMap.put(attribute.name().toLowerCase(), attribute);
 
 			attributeNameMap.put(key, attribute);
-			attributeNameMap.put(key.substring(key.indexOf('.')), attribute);
+			attributeNameMap.put(key.substring(key.indexOf('.') + 1), attribute);
 
 			attributeNameMap.put(rep, attribute);
-			attributeNameMap.put(rep.substring(key.indexOf('.')), attribute);
+			attributeNameMap.put(rep.substring(key.indexOf('.') + 1), attribute);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -2,91 +2,78 @@ package com.nisovin.magicspells.util;
 
 import java.util.Map;
 import java.util.HashMap;
+import java.util.Objects;
 
 import org.bukkit.attribute.Attribute;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.inventory.EquipmentSlot;
+import static org.bukkit.attribute.AttributeModifier.Operation;
 
 public class AttributeUtil {
 
-	public enum AttributeOperation {
+	private static final Map<String, Attribute> attributeNameMap = new HashMap<>();
+	private static final Map<String, Operation> operationNameMap = new HashMap<>();
 
-		ADD_NUMBER("add_number", "addnumber"),
-		ADD_SCALAR("add_scalar", "addscalar"),
-		MULTIPLY_SCALAR_1("multiply_scalar", "multiplyscalar");
+	static {
+		for (Operation operation : Operation.values()) {
+			String name = operation.name().toLowerCase();
 
-		private String[] names;
-
-		private static Map<String, AttributeModifier.Operation> nameMap = new HashMap<>();
-
-		AttributeOperation(String... names) {
-			this.names = names;
+			operationNameMap.put(name, operation);
+			operationNameMap.put(name.replaceAll("_", ""), operation);
 		}
 
-		static {
-			for (AttributeOperation op : AttributeOperation.values()) {
-				AttributeModifier.Operation operation = AttributeModifier.Operation.valueOf(op.name());
-				if (operation == null) continue;
+		operationNameMap.put("multiply_scalar", Operation.MULTIPLY_SCALAR_1);
+		operationNameMap.put("multiplyscalar", Operation.MULTIPLY_SCALAR_1);
 
-				nameMap.put(op.name().toLowerCase(), operation);
-				for (String s : op.names) {
-					nameMap.put(s.toLowerCase(), operation);
-				}
+		for (Attribute attribute : Attribute.values()) {
+			String key = attribute.getKey().getKey();
+			String rep = key.replaceAll("_", "");
 
-			}
-		}
+			attributeNameMap.put(attribute.name().toLowerCase(), attribute);
 
-		public AttributeModifier.Operation toBukkitOperation() {
-			return nameMap.get(names[0]);
-		}
+			attributeNameMap.put(key, attribute);
+			attributeNameMap.put(key.substring(key.indexOf('.')), attribute);
 
-		public static AttributeModifier.Operation getOperation(String operation) {
-			return nameMap.get(operation.toLowerCase());
+			attributeNameMap.put(rep, attribute);
+			attributeNameMap.put(rep.substring(key.indexOf('.')), attribute);
 		}
 
 	}
 
-	public enum AttributeType {
+	public static Attribute getAttribute(String attribute) {
+		return attributeNameMap.get(attribute.toLowerCase());
+	}
 
-		GENERIC_ARMOR("generic.armor", "armor"),
-		GENERIC_ARMOR_TOUGHNESS("generic.armortoughness", "armortoughness", "armor_toughness"),
-		GENERIC_ATTACK_DAMAGE("generic.attackdamage", "attackdamage", "attack_damage"),
-		GENERIC_ATTACK_SPEED("generic.attackspeed", "attackspeed", "attack_speed"),
-		GENERIC_FLYING_SPEED("generic.flyingspeed", "flyingspeed", "flying_speed"),
-		GENERIC_FOLLOW_RANGE("generic.followrange", "followrange", "follow_range"),
-		GENERIC_KNOCKBACK_RESISTANCE("generic.knockbackresistance", "knockbackresistance", "knockback_resistance"),
-		GENERIC_LUCK("generic.luck", "luck"),
-		GENERIC_MAX_HEALTH("generic.maxhealth", "maxhealth", "max_health"),
-		GENERIC_MOVEMENT_SPEED("generic.movementspeed", "movementspeed", "movement_speed"),
-		HORSE_JUMP_STRENGTH("horsejumpstrength", "horse_jump_strength"),
-		ZOMBIE_SPAWN_REINFORCEMENTS("zombiespawnreinforcements", "zombie_spawn_reinforcements");
+	public static Operation getOperation(String operation) {
+		return operationNameMap.get(operation.toLowerCase());
+	}
 
-		private String[] names;
+	public static class AttributeModifierData {
 
-		private static Map<String, Attribute> nameMap = new HashMap<>();
+		private final String name;
+		private final double amount;
+		private final Operation operation;
+		private final EquipmentSlot slot;
 
-		AttributeType(String... names) {
-			this.names = names;
+		public AttributeModifierData(AttributeModifier mod) {
+			name = mod.getName();
+			amount = mod.getAmount();
+			operation = mod.getOperation();
+			slot = mod.getSlot();
 		}
 
-		static {
-			for (AttributeType type : AttributeType.values()) {
-				Attribute attribute = Attribute.valueOf(type.name());
-				if (attribute == null) continue;
+		@Override
+		public boolean equals(Object o) {
+			if (this == o) return true;
+			if (o == null || getClass() != o.getClass()) return false;
 
-				nameMap.put(type.name().toLowerCase(), attribute);
-				for (String s : type.names) {
-					nameMap.put(s.toLowerCase(), attribute);
-				}
-
-			}
+			AttributeModifierData that = (AttributeModifierData) o;
+			return amount == that.amount && Objects.equals(name, that.name) && operation == that.operation && slot == that.slot;
 		}
 
-		public Attribute toBukkitAttribute() {
-			return nameMap.get(names[0]);
-		}
-
-		public static Attribute getAttribute(String attribute) {
-			return nameMap.get(attribute.toLowerCase());
+		@Override
+		public int hashCode() {
+			return Objects.hash(name, amount, operation, slot);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
@@ -116,7 +116,7 @@ public class BlockUtils {
 	}
 
 	public static boolean isAir(Material m) {
-		return m == Material.AIR || m.name().contains("_AIR");
+		return m.isAir();
 	}
 
 	public static boolean isBed(Material m) {

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -260,7 +260,7 @@ public class CastItem {
 			if (previous) output.append(',');
 
 			boolean previousEnchantment = false;
-			output.append("\"enchantments\":{");
+			output.append("\"enchants\":{");
 			for (Enchantment enchant : enchants.keySet()) {
 				if (previousEnchantment) output.append(',');
 

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -18,6 +18,7 @@ import com.nisovin.magicspells.util.itemreader.PotionHandler;
 import com.nisovin.magicspells.util.itemreader.DurabilityHandler;
 import com.nisovin.magicspells.util.itemreader.WrittenBookHandler;
 import com.nisovin.magicspells.util.itemreader.LeatherArmorHandler;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.*;
 
 public class CastItem {
 
@@ -69,22 +70,22 @@ public class CastItem {
 		MagicItem magicItem = MagicItems.getMagicItemFromString(string);
 		if (magicItem != null && magicItem.getMagicItemData() != null) {
 			MagicItemData data = magicItem.getMagicItemData();
-			type = data.getType();
+			type = (Material) data.getItemAttribute(TYPE);
 			if (isTypeValid()) {
-				if (!MagicSpells.ignoreCastItemNames() && data.getName() != null) {
-					if (MagicSpells.ignoreCastItemNameColors()) name = Util.decolorize(data.getName());
-					else name = Util.colorize(data.getName());
+				if (!MagicSpells.ignoreCastItemNames() && data.hasItemAttribute(NAME)) {
+					if (MagicSpells.ignoreCastItemNameColors()) name = Util.decolorize((String) data.getItemAttribute(NAME));
+					else name = Util.colorize((String) data.getItemAttribute(NAME));
 				}
-				if (!MagicSpells.ignoreCastItemAmount()) amount = data.getAmount();
-				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) durability = data.getDurability();
-				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = data.getCustomModelData();
-				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = data.isUnbreakable();
-				if (!MagicSpells.ignoreCastItemColor()) color = data.getColor();
-				if (!MagicSpells.ignoreCastItemPotionType()) potionType = data.getPotionType();
-				if (!MagicSpells.ignoreCastItemTitle()) title = data.getTitle();
-				if (!MagicSpells.ignoreCastItemAuthor()) author = data.getAuthor();
-				if (!MagicSpells.ignoreCastItemEnchants()) enchants = data.getEnchantments();
-				if (!MagicSpells.ignoreCastItemLore()) lore = data.getLore();
+				if (!MagicSpells.ignoreCastItemAmount()) amount = (int) data.getItemAttribute(AMOUNT);
+				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) durability = (int) data.getItemAttribute(DURABILITY);
+				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = (int) data.getItemAttribute(CUSTOM_MODEL_DATA);
+				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = (boolean) data.getItemAttribute(UNBREAKABLE);
+				if (!MagicSpells.ignoreCastItemColor()) color = (Color) data.getItemAttribute(COLOR);
+				if (!MagicSpells.ignoreCastItemPotionType()) potionType = (PotionType) data.getItemAttribute(POTION_TYPE);
+				if (!MagicSpells.ignoreCastItemTitle()) title = (String) data.getItemAttribute(TITLE);
+				if (!MagicSpells.ignoreCastItemAuthor()) author = (String) data.getItemAttribute(AUTHOR);
+				if (!MagicSpells.ignoreCastItemEnchants()) enchants = (Map<Enchantment, Integer>) data.getItemAttribute(ENCHANTMENTS);
+				if (!MagicSpells.ignoreCastItemLore()) lore = (List<String>) data.getItemAttribute(LORE);
 			}
 		}
 	}
@@ -122,8 +123,7 @@ public class CastItem {
 
 	public boolean objectEquals(Object o, Object object) {
 		if (o == null && object == null) return true;
-		if (o == null && object != null) return false;
-		if (o != null && object == null) return false;
+		if (o == null || object == null) return false;
 		return o.equals(object);
 	}
 
@@ -135,19 +135,21 @@ public class CastItem {
 	@Override
 	public String toString() {
 		if (type == null) return "";
+
 		MagicItemData data = new MagicItemData();
-		data.setType(type);
-		data.setName(name);
-		data.setAmount(amount);
-		data.setDurability(durability);
-		data.setCustomModelData(customModelData);
-		data.setUnbreakable(unbreakable);
-		data.setColor(color);
-		data.setPotionType(potionType);
-		data.setTitle(title);
-		data.setAuthor(author);
-		data.setEnchantments(enchants);
-		data.setLore(lore);
+		data.setItemAttribute(TYPE, type);
+		data.setItemAttribute(NAME, name);
+		data.setItemAttribute(AMOUNT, amount);
+		data.setItemAttribute(DURABILITY, durability);
+		data.setItemAttribute(CUSTOM_MODEL_DATA, customModelData);
+		data.setItemAttribute(UNBREAKABLE, unbreakable);
+		data.setItemAttribute(COLOR, color);
+		data.setItemAttribute(POTION_TYPE, potionType);
+		data.setItemAttribute(TITLE, title);
+		data.setItemAttribute(AUTHOR, author);
+		data.setItemAttribute(ENCHANTMENTS, enchants);
+		data.setItemAttribute(LORE, lore);
+
 		return data.toString();
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
+import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -81,7 +82,7 @@ public class CastItem {
 				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
 				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = (boolean) data.getAttribute(UNBREAKABLE);
 				if (!MagicSpells.ignoreCastItemColor()) color = (Color) data.getAttribute(COLOR);
-				if (!MagicSpells.ignoreCastItemPotionType()) potionType = (PotionType) data.getAttribute(POTION_TYPE);
+				if (!MagicSpells.ignoreCastItemPotionType()) potionType = ((PotionData) data.getAttribute(POTION_DATA)).getType();
 				if (!MagicSpells.ignoreCastItemTitle()) title = (String) data.getAttribute(TITLE);
 				if (!MagicSpells.ignoreCastItemAuthor()) author = (String) data.getAttribute(AUTHOR);
 				if (!MagicSpells.ignoreCastItemEnchants()) enchants = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
@@ -144,7 +145,7 @@ public class CastItem {
 		data.setAttribute(CUSTOM_MODEL_DATA, customModelData);
 		data.setAttribute(UNBREAKABLE, unbreakable);
 		data.setAttribute(COLOR, color);
-		data.setAttribute(POTION_TYPE, potionType);
+		data.setAttribute(POTION_DATA, new PotionData(potionType));
 		data.setAttribute(TITLE, title);
 		data.setAttribute(AUTHOR, author);
 		data.setAttribute(ENCHANTMENTS, enchants);

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -2,11 +2,11 @@ package com.nisovin.magicspells.util;
 
 import java.util.Map;
 import java.util.List;
+import java.util.Objects;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.potion.PotionData;
-import org.bukkit.potion.PotionType;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.enchantments.Enchantment;
@@ -32,7 +32,7 @@ public class CastItem {
 	private boolean unbreakable = false;
 
 	private Color color = null;
-	private PotionType potionType = null;
+	private PotionData potionData = null;
 	private String title = null;
 	private String author = null;
 
@@ -59,7 +59,7 @@ public class CastItem {
 			if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = ItemUtil.getCustomModelData(meta);
 			if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = meta.isUnbreakable();
 			if (!MagicSpells.ignoreCastItemColor()) color = LeatherArmorHandler.getColor(meta);
-			if (!MagicSpells.ignoreCastItemPotionType()) potionType = PotionHandler.getPotionType(meta);
+			if (!MagicSpells.ignoreCastItemPotionType()) potionData = PotionHandler.getPotionData(meta);
 			if (!MagicSpells.ignoreCastItemTitle()) title = WrittenBookHandler.getTitle(meta);
 			if (!MagicSpells.ignoreCastItemAuthor()) author = WrittenBookHandler.getAuthor(meta);
 			if (!MagicSpells.ignoreCastItemEnchants()) enchants = meta.getEnchants();
@@ -75,18 +75,38 @@ public class CastItem {
 			if (isTypeValid()) {
 				if (!MagicSpells.ignoreCastItemNames() && data.hasAttribute(NAME)) {
 					if (MagicSpells.ignoreCastItemNameColors()) name = Util.decolorize((String) data.getAttribute(NAME));
-					else name = Util.colorize((String) data.getAttribute(NAME));
+					else name = (String) data.getAttribute(NAME);
 				}
-				if (!MagicSpells.ignoreCastItemAmount()) amount = (int) data.getAttribute(AMOUNT);
-				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) durability = (int) data.getAttribute(DURABILITY);
-				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
-				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = (boolean) data.getAttribute(UNBREAKABLE);
-				if (!MagicSpells.ignoreCastItemColor()) color = (Color) data.getAttribute(COLOR);
-				if (!MagicSpells.ignoreCastItemPotionType()) potionType = ((PotionData) data.getAttribute(POTION_DATA)).getType();
-				if (!MagicSpells.ignoreCastItemTitle()) title = (String) data.getAttribute(TITLE);
-				if (!MagicSpells.ignoreCastItemAuthor()) author = (String) data.getAttribute(AUTHOR);
-				if (!MagicSpells.ignoreCastItemEnchants()) enchants = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
-				if (!MagicSpells.ignoreCastItemLore()) lore = (List<String>) data.getAttribute(LORE);
+
+				if (!MagicSpells.ignoreCastItemAmount() && data.hasAttribute(AMOUNT))
+					amount = (int) data.getAttribute(AMOUNT);
+
+				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type) && data.hasAttribute(DURABILITY))
+					durability = (int) data.getAttribute(DURABILITY);
+
+				if (!MagicSpells.ignoreCastItemCustomModelData() && data.hasAttribute(CUSTOM_MODEL_DATA))
+					customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
+
+				if (!MagicSpells.ignoreCastItemBreakability() && data.hasAttribute(UNBREAKABLE))
+					unbreakable = (boolean) data.getAttribute(UNBREAKABLE);
+
+				if (!MagicSpells.ignoreCastItemColor() && data.hasAttribute(COLOR))
+					color = (Color) data.getAttribute(COLOR);
+
+				if (!MagicSpells.ignoreCastItemPotionType() && data.hasAttribute(POTION_DATA))
+					potionData = (PotionData) data.getAttribute(POTION_DATA);
+
+				if (!MagicSpells.ignoreCastItemTitle() && data.hasAttribute(TITLE))
+					title = (String) data.getAttribute(TITLE);
+
+				if (!MagicSpells.ignoreCastItemAuthor() && data.hasAttribute(AUTHOR))
+					author = (String) data.getAttribute(AUTHOR);
+
+				if (!MagicSpells.ignoreCastItemEnchants() && data.hasAttribute(ENCHANTMENTS))
+					enchants = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
+
+				if (!MagicSpells.ignoreCastItemLore() && data.hasAttribute(LORE))
+					lore = (List<String>) data.getAttribute(LORE);
 			}
 		}
 	}
@@ -108,50 +128,178 @@ public class CastItem {
 
 	public boolean equalsCastItem(CastItem i) {
 		if (i == null) return false;
-		if (i.type != type) return false;
-		if (i.durability != durability) return false;
-		if (!MagicSpells.ignoreCastItemNames()) return objectEquals(i.name, name);
-		if (!MagicSpells.ignoreCastItemCustomModelData()) return i.customModelData == customModelData;
-		if (!MagicSpells.ignoreCastItemBreakability()) return i.unbreakable == unbreakable;
-		if (!MagicSpells.ignoreCastItemColor()) return objectEquals(i.color, color);
-		if (!MagicSpells.ignoreCastItemPotionType()) return i.potionType == potionType;
-		if (!MagicSpells.ignoreCastItemTitle()) return objectEquals(i.title, title);
-		if (!MagicSpells.ignoreCastItemAuthor()) return objectEquals(i.author, author);
-		if (!MagicSpells.ignoreCastItemEnchants()) return objectEquals(i.enchants, enchants);
-		if (!MagicSpells.ignoreCastItemLore()) return objectEquals(i.lore, lore);
-		return true;
-	}
 
-	public boolean objectEquals(Object o, Object object) {
-		if (o == null && object == null) return true;
-		if (o == null || object == null) return false;
-		return o.equals(object);
+		return type == i.type
+			&& (MagicSpells.ignoreCastItemDurability(type) || durability == i.durability)
+			&& (MagicSpells.ignoreCastItemAmount() || amount == i.amount)
+			&& (MagicSpells.ignoreCastItemNames() || Objects.equals(name, i.name))
+			&& (MagicSpells.ignoreCastItemCustomModelData() || customModelData == i.customModelData)
+			&& (MagicSpells.ignoreCastItemBreakability() || unbreakable == i.unbreakable)
+			&& (MagicSpells.ignoreCastItemColor() || Objects.equals(color, i.color))
+			&& (MagicSpells.ignoreCastItemPotionType() || Objects.equals(potionData, i.potionData))
+			&& (MagicSpells.ignoreCastItemTitle() || Objects.equals(title, i.title))
+			&& (MagicSpells.ignoreCastItemAuthor() || Objects.equals(author, i.author))
+			&& (MagicSpells.ignoreCastItemEnchants() || Objects.equals(enchants, i.enchants))
+			&& (MagicSpells.ignoreCastItemLore() || Objects.equals(lore, i.lore));
 	}
 
 	@Override
 	public int hashCode() {
-		return toString().hashCode();
+		return Objects.hash(type, name, amount, durability, customModelData, unbreakable, color, potionData, title, author, enchants, lore);
 	}
 
 	@Override
 	public String toString() {
 		if (type == null) return "";
 
-		MagicItemData data = new MagicItemData();
-		data.setAttribute(TYPE, type);
-		data.setAttribute(NAME, name);
-		data.setAttribute(AMOUNT, amount);
-		data.setAttribute(DURABILITY, durability);
-		data.setAttribute(CUSTOM_MODEL_DATA, customModelData);
-		data.setAttribute(UNBREAKABLE, unbreakable);
-		data.setAttribute(COLOR, color);
-		data.setAttribute(POTION_DATA, new PotionData(potionType));
-		data.setAttribute(TITLE, title);
-		data.setAttribute(AUTHOR, author);
-		data.setAttribute(ENCHANTMENTS, enchants);
-		data.setAttribute(LORE, lore);
+		StringBuilder output = new StringBuilder();
+		boolean previous = false;
 
-		return data.toString();
+		output
+			.append(type.name())
+			.append("{");
+
+		if (!MagicSpells.ignoreCastItemNames() && name != null) {
+			output
+				.append("\"name\":\"")
+				.append(TxtUtil.escapeJSON(name))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemAmount()) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"amount\":")
+				.append(amount);
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"durability\":")
+				.append(durability);
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemCustomModelData()) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"custommodeldata\":")
+				.append(customModelData);
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemBreakability()) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"unbreakable\":")
+				.append(unbreakable);
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemColor() && color != null) {
+			if (previous) output.append(',');
+
+			String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+
+			output
+				.append("\"color\":\"")
+				.append(hex)
+				.append('"');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemPotionType() && potionData != null) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"potiondata\":\"")
+				.append(potionData.getType());
+
+			if (potionData.isExtended()) output.append(" extended");
+			else if (potionData.isUpgraded()) output.append(" upgraded");
+
+			output.append('"');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemTitle() && title != null) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"title\":\"")
+				.append(TxtUtil.escapeJSON(title))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemAuthor() && author != null) {
+			if (previous) output.append(',');
+
+			output
+				.append("\"author\":\"")
+				.append(TxtUtil.escapeJSON(author))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemEnchants() && enchants != null) {
+			if (previous) output.append(',');
+
+			boolean previousEnchantment = false;
+			output.append("\"enchantments\":{");
+			for (Enchantment enchant : enchants.keySet()) {
+				if (previousEnchantment) output.append(',');
+
+				output
+					.append('"')
+					.append(enchant.getKey().getKey())
+					.append("\":")
+					.append(enchants.get(enchant));
+
+				previousEnchantment = true;
+			}
+			output.append('}');
+
+			previous = true;
+		}
+
+		if (!MagicSpells.ignoreCastItemLore() && lore != null) {
+			if (previous) output.append(',');
+
+			boolean previousLore = false;
+			output.append("\"lore\":[");
+			for (String line : lore) {
+				if (previousLore) output.append(',');
+
+				output
+					.append('"')
+					.append(TxtUtil.escapeJSON(line))
+					.append('"');
+
+				previousLore = true;
+			}
+			output.append(']');
+		}
+
+		output.append("}");
+
+		return output.toString();
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -18,7 +18,7 @@ import com.nisovin.magicspells.util.itemreader.PotionHandler;
 import com.nisovin.magicspells.util.itemreader.DurabilityHandler;
 import com.nisovin.magicspells.util.itemreader.WrittenBookHandler;
 import com.nisovin.magicspells.util.itemreader.LeatherArmorHandler;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.*;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
 public class CastItem {
 
@@ -70,22 +70,22 @@ public class CastItem {
 		MagicItem magicItem = MagicItems.getMagicItemFromString(string);
 		if (magicItem != null && magicItem.getMagicItemData() != null) {
 			MagicItemData data = magicItem.getMagicItemData();
-			type = (Material) data.getItemAttribute(TYPE);
+			type = (Material) data.getAttribute(TYPE);
 			if (isTypeValid()) {
-				if (!MagicSpells.ignoreCastItemNames() && data.hasItemAttribute(NAME)) {
-					if (MagicSpells.ignoreCastItemNameColors()) name = Util.decolorize((String) data.getItemAttribute(NAME));
-					else name = Util.colorize((String) data.getItemAttribute(NAME));
+				if (!MagicSpells.ignoreCastItemNames() && data.hasAttribute(NAME)) {
+					if (MagicSpells.ignoreCastItemNameColors()) name = Util.decolorize((String) data.getAttribute(NAME));
+					else name = Util.colorize((String) data.getAttribute(NAME));
 				}
-				if (!MagicSpells.ignoreCastItemAmount()) amount = (int) data.getItemAttribute(AMOUNT);
-				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) durability = (int) data.getItemAttribute(DURABILITY);
-				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = (int) data.getItemAttribute(CUSTOM_MODEL_DATA);
-				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = (boolean) data.getItemAttribute(UNBREAKABLE);
-				if (!MagicSpells.ignoreCastItemColor()) color = (Color) data.getItemAttribute(COLOR);
-				if (!MagicSpells.ignoreCastItemPotionType()) potionType = (PotionType) data.getItemAttribute(POTION_TYPE);
-				if (!MagicSpells.ignoreCastItemTitle()) title = (String) data.getItemAttribute(TITLE);
-				if (!MagicSpells.ignoreCastItemAuthor()) author = (String) data.getItemAttribute(AUTHOR);
-				if (!MagicSpells.ignoreCastItemEnchants()) enchants = (Map<Enchantment, Integer>) data.getItemAttribute(ENCHANTMENTS);
-				if (!MagicSpells.ignoreCastItemLore()) lore = (List<String>) data.getItemAttribute(LORE);
+				if (!MagicSpells.ignoreCastItemAmount()) amount = (int) data.getAttribute(AMOUNT);
+				if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) durability = (int) data.getAttribute(DURABILITY);
+				if (!MagicSpells.ignoreCastItemCustomModelData()) customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
+				if (!MagicSpells.ignoreCastItemBreakability()) unbreakable = (boolean) data.getAttribute(UNBREAKABLE);
+				if (!MagicSpells.ignoreCastItemColor()) color = (Color) data.getAttribute(COLOR);
+				if (!MagicSpells.ignoreCastItemPotionType()) potionType = (PotionType) data.getAttribute(POTION_TYPE);
+				if (!MagicSpells.ignoreCastItemTitle()) title = (String) data.getAttribute(TITLE);
+				if (!MagicSpells.ignoreCastItemAuthor()) author = (String) data.getAttribute(AUTHOR);
+				if (!MagicSpells.ignoreCastItemEnchants()) enchants = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
+				if (!MagicSpells.ignoreCastItemLore()) lore = (List<String>) data.getAttribute(LORE);
 			}
 		}
 	}
@@ -137,18 +137,18 @@ public class CastItem {
 		if (type == null) return "";
 
 		MagicItemData data = new MagicItemData();
-		data.setItemAttribute(TYPE, type);
-		data.setItemAttribute(NAME, name);
-		data.setItemAttribute(AMOUNT, amount);
-		data.setItemAttribute(DURABILITY, durability);
-		data.setItemAttribute(CUSTOM_MODEL_DATA, customModelData);
-		data.setItemAttribute(UNBREAKABLE, unbreakable);
-		data.setItemAttribute(COLOR, color);
-		data.setItemAttribute(POTION_TYPE, potionType);
-		data.setItemAttribute(TITLE, title);
-		data.setItemAttribute(AUTHOR, author);
-		data.setItemAttribute(ENCHANTMENTS, enchants);
-		data.setItemAttribute(LORE, lore);
+		data.setAttribute(TYPE, type);
+		data.setAttribute(NAME, name);
+		data.setAttribute(AMOUNT, amount);
+		data.setAttribute(DURABILITY, durability);
+		data.setAttribute(CUSTOM_MODEL_DATA, customModelData);
+		data.setAttribute(UNBREAKABLE, unbreakable);
+		data.setAttribute(COLOR, color);
+		data.setAttribute(POTION_TYPE, potionType);
+		data.setAttribute(TITLE, title);
+		data.setAttribute(AUTHOR, author);
+		data.setAttribute(ENCHANTMENTS, enchants);
+		data.setAttribute(LORE, lore);
 
 		return data.toString();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -12,7 +12,6 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.enchantments.Enchantment;
 
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.util.itemreader.PotionHandler;
@@ -68,9 +67,8 @@ public class CastItem {
 	}
 
 	public CastItem(String string) {
-		MagicItem magicItem = MagicItems.getMagicItemFromString(string);
-		if (magicItem != null && magicItem.getMagicItemData() != null) {
-			MagicItemData data = magicItem.getMagicItemData();
+		MagicItemData data = MagicItems.getMagicItemDataFromString(string);
+		if (data != null) {
 			type = (Material) data.getAttribute(TYPE);
 			if (isTypeValid()) {
 				if (!MagicSpells.ignoreCastItemNames() && data.hasAttribute(NAME)) {

--- a/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
@@ -95,7 +95,7 @@ public class InventoryUtil {
 
 	public static boolean inventoryContains(EntityEquipment entityEquipment, SpellReagents.ReagentItem item) {
 		if (entityEquipment == null) return false;
-		MagicItemData itemData = item.getMagicItem().getMagicItemData();
+		MagicItemData itemData = item.getMagicItemData();
 		if (itemData == null) return false;
 
 		int count = 0;
@@ -123,7 +123,7 @@ public class InventoryUtil {
 
 	public static boolean inventoryContains(Inventory inventory, SpellReagents.ReagentItem item) {
 		if (inventory == null) return false;
-		MagicItemData itemData = item.getMagicItem().getMagicItemData();
+		MagicItemData itemData = item.getMagicItemData();
 		if (itemData == null) return false;
 		int count = 0;
 		ItemStack[] items = inventory.getContents();

--- a/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/InventoryUtil.java
@@ -95,7 +95,7 @@ public class InventoryUtil {
 
 	public static boolean inventoryContains(EntityEquipment entityEquipment, SpellReagents.ReagentItem item) {
 		if (entityEquipment == null) return false;
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item.getItemStack());
+		MagicItemData itemData = item.getMagicItem().getMagicItemData();
 		if (itemData == null) return false;
 
 		int count = 0;
@@ -110,10 +110,12 @@ public class InventoryUtil {
 		equipment[5] = offHand;
 
 		for (ItemStack itemInside : equipment) {
+			if (itemInside == null) continue;
+
 			MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(itemInside);
 			if (magicItemData == null) continue;
-			if (itemInside == null) continue;
-			if (magicItemData.equals(itemData)) count += itemInside.getAmount();
+
+			if (itemData.matches(magicItemData)) count += itemInside.getAmount();
 			if (count >= item.getAmount()) return true;
 		}
 		return false;
@@ -121,15 +123,17 @@ public class InventoryUtil {
 
 	public static boolean inventoryContains(Inventory inventory, SpellReagents.ReagentItem item) {
 		if (inventory == null) return false;
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item.getItemStack());
+		MagicItemData itemData = item.getMagicItem().getMagicItemData();
 		if (itemData == null) return false;
 		int count = 0;
 		ItemStack[] items = inventory.getContents();
 		for (ItemStack itemStack : items) {
 			if (itemStack == null) continue;
+
 			MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(itemStack);
 			if (magicItemData == null) continue;
-			if (magicItemData.equals(itemData)) count += itemStack.getAmount();
+
+			if (itemData.matches(magicItemData)) count += itemStack.getAmount();
 			if (count >= item.getAmount()) return true;
 		}
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
@@ -59,11 +59,6 @@ public class ItemUtil {
 		return 0;
 	}
 
-	public static void setCustomModelData(ItemMeta meta, int data) {
-		if (meta == null) return;
-		meta.setCustomModelData(data);
-	}
-
 	public static Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime) {
 		Recipe recipe = null;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
@@ -9,13 +9,18 @@ import org.bukkit.inventory.meta.Damageable;
 
 public class ItemUtil {
 
-	public static ItemStack addFakeEnchantment(ItemStack item) {
-		ItemMeta meta = item.getItemMeta();
-		if (meta == null) return item;
+	public static void addFakeEnchantment(ItemMeta meta) {
+		if (meta == null) return;
+
 		meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
-		item.setItemMeta(meta);
-		item.addUnsafeEnchantment(Enchantment.FROST_WALKER, -1);
-		return item;
+		meta.addEnchant(Enchantment.FROST_WALKER, -1, true);
+	}
+
+	public static boolean hasFakeEnchantment(ItemMeta meta) {
+
+		return meta.hasItemFlag(ItemFlag.HIDE_ENCHANTS)
+			&& meta.hasEnchant(Enchantment.FROST_WALKER)
+			&& meta.getEnchantLevel(Enchantment.FROST_WALKER) == 65535;
 	}
 
 	public static boolean hasDurability(Material type) {

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Collection;
 
-import org.bukkit.inventory.ItemStack;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
 
 public class SpellReagents {
 	
@@ -28,6 +28,7 @@ public class SpellReagents {
 		hunger = 0;
 		experience = 0;
 		levels = 0;
+		durability = 0;
 		money = 0;
 		variables = null;
 	}
@@ -42,6 +43,7 @@ public class SpellReagents {
 		hunger = other.hunger;
 		experience = other.experience;
 		levels = other.levels;
+		durability = other.durability;
 		money = other.money;
 		if (other.variables != null) {
 			variables = new HashMap<>();
@@ -217,34 +219,33 @@ public class SpellReagents {
 
 	public static class ReagentItem {
 
-		private ItemStack itemStack;
-
+		private MagicItem magicItem;
 		private int amount;
 
-		public ReagentItem(ItemStack itemStack, int amount) {
-			this.itemStack = itemStack;
+		public ReagentItem(MagicItem magicItem, int amount) {
+			this.magicItem = magicItem;
 			this.amount = amount;
 		}
 
-		public void setItemStack(ItemStack itemStack) {
-			this.itemStack = itemStack;
-		}
-
-		public void setAmount(int amount) {
-			this.amount = amount;
-		}
-
-		public ItemStack getItemStack() {
-			return itemStack;
+		public MagicItem getMagicItem() {
+			return magicItem;
 		}
 
 		public int getAmount() {
 			return amount;
 		}
 
+		public void setMagicItem(MagicItem magicItem) {
+			this.magicItem = magicItem;
+		}
+
+		public void setAmount(int amount) {
+			this.amount = amount;
+		}
+
 		@Override
 		public ReagentItem clone() {
-			return new ReagentItem(itemStack, amount);
+			return new ReagentItem(magicItem, amount);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
@@ -7,7 +7,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Collection;
 
-import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
 public class SpellReagents {
 	
@@ -219,24 +219,24 @@ public class SpellReagents {
 
 	public static class ReagentItem {
 
-		private MagicItem magicItem;
+		private MagicItemData magicItemData;
 		private int amount;
 
-		public ReagentItem(MagicItem magicItem, int amount) {
-			this.magicItem = magicItem;
+		public ReagentItem(MagicItemData magicItemData, int amount) {
+			this.magicItemData = magicItemData;
 			this.amount = amount;
 		}
 
-		public MagicItem getMagicItem() {
-			return magicItem;
+		public MagicItemData getMagicItemData() {
+			return magicItemData;
 		}
 
 		public int getAmount() {
 			return amount;
 		}
 
-		public void setMagicItem(MagicItem magicItem) {
-			this.magicItem = magicItem;
+		public void setItemData(MagicItemData magicItemData) {
+			this.magicItemData = magicItemData;
 		}
 
 		public void setAmount(int amount) {
@@ -245,7 +245,7 @@ public class SpellReagents {
 
 		@Override
 		public ReagentItem clone() {
-			return new ReagentItem(magicItem, amount);
+			return new ReagentItem(magicItemData.clone(), amount);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
@@ -28,6 +28,10 @@ public class TxtUtil {
 		}
 		return ret;
 	}
+
+	public static String escapeJSON(String str) {
+		return str.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
+	}
 	
 	public static List<String> tabCompleteSpellName(CommandSender sender, String partial) {
 		List<String> matches = new ArrayList<>();

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -324,7 +324,7 @@ public class Util {
 	}
 
 	public static boolean removeFromInventory(Inventory inventory, SpellReagents.ReagentItem item) {
-		MagicItemData itemData = item.getMagicItem().getMagicItemData();
+		MagicItemData itemData = item.getMagicItemData();
 		if (itemData == null) return false;
 
 		int amt = item.getAmount();
@@ -356,7 +356,7 @@ public class Util {
 	}
 
 	public static boolean removeFromInventory(EntityEquipment entityEquipment, SpellReagents.ReagentItem item) {
-		MagicItemData itemData = item.getMagicItem().getMagicItemData();
+		MagicItemData itemData = item.getMagicItemData();
 		if (itemData == null) return false;
 
 		int amt = item.getAmount();

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -324,16 +324,16 @@ public class Util {
 	}
 
 	public static boolean removeFromInventory(Inventory inventory, SpellReagents.ReagentItem item) {
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item.getItemStack());
+		MagicItemData itemData = item.getMagicItem().getMagicItemData();
 		if (itemData == null) return false;
 
 		int amt = item.getAmount();
 		ItemStack[] items = inventory.getContents();
 		for (int i = 0; i < items.length; i++) {
 			if (items[i] == null) continue;
+
 			MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(items[i]);
-			if (magicItemData == null) continue;
-			if (!magicItemData.equals(itemData)) continue;
+			if (magicItemData == null || !itemData.matches(magicItemData)) continue;
 
 			if (items[i].getAmount() > amt) {
 				items[i].setAmount(items[i].getAmount() - amt);
@@ -356,7 +356,7 @@ public class Util {
 	}
 
 	public static boolean removeFromInventory(EntityEquipment entityEquipment, SpellReagents.ReagentItem item) {
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item.getItemStack());
+		MagicItemData itemData = item.getMagicItem().getMagicItemData();
 		if (itemData == null) return false;
 
 		int amt = item.getAmount();
@@ -368,9 +368,9 @@ public class Util {
 
 		for (int i = 0; i < items.length; i++) {
 			if (items[i] == null) continue;
+
 			MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(items[i]);
-			if (magicItemData == null) continue;
-			if (!magicItemData.equals(itemData)) continue;
+			if (magicItemData == null || !itemData.matches(magicItemData)) continue;
 
 			if (items[i].getAmount() > amt) {
 				items[i].setAmount(items[i].getAmount() - amt);
@@ -398,17 +398,11 @@ public class Util {
 	}
 
 	public static boolean addToInventory(Inventory inventory, ItemStack item, boolean stackExisting, boolean ignoreMaxStack) {
-		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-		if (itemData == null) return false;
-
 		int amt = item.getAmount();
 		ItemStack[] items = Arrays.copyOf(inventory.getContents(), inventory.getSize());
 		if (stackExisting) {
 			for (ItemStack itemStack : items) {
-				if (itemStack == null) continue;
-				MagicItemData magicItemData = MagicItems.getMagicItemDataFromItemStack(itemStack);
-				if (magicItemData == null) continue;
-				if (!magicItemData.equals(itemData)) continue;
+				if (itemStack == null || !itemStack.isSimilar(item)) continue;
 
 				if (itemStack.getAmount() + amt <= itemStack.getMaxStackSize()) {
 					itemStack.setAmount(itemStack.getAmount() + amt);

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -2,25 +2,24 @@ package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
 
-import com.nisovin.magicspells.handlers.DebugHandler;
 import org.bukkit.DyeColor;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.block.banner.Pattern;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.block.banner.PatternType;
 import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
+import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.PATTERNS;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.PATTERNS;
 
 public class BannerHandler {
 
 	private static final String CONFIG_NAME = PATTERNS.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BannerMeta)) return meta;
-		if (!config.isList(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BannerMeta)) return;
+		if (!config.isList(CONFIG_NAME)) return;
 
 		BannerMeta bannerMeta = (BannerMeta) meta;
 
@@ -50,32 +49,22 @@ public class BannerHandler {
 			bannerMeta.addPattern(pattern);
 		}
 
-		if (!bannerMeta.getPatterns().isEmpty()) data.setItemAttribute(PATTERNS, bannerMeta.getPatterns());
-		return bannerMeta;
+		if (!bannerMeta.getPatterns().isEmpty()) data.setAttribute(PATTERNS, bannerMeta.getPatterns());
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BannerMeta)) return meta;
-		if (!data.hasItemAttribute(PATTERNS)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BannerMeta)) return;
+		if (!data.hasAttribute(PATTERNS)) return;
 
-		List<Pattern> patterns = (List<Pattern>) data.getItemAttribute(PATTERNS);
-		BannerMeta bannerMeta = (BannerMeta) meta;
+		List<Pattern> patterns = (List<Pattern>) data.getAttribute(PATTERNS);
 		((BannerMeta) meta).setPatterns(patterns);
-
-		return bannerMeta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BannerMeta)) return;
 
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof BannerMeta)) return data;
-
-		List<Pattern> patterns = ((BannerMeta) itemStack.getItemMeta()).getPatterns();
-		if (!patterns.isEmpty()) data.setItemAttribute(PATTERNS, patterns);
-
-		return data;
+		List<Pattern> patterns = ((BannerMeta) meta).getPatterns();
+		if (!patterns.isEmpty()) data.setAttribute(PATTERNS, patterns);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
+import java.util.ArrayList;
 
 import org.bukkit.DyeColor;
 import org.bukkit.block.banner.Pattern;
@@ -25,6 +26,7 @@ public class BannerHandler {
 
 		// patternType dyeColor
 		List<String> strPatterns = config.getStringList(CONFIG_NAME);
+		List<Pattern> patterns = new ArrayList<>();
 		for (String str : strPatterns) {
 			String[] args = str.split(" ");
 			if (args.length < 2) continue;
@@ -47,9 +49,10 @@ public class BannerHandler {
 
 			Pattern pattern = new Pattern(dyeColor, patternType);
 			bannerMeta.addPattern(pattern);
+			patterns.add(pattern);
 		}
 
-		data.setAttribute(PATTERNS, bannerMeta.getPatterns());
+		if (!patterns.isEmpty()) data.setAttribute(PATTERNS, patterns);
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
@@ -61,7 +64,8 @@ public class BannerHandler {
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BannerMeta)) return;
 
-		data.setAttribute(PATTERNS, ((BannerMeta) meta).getPatterns());
+		List<Pattern> patterns = ((BannerMeta) meta).getPatterns();
+		if (!patterns.isEmpty()) data.setAttribute(PATTERNS, ((BannerMeta) meta).getPatterns());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -49,7 +49,7 @@ public class BannerHandler {
 			bannerMeta.addPattern(pattern);
 		}
 
-		if (!bannerMeta.getPatterns().isEmpty()) data.setAttribute(PATTERNS, bannerMeta.getPatterns());
+		data.setAttribute(PATTERNS, bannerMeta.getPatterns());
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
@@ -64,7 +64,7 @@ public class BannerHandler {
 		if (!(meta instanceof BannerMeta)) return;
 
 		List<Pattern> patterns = ((BannerMeta) meta).getPatterns();
-		if (!patterns.isEmpty()) data.setAttribute(PATTERNS, patterns);
+		data.setAttribute(PATTERNS, patterns);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
 
+import com.nisovin.magicspells.handlers.DebugHandler;
 import org.bukkit.DyeColor;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.block.banner.Pattern;
@@ -11,14 +12,14 @@ import org.bukkit.inventory.meta.BannerMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.PATTERNS;
 
 public class BannerHandler {
 
-	private static final String CONFIG_NAME = "patterns";
+	private static final String CONFIG_NAME = PATTERNS.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BannerMeta)) return meta;
-		if (!config.contains(CONFIG_NAME)) return meta;
 		if (!config.isList(CONFIG_NAME)) return meta;
 
 		BannerMeta bannerMeta = (BannerMeta) meta;
@@ -30,38 +31,50 @@ public class BannerHandler {
 			if (args.length < 2) continue;
 
 			PatternType patternType = PatternType.getByIdentifier(args[0].toLowerCase());
-			if (patternType == null) patternType = PatternType.valueOf(args[0].toUpperCase());
-			if (patternType == null) continue;
+			try {
+				if (patternType == null) patternType = PatternType.valueOf(args[0].toUpperCase());
+			} catch (IllegalArgumentException e) {
+				DebugHandler.debugBadEnumValue(PatternType.class, args[0].toUpperCase());
+				continue;
+			}
 
-			DyeColor dyeColor = DyeColor.valueOf(args[1].toUpperCase());
-			if (dyeColor == null) dyeColor = DyeColor.WHITE;
+			DyeColor dyeColor;
+			try {
+				dyeColor = DyeColor.valueOf(args[1].toUpperCase());
+			} catch (IllegalArgumentException e) {
+				DebugHandler.debugBadEnumValue(DyeColor.class, args[1].toUpperCase());
+				continue;
+			}
 
 			Pattern pattern = new Pattern(dyeColor, patternType);
 			bannerMeta.addPattern(pattern);
 		}
 
-		if (!bannerMeta.getPatterns().isEmpty()) data.setPatterns(bannerMeta.getPatterns());
+		if (!bannerMeta.getPatterns().isEmpty()) data.setItemAttribute(PATTERNS, bannerMeta.getPatterns());
 		return bannerMeta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof BannerMeta)) return meta;
+		if (!data.hasItemAttribute(PATTERNS)) return meta;
 
+		List<Pattern> patterns = (List<Pattern>) data.getItemAttribute(PATTERNS);
 		BannerMeta bannerMeta = (BannerMeta) meta;
-		if (data.getPatterns() == null) return meta;
+		((BannerMeta) meta).setPatterns(patterns);
 
-		((BannerMeta) meta).setPatterns(data.getPatterns());
 		return bannerMeta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
 		if (data == null) return null;
 		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof BannerMeta)) return data;
 
-		BannerMeta meta = (BannerMeta) itemStack.getItemMeta();
-		if (!meta.getPatterns().isEmpty()) data.setPatterns(meta.getPatterns());
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof BannerMeta)) return data;
+
+		List<Pattern> patterns = ((BannerMeta) itemStack.getItemMeta()).getPatterns();
+		if (!patterns.isEmpty()) data.setItemAttribute(PATTERNS, patterns);
+
 		return data;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -54,17 +54,14 @@ public class BannerHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BannerMeta)) return;
-		if (!data.hasAttribute(PATTERNS)) return;
 
-		List<Pattern> patterns = (List<Pattern>) data.getAttribute(PATTERNS);
-		((BannerMeta) meta).setPatterns(patterns);
+		if (data.hasAttribute(PATTERNS)) ((BannerMeta) meta).setPatterns((List<Pattern>) data.getAttribute(PATTERNS));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BannerMeta)) return;
 
-		List<Pattern> patterns = ((BannerMeta) meta).getPatterns();
-		data.setAttribute(PATTERNS, patterns);
+		data.setAttribute(PATTERNS, ((BannerMeta) meta).getPatterns());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
@@ -1,45 +1,34 @@
 package com.nisovin.magicspells.util.itemreader;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.CUSTOM_MODEL_DATA;
-
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.CUSTOM_MODEL_DATA;
 
 public class CustomModelDataHandler {
 
 	private static final String CONFIG_NAME = CUSTOM_MODEL_DATA.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.isInt(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!config.isInt(CONFIG_NAME)) return;
 
 		int customModelData = config.getInt(CONFIG_NAME);
 
 		ItemUtil.setCustomModelData(meta, customModelData);
-		data.setItemAttribute(CUSTOM_MODEL_DATA, customModelData);
-		return meta;
+		data.setAttribute(CUSTOM_MODEL_DATA, customModelData);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (meta == null) return null;
-		if (data == null) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!data.hasAttribute(CUSTOM_MODEL_DATA)) return;
 
-		if (!data.hasItemAttribute(CUSTOM_MODEL_DATA)) return meta;
-		int customModelData = (int) data.getItemAttribute(CUSTOM_MODEL_DATA);
+		int customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
 		ItemUtil.setCustomModelData(meta, customModelData);
-
-		return meta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
-		if (itemData == null) return null;
-		if (itemStack == null) return itemData;
-
-		itemData.setItemAttribute(CUSTOM_MODEL_DATA, ItemUtil.getCustomModelData(itemStack.getItemMeta()));
-		return itemData;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		data.setAttribute(CUSTOM_MODEL_DATA, ItemUtil.getCustomModelData(meta));
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
@@ -21,10 +21,7 @@ public class CustomModelDataHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!data.hasAttribute(CUSTOM_MODEL_DATA)) return;
-
-		int customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
-		meta.setCustomModelData(customModelData);
+		if (data.hasAttribute(CUSTOM_MODEL_DATA)) meta.setCustomModelData((int) data.getAttribute(CUSTOM_MODEL_DATA));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
@@ -6,19 +6,20 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.CUSTOM_MODEL_DATA;
+
 
 public class CustomModelDataHandler {
 
-	private static final String CONFIG_NAME = "custom-model-data";
+	private static final String CONFIG_NAME = CUSTOM_MODEL_DATA.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.contains(CONFIG_NAME)) return meta;
 		if (!config.isInt(CONFIG_NAME)) return meta;
 
 		int customModelData = config.getInt(CONFIG_NAME);
 
 		ItemUtil.setCustomModelData(meta, customModelData);
-		data.setCustomModelData(customModelData);
+		data.setItemAttribute(CUSTOM_MODEL_DATA, customModelData);
 		return meta;
 	}
 
@@ -26,10 +27,10 @@ public class CustomModelDataHandler {
 		if (meta == null) return null;
 		if (data == null) return meta;
 
-		int customModelData = data.getCustomModelData();
-		if (customModelData <= 0) return meta;
-
+		if (!data.hasItemAttribute(CUSTOM_MODEL_DATA)) return meta;
+		int customModelData = (int) data.getItemAttribute(CUSTOM_MODEL_DATA);
 		ItemUtil.setCustomModelData(meta, customModelData);
+
 		return meta;
 	}
 
@@ -37,7 +38,7 @@ public class CustomModelDataHandler {
 		if (itemData == null) return null;
 		if (itemStack == null) return itemData;
 
-		itemData.setCustomModelData(ItemUtil.getCustomModelData(itemStack.getItemMeta()));
+		itemData.setItemAttribute(CUSTOM_MODEL_DATA, ItemUtil.getCustomModelData(itemStack.getItemMeta()));
 		return itemData;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
@@ -16,7 +16,7 @@ public class CustomModelDataHandler {
 
 		int customModelData = config.getInt(CONFIG_NAME);
 
-		ItemUtil.setCustomModelData(meta, customModelData);
+		meta.setCustomModelData(customModelData);
 		data.setAttribute(CUSTOM_MODEL_DATA, customModelData);
 	}
 
@@ -24,11 +24,11 @@ public class CustomModelDataHandler {
 		if (!data.hasAttribute(CUSTOM_MODEL_DATA)) return;
 
 		int customModelData = (int) data.getAttribute(CUSTOM_MODEL_DATA);
-		ItemUtil.setCustomModelData(meta, customModelData);
+		meta.setCustomModelData(customModelData);
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		data.setAttribute(CUSTOM_MODEL_DATA, ItemUtil.getCustomModelData(meta));
+		if (meta.hasCustomModelData()) data.setAttribute(CUSTOM_MODEL_DATA, meta.getCustomModelData());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/CustomModelDataHandler.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells.util.itemreader;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
-import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.CUSTOM_MODEL_DATA;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
@@ -6,33 +6,30 @@ import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.DURABILITY;
 
 public class DurabilityHandler {
 
-	private static final String CONFIG_NAME = "durability";
+	private static final String CONFIG_NAME = DURABILITY.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Damageable)) return meta;
-		Damageable damageableMeta = (Damageable) meta;
-		data.setDurability(damageableMeta.getDamage());
-
-		if (!config.contains(CONFIG_NAME)) return meta;
 		if (!config.isInt(CONFIG_NAME)) return meta;
 
 		int durability = config.getInt(CONFIG_NAME);
+		((Damageable) meta).setDamage(durability);
+		data.setItemAttribute(DURABILITY, durability);
 
-		damageableMeta.setDamage(durability);
-		data.setDurability(durability);
 		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof Damageable)) return meta;
+		if (!data.hasItemAttribute(DURABILITY)) return meta;
 
-		int durability = data.getDurability();
-
+		int durability = (int) data.getItemAttribute(DURABILITY);
 		((Damageable) meta).setDamage(durability);
+
 		return meta;
 	}
 
@@ -42,7 +39,7 @@ public class DurabilityHandler {
 		if (!(itemStack.getItemMeta() instanceof Damageable)) return itemData;
 
 		int damage = ((Damageable) itemStack.getItemMeta()).getDamage();
-		itemData.setDurability(damage);
+		itemData.setItemAttribute(DURABILITY, damage);
 		
 		return itemData;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
@@ -22,17 +22,15 @@ public class DurabilityHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Damageable)) return;
-		if (!data.hasAttribute(DURABILITY)) return;
 
-		int durability = (int) data.getAttribute(DURABILITY);
-		((Damageable) meta).setDamage(durability);
+		if (data.hasAttribute(DURABILITY)) ((Damageable) meta).setDamage((int) data.getAttribute(DURABILITY));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Damageable)) return;
 
-		int damage = ((Damageable) meta).getDamage();
-		data.setAttribute(DURABILITY, damage);
+		Damageable damageableMeta = (Damageable) meta;
+		if (damageableMeta.hasDamage()) data.setAttribute(DURABILITY, damageableMeta.getDamage());
 	}
 
 	public static int getDurability(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
@@ -1,47 +1,38 @@
 package com.nisovin.magicspells.util.itemreader;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Damageable;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.DURABILITY;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.DURABILITY;
 
 public class DurabilityHandler {
 
 	private static final String CONFIG_NAME = DURABILITY.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Damageable)) return meta;
-		if (!config.isInt(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Damageable)) return;
+		if (!config.isInt(CONFIG_NAME)) return;
 
 		int durability = config.getInt(CONFIG_NAME);
 		((Damageable) meta).setDamage(durability);
-		data.setItemAttribute(DURABILITY, durability);
-
-		return meta;
+		data.setAttribute(DURABILITY, durability);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Damageable)) return meta;
-		if (!data.hasItemAttribute(DURABILITY)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Damageable)) return;
+		if (!data.hasAttribute(DURABILITY)) return;
 
-		int durability = (int) data.getItemAttribute(DURABILITY);
+		int durability = (int) data.getAttribute(DURABILITY);
 		((Damageable) meta).setDamage(durability);
-
-		return meta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
-		if (itemData == null) return null;
-		if (itemStack == null) return itemData;
-		if (!(itemStack.getItemMeta() instanceof Damageable)) return itemData;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Damageable)) return;
 
-		int damage = ((Damageable) itemStack.getItemMeta()).getDamage();
-		itemData.setItemAttribute(DURABILITY, damage);
-		
-		return itemData;
+		int damage = ((Damageable) meta).getDamage();
+		data.setAttribute(DURABILITY, damage);
 	}
 
 	public static int getDurability(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
@@ -76,16 +76,15 @@ public class FireworkEffectHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof FireworkEffectMeta)) return;
-		if (!data.hasAttribute(FIREWORK_EFFECT)) return;
 
-		((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getAttribute(FIREWORK_EFFECT));
+		if (data.hasAttribute(FIREWORK_EFFECT)) ((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getAttribute(FIREWORK_EFFECT));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof FireworkEffectMeta)) return;
 
-		FireworkEffect effect = ((FireworkEffectMeta) meta).getEffect();
-		data.setAttribute(FIREWORK_EFFECT, effect);
+		FireworkEffectMeta effectMeta = (FireworkEffectMeta) meta;
+		if (effectMeta.hasEffect()) data.setAttribute(FIREWORK_EFFECT, effectMeta.getEffect());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
@@ -10,6 +10,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.FIREWORK_EFFECT;
 
 public class FireworkEffectHandler {
 
@@ -30,23 +31,23 @@ public class FireworkEffectHandler {
 		Color[] colors = null;
 		Color[] fadeColors = null;
 
-		if (config.contains(TYPE_CONFIG_NAME) && config.isString(TYPE_CONFIG_NAME)) {
+		if (config.isString(TYPE_CONFIG_NAME)) {
 			type = config.getString(TYPE_CONFIG_NAME).trim();
 		}
 
-		if (config.contains(TRAIL_CONFIG_NAME) && config.isBoolean(TRAIL_CONFIG_NAME)) {
+		if (config.isBoolean(TRAIL_CONFIG_NAME)) {
 			trail = config.getBoolean(TRAIL_CONFIG_NAME);
 		}
 
-		if (config.contains(FLICKER_CONFIG_NAME) && config.isBoolean(FLICKER_CONFIG_NAME)) {
+		if (config.isBoolean(FLICKER_CONFIG_NAME)) {
 			flicker = config.getBoolean(FLICKER_CONFIG_NAME);
 		}
 
-		if (config.contains(COLORS_CONFIG_NAME) && config.isString(COLORS_CONFIG_NAME)) {
+		if (config.isString(COLORS_CONFIG_NAME)) {
 			colors = Util.getColorsFromString(config.getString(COLORS_CONFIG_NAME, "FF0000"));
 		}
 
-		if (config.contains(FADE_COLORS_CONFIG_NAME) && config.isString(FADE_COLORS_CONFIG_NAME)) {
+		if (config.isString(FADE_COLORS_CONFIG_NAME)) {
 			fadeColors = Util.getColorsFromString(config.getString(FADE_COLORS_CONFIG_NAME, "FF0000"));
 		}
 
@@ -71,32 +72,30 @@ public class FireworkEffectHandler {
 				.withFade(fadeColors)
 				.build();
 
-		FireworkEffectMeta fireworkEffectMeta = (FireworkEffectMeta) meta;
+		((FireworkEffectMeta) meta).setEffect(effect);
+		data.setItemAttribute(FIREWORK_EFFECT, effect);
 
-		fireworkEffectMeta.setEffect(effect);
-		data.setFireworkEffect(effect);
-
-		return fireworkEffectMeta;
+		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof FireworkEffectMeta)) return meta;
+		if (!data.hasItemAttribute(FIREWORK_EFFECT)) return meta;
 
-		if (data.getFireworkEffect() == null) return meta;
-		FireworkEffectMeta fireworkEffectMeta = (FireworkEffectMeta) meta;
-
-		fireworkEffectMeta.setEffect(data.getFireworkEffect());
-		return fireworkEffectMeta;
+		((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getItemAttribute(FIREWORK_EFFECT));
+		return meta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
 		if (data == null) return null;
 		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof FireworkEffectMeta)) return data;
 
-		FireworkEffectMeta meta = (FireworkEffectMeta) itemStack.getItemMeta();
-		data.setFireworkEffect(meta.getEffect());
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof FireworkEffectMeta)) return data;
+
+		FireworkEffect effect = ((FireworkEffectMeta) meta).getEffect();
+		data.setItemAttribute(FIREWORK_EFFECT, effect);
+
 		return data;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
@@ -2,7 +2,6 @@ package com.nisovin.magicspells.util.itemreader;
 
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.FireworkEffectMeta;
 import org.bukkit.configuration.ConfigurationSection;
@@ -10,7 +9,7 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.FIREWORK_EFFECT;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.FIREWORK_EFFECT;
 
 public class FireworkEffectHandler {
 
@@ -20,10 +19,10 @@ public class FireworkEffectHandler {
 	private static final String COLORS_CONFIG_NAME = "colors";
 	private static final String FADE_COLORS_CONFIG_NAME = "fade-colors";
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkEffectMeta)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkEffectMeta)) return;
 
-		String type = "ball";
+		String type = "BALL";
 
 		boolean trail = false;
 		boolean flicker = false;
@@ -32,7 +31,7 @@ public class FireworkEffectHandler {
 		Color[] fadeColors = null;
 
 		if (config.isString(TYPE_CONFIG_NAME)) {
-			type = config.getString(TYPE_CONFIG_NAME).trim();
+			type = config.getString(TYPE_CONFIG_NAME).trim().toUpperCase();
 		}
 
 		if (config.isBoolean(TRAIL_CONFIG_NAME)) {
@@ -52,17 +51,16 @@ public class FireworkEffectHandler {
 		}
 
 		// colors cant be null
-		if (colors == null) return meta;
+		if (colors == null) return;
 		if (fadeColors == null) fadeColors = new Color[0];
 
-		FireworkEffect.Type fireworkType = null;
+		FireworkEffect.Type fireworkType;
 		try {
-			fireworkType = FireworkEffect.Type.valueOf(type.toUpperCase());
+			fireworkType = FireworkEffect.Type.valueOf(type);
 		} catch (IllegalArgumentException e) {
-			DebugHandler.debugIllegalArgumentException(e);
+			DebugHandler.debugBadEnumValue(FireworkEffect.Type.class, type);
+			return;
 		}
-
-		if (fireworkType == null) return meta;
 
 		FireworkEffect effect = FireworkEffect.builder()
 				.flicker(flicker)
@@ -73,30 +71,21 @@ public class FireworkEffectHandler {
 				.build();
 
 		((FireworkEffectMeta) meta).setEffect(effect);
-		data.setItemAttribute(FIREWORK_EFFECT, effect);
-
-		return meta;
+		data.setAttribute(FIREWORK_EFFECT, effect);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkEffectMeta)) return meta;
-		if (!data.hasItemAttribute(FIREWORK_EFFECT)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkEffectMeta)) return;
+		if (!data.hasAttribute(FIREWORK_EFFECT)) return;
 
-		((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getItemAttribute(FIREWORK_EFFECT));
-		return meta;
+		((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getAttribute(FIREWORK_EFFECT));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
-
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof FireworkEffectMeta)) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkEffectMeta)) return;
 
 		FireworkEffect effect = ((FireworkEffectMeta) meta).getEffect();
-		data.setItemAttribute(FIREWORK_EFFECT, effect);
-
-		return data;
+		data.setAttribute(FIREWORK_EFFECT, effect);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
@@ -86,7 +86,7 @@ public class FireworkHandler {
 
 		FireworkMeta fireworkMeta = (FireworkMeta) meta;
 		data.setAttribute(POWER, fireworkMeta.getPower());
-		data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
+		if (fireworkMeta.hasEffects()) data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
@@ -65,8 +65,10 @@ public class FireworkHandler {
 				fireworkEffects.add(effect);
 			}
 
-			fireworkMeta.addEffects(fireworkEffects);
-			data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
+			if (!fireworkEffects.isEmpty()) {
+				fireworkMeta.addEffects(fireworkEffects);
+				data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
+			}
 		}
 
 		fireworkMeta.setPower(power);
@@ -86,7 +88,10 @@ public class FireworkHandler {
 
 		FireworkMeta fireworkMeta = (FireworkMeta) meta;
 		data.setAttribute(POWER, fireworkMeta.getPower());
-		if (fireworkMeta.hasEffects()) data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
+		if (fireworkMeta.hasEffects()) {
+			List<FireworkEffect> effects = fireworkMeta.getEffects();
+			if (!effects.isEmpty()) data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
+		}
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
@@ -5,7 +5,6 @@ import java.util.ArrayList;
 
 import org.bukkit.Color;
 import org.bukkit.FireworkEffect;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.FireworkMeta;
 import org.bukkit.configuration.ConfigurationSection;
@@ -13,17 +12,17 @@ import org.bukkit.configuration.ConfigurationSection;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.POWER;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.FIREWORK_EFFECTS;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.POWER;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.FIREWORK_EFFECTS;
 
 public class FireworkHandler {
 
 	private static final String FIREWORK_EFFECTS_CONFIG_NAME = FIREWORK_EFFECTS.toString();
 	private static final String POWER_CONFIG_NAME = POWER.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkMeta)) return meta;
-		if (!config.isList(FIREWORK_EFFECTS_CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkMeta)) return;
+		if (!config.isList(FIREWORK_EFFECTS_CONFIG_NAME)) return;
 
 		FireworkMeta fireworkMeta = (FireworkMeta) meta;
 
@@ -67,39 +66,27 @@ public class FireworkHandler {
 			}
 
 			fireworkMeta.addEffects(fireworkEffects);
-			data.setItemAttribute(FIREWORK_EFFECTS, fireworkEffects);
+			data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
 		}
 
 		fireworkMeta.setPower(power);
-		data.setItemAttribute(POWER, power);
-
-		return meta;
+		data.setAttribute(POWER, power);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkMeta)) return;
 
 		FireworkMeta fireworkMeta = (FireworkMeta) meta;
-		fireworkMeta.setPower((int) data.getItemAttribute(POWER));
-
-		if (!data.hasItemAttribute(FIREWORK_EFFECTS)) return fireworkMeta;
-		fireworkMeta.addEffects((List<FireworkEffect>) data.getItemAttribute(FIREWORK_EFFECTS));
-
-		return fireworkMeta;
+		if (data.hasAttribute(POWER)) fireworkMeta.setPower((int) data.getAttribute(POWER));
+		if (data.hasAttribute(FIREWORK_EFFECTS)) fireworkMeta.addEffects((List<FireworkEffect>) data.getAttribute(FIREWORK_EFFECTS));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof FireworkMeta)) return;
 
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof FireworkMeta)) return data;
 		FireworkMeta fireworkMeta = (FireworkMeta) meta;
-
-		data.setItemAttribute(POWER, fireworkMeta.getPower());
-		data.setItemAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
-
-		return data;
+		data.setAttribute(POWER, fireworkMeta.getPower());
+		data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
@@ -32,10 +32,9 @@ public class LeatherArmorHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof LeatherArmorMeta)) return;
-
-		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
 		if (!data.hasAttribute(COLOR)) return;
 
+		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
 		armorMeta.setColor((Color) data.getAttribute(COLOR));
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
@@ -8,22 +8,24 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.COLOR;
 
 public class LeatherArmorHandler {
 
-	private final static String CONFIG_NAME = "color";
+	private final static String CONFIG_NAME = COLOR.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof LeatherArmorMeta)) return meta;
-		if (!config.contains(CONFIG_NAME)) return meta;
-		if (!config.isSet(CONFIG_NAME)) return meta;
+		if (!config.isString(CONFIG_NAME)) return meta;
 
 		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
 
 		try {
-			int color = Integer.parseInt(config.get(CONFIG_NAME).toString().replace("#", ""), 16);
-			armorMeta.setColor(Color.fromRGB(color));
-			if (data != null) data.setColor(Color.fromRGB(color));
+			int color = Integer.parseInt(config.getString(CONFIG_NAME).replace("#", ""), 16);
+			Color c = Color.fromRGB(color);
+
+			armorMeta.setColor(c);
+			if (data != null) data.setItemAttribute(COLOR, c);
 		} catch (NumberFormatException e) {
 			DebugHandler.debugNumberFormat(e);
 		}
@@ -35,27 +37,27 @@ public class LeatherArmorHandler {
 		if (!(meta instanceof LeatherArmorMeta)) return meta;
 
 		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
+		if (!data.hasItemAttribute(COLOR)) return meta;
 
-		if (data.getColor() == null) return meta;
-
-		armorMeta.setColor(data.getColor());
+		armorMeta.setColor((Color) data.getItemAttribute(COLOR));
 		return armorMeta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
 		if (data == null) return null;
 		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof LeatherArmorMeta)) return data;
-		LeatherArmorMeta meta = (LeatherArmorMeta) itemStack.getItemMeta();
 
-		Color color = meta.getColor();
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof LeatherArmorMeta)) return data;
+
+		Color color = ((LeatherArmorMeta) meta).getColor();
 
 		String hex = Integer.toHexString(color.getRed()).toUpperCase() +
 				Integer.toHexString(color.getGreen()).toUpperCase() +
 				Integer.toHexString(color.getBlue()).toUpperCase();
 
 		// default color is null
-		if (!hex.equals("A06540")) data.setColor(meta.getColor());
+		if (!hex.equals("A06540")) data.setItemAttribute(COLOR, color);
 		return data;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
@@ -1,22 +1,21 @@
 package com.nisovin.magicspells.util.itemreader;
 
 import org.bukkit.Color;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.LeatherArmorMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.COLOR;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.COLOR;
 
 public class LeatherArmorHandler {
 
 	private final static String CONFIG_NAME = COLOR.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof LeatherArmorMeta)) return meta;
-		if (!config.isString(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof LeatherArmorMeta)) return;
+		if (!config.isString(CONFIG_NAME)) return;
 
 		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
 
@@ -25,30 +24,23 @@ public class LeatherArmorHandler {
 			Color c = Color.fromRGB(color);
 
 			armorMeta.setColor(c);
-			if (data != null) data.setItemAttribute(COLOR, c);
+			if (data != null) data.setAttribute(COLOR, c);
 		} catch (NumberFormatException e) {
 			DebugHandler.debugNumberFormat(e);
 		}
-
-		return armorMeta;
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof LeatherArmorMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof LeatherArmorMeta)) return;
 
 		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-		if (!data.hasItemAttribute(COLOR)) return meta;
+		if (!data.hasAttribute(COLOR)) return;
 
-		armorMeta.setColor((Color) data.getItemAttribute(COLOR));
-		return armorMeta;
+		armorMeta.setColor((Color) data.getAttribute(COLOR));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
-
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof LeatherArmorMeta)) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof LeatherArmorMeta)) return;
 
 		Color color = ((LeatherArmorMeta) meta).getColor();
 
@@ -57,8 +49,7 @@ public class LeatherArmorHandler {
 				Integer.toHexString(color.getBlue()).toUpperCase();
 
 		// default color is null
-		if (!hex.equals("A06540")) data.setItemAttribute(COLOR, color);
-		return data;
+		if (!hex.equals("A06540")) data.setAttribute(COLOR, color);
 	}
 
 	public static Color getColor(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -23,8 +23,10 @@ public class LoreHandler {
 				lore.set(i, Util.colorize(lore.get(i)));
 			}
 
-			meta.setLore(lore);
-			data.setAttribute(LORE, lore);
+			if (!lore.isEmpty()) {
+				meta.setLore(lore);
+				data.setAttribute(LORE, lore);
+			}
 		} else if (config.isString(CONFIG_NAME)) {
 			List<String> lore = Collections.singletonList(Util.colorize(config.getString(CONFIG_NAME)));
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -1,49 +1,51 @@
 package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
-import java.util.ArrayList;
+import java.util.Collections;
 
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.LORE;
 
 public class LoreHandler {
 
-	private static final String CONFIG_NAME = "lore";
+	private static final String CONFIG_NAME = LORE.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!config.contains(CONFIG_NAME)) return meta;
-		if (config.isList(CONFIG_NAME)) {
 
+		if (config.isList(CONFIG_NAME)) {
 			List<String> lore = config.getStringList(CONFIG_NAME);
 			for (int i = 0; i < lore.size(); i++) {
 				lore.set(i, Util.colorize(lore.get(i)));
 			}
 
 			meta.setLore(lore);
-			if (data != null) data.setLore(lore);
+			data.setItemAttribute(LORE, lore);
 		} else if (config.isString(CONFIG_NAME)) {
-			List<String> lore = new ArrayList<>();
-			lore.add(Util.colorize(config.getString(CONFIG_NAME)));
+			List<String> lore = Collections.singletonList(Util.colorize(config.getString(CONFIG_NAME)));
+
 			meta.setLore(lore);
-			if (data != null) data.setLore(lore);
+			data.setItemAttribute(LORE, lore);
 		}
+
 		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
 		if (meta == null) return null;
 		if (data == null) return meta;
-		if (data.getLore() == null) return meta;
+		if (!data.hasItemAttribute(LORE)) return meta;
 
-		List<String> lore = data.getLore();
+		List<String> lore = (List<String>) data.getItemAttribute(LORE);
 		for (int i = 0; i < lore.size(); i++) {
 			lore.set(i, Util.colorize(lore.get(i)));
 		}
-
 		meta.setLore(lore);
+
 		return meta;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -25,7 +25,7 @@ public class LoreHandler {
 
 			if (!lore.isEmpty()) {
 				meta.setLore(lore);
-				data.setAttribute(LORE, lore);
+				data.setAttribute(LORE, meta.getLore());
 			}
 		} else if (config.isString(CONFIG_NAME)) {
 			List<String> lore = Collections.singletonList(Util.colorize(config.getString(CONFIG_NAME)));

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -8,14 +8,14 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.LORE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.LORE;
 
 public class LoreHandler {
 
 	private static final String CONFIG_NAME = LORE.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.contains(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!config.contains(CONFIG_NAME)) return;
 
 		if (config.isList(CONFIG_NAME)) {
 			List<String> lore = config.getStringList(CONFIG_NAME);
@@ -24,29 +24,23 @@ public class LoreHandler {
 			}
 
 			meta.setLore(lore);
-			data.setItemAttribute(LORE, lore);
+			data.setAttribute(LORE, lore);
 		} else if (config.isString(CONFIG_NAME)) {
 			List<String> lore = Collections.singletonList(Util.colorize(config.getString(CONFIG_NAME)));
 
 			meta.setLore(lore);
-			data.setItemAttribute(LORE, lore);
+			data.setAttribute(LORE, lore);
 		}
-
-		return meta;
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (meta == null) return null;
-		if (data == null) return meta;
-		if (!data.hasItemAttribute(LORE)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!data.hasAttribute(LORE)) return;
 
-		List<String> lore = (List<String>) data.getItemAttribute(LORE);
+		List<String> lore = (List<String>) data.getAttribute(LORE);
 		for (int i = 0; i < lore.size(); i++) {
 			lore.set(i, Util.colorize(lore.get(i)));
 		}
 		meta.setLore(lore);
-
-		return meta;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -34,13 +34,7 @@ public class LoreHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!data.hasAttribute(LORE)) return;
-
-		List<String> lore = (List<String>) data.getAttribute(LORE);
-		for (int i = 0; i < lore.size(); i++) {
-			lore.set(i, Util.colorize(lore.get(i)));
-		}
-		meta.setLore(lore);
+		if (data.hasAttribute(LORE)) meta.setLore((List<String>) data.getAttribute(LORE));
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -16,7 +16,7 @@ public class NameHandler {
 
 		String name = Util.colorize(config.getString(CONFIG_NAME));
 		meta.setDisplayName(name);
-		data.setAttribute(NAME, name);
+		data.setAttribute(NAME, meta.getDisplayName());
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -1,47 +1,32 @@
 package com.nisovin.magicspells.util.itemreader;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.*;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
 public class NameHandler {
 
 	private static final String CONFIG_NAME = NAME.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.isString(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!config.isString(CONFIG_NAME)) return;
 
 		String name = config.getString(CONFIG_NAME);
 		meta.setDisplayName(Util.colorize(name));
-		data.setItemAttribute(NAME, Util.decolorize(name));
-
-		return meta;
+		data.setAttribute(NAME, Util.decolorize(name));
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (meta == null) return null;
-		if (data == null) return meta;
-		if (!data.hasItemAttribute(NAME)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!data.hasAttribute(NAME)) return;
 
-		meta.setDisplayName(Util.colorize((String) data.getItemAttribute(NAME)));
-
-		return meta;
+		meta.setDisplayName(Util.colorize((String) data.getAttribute(NAME)));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
-		if (itemData == null) return null;
-		if (itemStack == null) return itemData;
-
-		ItemMeta meta = itemStack.getItemMeta();
-		if (meta == null) return itemData;
-
-		if (!meta.getDisplayName().isEmpty()) itemData.setItemAttribute(NAME, Util.decolorize(meta.getDisplayName()));
-		return itemData;
-
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!meta.getDisplayName().isEmpty()) data.setAttribute(NAME, Util.decolorize(meta.getDisplayName()));
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -14,19 +14,17 @@ public class NameHandler {
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!config.isString(CONFIG_NAME)) return;
 
-		String name = config.getString(CONFIG_NAME);
-		meta.setDisplayName(Util.colorize(name));
-		data.setAttribute(NAME, Util.decolorize(name));
+		String name = Util.colorize(config.getString(CONFIG_NAME));
+		meta.setDisplayName(name);
+		data.setAttribute(NAME, name);
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!data.hasAttribute(NAME)) return;
-
-		meta.setDisplayName(Util.colorize((String) data.getAttribute(NAME)));
+		if (data.hasAttribute(NAME)) meta.setDisplayName((String) data.getAttribute(NAME));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!meta.getDisplayName().isEmpty()) data.setAttribute(NAME, Util.decolorize(meta.getDisplayName()));
+		if (meta.hasDisplayName()) data.setAttribute(NAME, meta.getDisplayName());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -6,37 +6,42 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.*;
 
 public class NameHandler {
 
-	private static final String CONFIG_NAME = "name";
+	private static final String CONFIG_NAME = NAME.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.contains(CONFIG_NAME)) return meta;
 		if (!config.isString(CONFIG_NAME)) return meta;
 
-		meta.setDisplayName(Util.colorize(config.getString(CONFIG_NAME)));
-		if (data != null) data.setName(Util.decolorize(config.getString(CONFIG_NAME)));
+		String name = config.getString(CONFIG_NAME);
+		meta.setDisplayName(Util.colorize(name));
+		data.setItemAttribute(NAME, Util.decolorize(name));
+
 		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
 		if (meta == null) return null;
 		if (data == null) return meta;
-		if (data.getName() == null) return meta;
+		if (!data.hasItemAttribute(NAME)) return meta;
 
-		meta.setDisplayName(Util.colorize(data.getName()));
+		meta.setDisplayName(Util.colorize((String) data.getItemAttribute(NAME)));
+
 		return meta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
 		if (itemData == null) return null;
 		if (itemStack == null) return itemData;
+
 		ItemMeta meta = itemStack.getItemMeta();
 		if (meta == null) return itemData;
 
-		if (!meta.getDisplayName().isEmpty()) itemData.setName(Util.decolorize(meta.getDisplayName()));
+		if (!meta.getDisplayName().isEmpty()) itemData.setItemAttribute(NAME, Util.decolorize(meta.getDisplayName()));
 		return itemData;
+
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -5,7 +5,7 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.NAME;
 
 public class NameHandler {
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
@@ -2,24 +2,21 @@ package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
 import java.util.ArrayList;
-import java.util.Locale;
 
-import com.nisovin.magicspells.handlers.DebugHandler;
 import org.bukkit.Color;
 import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.PotionMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.POTION_EFFECTS;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.POTION_TYPE;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.COLOR;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.COLOR;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.POTION_TYPE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.POTION_EFFECTS;
 
 public class PotionHandler {
 
@@ -27,8 +24,8 @@ public class PotionHandler {
 	public static final String POTION_TYPE_CONFIG_NAME = POTION_TYPE.toString();
 	public static final String POTION_COLOR_CONFIG_NAME = "potion-color";
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof PotionMeta)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof PotionMeta)) return;
 		
 		PotionMeta potionMeta = (PotionMeta) meta;
 		
@@ -46,7 +43,7 @@ public class PotionHandler {
 				potionEffects.add(eff);
 			}
 
-			data.setItemAttribute(POTION_EFFECTS, potionEffects);
+			data.setAttribute(POTION_EFFECTS, potionEffects);
 		}
 
 		if (config.isString(POTION_COLOR_CONFIG_NAME)) {
@@ -55,7 +52,7 @@ public class PotionHandler {
 				Color c = Color.fromRGB(color);
 
 				potionMeta.setColor(c);
-				data.setItemAttribute(COLOR, c);
+				data.setAttribute(COLOR, c);
 			} catch (NumberFormatException e) {
 				DebugHandler.debugNumberFormat(e);
 			}
@@ -69,40 +66,32 @@ public class PotionHandler {
 				PotionData potionData = new PotionData(potionType);
 
 				potionMeta.setBasePotionData(potionData);
-				data.setItemAttribute(POTION_TYPE, potionType);
+				data.setAttribute(POTION_TYPE, potionType);
 			} catch (IllegalArgumentException e) {
 				DebugHandler.debugBadEnumValue(PotionType.class, potionTypeString);
 			}
 		}
-		
-		return potionMeta;
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof PotionMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof PotionMeta)) return;
 
 		PotionMeta potionMeta = (PotionMeta) meta;
-		if (data.hasItemAttribute(POTION_EFFECTS)) {
+		if (data.hasAttribute(POTION_EFFECTS)) {
 			potionMeta.clearCustomEffects();
-			((List<PotionEffect>) data.getItemAttribute(POTION_EFFECTS)).forEach(potionEffect -> potionMeta.addCustomEffect(potionEffect, true));
+			((List<PotionEffect>) data.getAttribute(POTION_EFFECTS)).forEach(potionEffect -> potionMeta.addCustomEffect(potionEffect, true));
 		}
-		if (data.hasItemAttribute(COLOR)) potionMeta.setColor((Color) data.getItemAttribute(COLOR));
-		if (data.hasItemAttribute(POTION_TYPE)) potionMeta.setBasePotionData(new PotionData((PotionType) data.getItemAttribute(POTION_TYPE)));
-
-		return potionMeta;
+		if (data.hasAttribute(COLOR)) potionMeta.setColor((Color) data.getAttribute(COLOR));
+		if (data.hasAttribute(POTION_TYPE)) potionMeta.setBasePotionData(new PotionData((PotionType) data.getAttribute(POTION_TYPE)));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof PotionMeta)) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof PotionMeta)) return;
 
-		PotionMeta meta = (PotionMeta) itemStack.getItemMeta();
-		data.setItemAttribute(POTION_TYPE, meta.getBasePotionData().getType());
-		if (!meta.getCustomEffects().isEmpty()) data.setItemAttribute(POTION_EFFECTS, meta.getCustomEffects());
-		data.setItemAttribute(COLOR, meta.getColor());
-
-		return data;
+		PotionMeta potionMeta = (PotionMeta) meta;
+		data.setAttribute(POTION_TYPE, potionMeta.getBasePotionData().getType());
+		data.setAttribute(POTION_EFFECTS, potionMeta.getCustomEffects());
+		data.setAttribute(COLOR, potionMeta.getColor());
 	}
 
 	public static PotionType getPotionType(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
@@ -35,7 +35,6 @@ public class PotionHandler {
 			List<PotionEffect> potionEffects = new ArrayList<>();
 
 			for (String potionEffect : potionEffectStrings) {
-
 				PotionEffect eff = Util.buildPotionEffect(potionEffect);
 				if (eff == null) continue;
 
@@ -90,8 +89,8 @@ public class PotionHandler {
 
 		PotionMeta potionMeta = (PotionMeta) meta;
 		data.setAttribute(POTION_TYPE, potionMeta.getBasePotionData().getType());
-		data.setAttribute(POTION_EFFECTS, potionMeta.getCustomEffects());
-		data.setAttribute(COLOR, potionMeta.getColor());
+		if (potionMeta.hasCustomEffects()) data.setAttribute(POTION_EFFECTS, potionMeta.getCustomEffects());
+		if (potionMeta.hasColor()) data.setAttribute(COLOR, potionMeta.getColor());
 	}
 
 	public static PotionType getPotionType(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
@@ -61,9 +61,10 @@ public class PotionHandler {
 			String potionDataString = config.getString(POTION_DATA_CONFIG_NAME);
 			String[] args = potionDataString.split(" ");
 
+			boolean extended = false, upgraded = false;
+			PotionType potionType;
 			try {
-				PotionType potionType = PotionType.valueOf(args[0].toUpperCase());
-				boolean extended = false, upgraded = false;
+				potionType = PotionType.valueOf(args[0].toUpperCase());
 
 				if (args.length > 1) {
 					if (args[1].equalsIgnoreCase("extended")) extended = true;
@@ -75,7 +76,7 @@ public class PotionHandler {
 				potionMeta.setBasePotionData(potionData);
 				data.setAttribute(POTION_DATA, potionData);
 			} catch (IllegalArgumentException e) {
-				DebugHandler.debugBadEnumValue(PotionType.class, args[0]);
+				DebugHandler.debugIllegalArgumentException(e);
 			}
 		}
 	}
@@ -101,11 +102,11 @@ public class PotionHandler {
 		if (potionMeta.hasColor()) data.setAttribute(COLOR, potionMeta.getColor());
 	}
 
-	public static PotionType getPotionType(ItemMeta meta) {
+	public static PotionData getPotionData(ItemMeta meta) {
 		if (!(meta instanceof PotionMeta)) return null;
 
 		PotionMeta potionMeta = (PotionMeta) meta;
-		return potionMeta.getBasePotionData().getType();
+		return potionMeta.getBasePotionData();
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
@@ -42,7 +42,7 @@ public class PotionHandler {
 				potionEffects.add(eff);
 			}
 
-			data.setAttribute(POTION_EFFECTS, potionEffects);
+			if (!potionEffects.isEmpty()) data.setAttribute(POTION_EFFECTS, potionEffects);
 		}
 
 		if (config.isString(POTION_COLOR_CONFIG_NAME)) {
@@ -98,7 +98,10 @@ public class PotionHandler {
 
 		PotionMeta potionMeta = (PotionMeta) meta;
 		data.setAttribute(POTION_DATA, potionMeta.getBasePotionData());
-		if (potionMeta.hasCustomEffects()) data.setAttribute(POTION_EFFECTS, potionMeta.getCustomEffects());
+		if (potionMeta.hasCustomEffects()) {
+			List<PotionEffect> effects = potionMeta.getCustomEffects();
+			if (!effects.isEmpty()) data.setAttribute(POTION_EFFECTS, effects);
+		}
 		if (potionMeta.hasColor()) data.setAttribute(COLOR, potionMeta.getColor());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
@@ -22,15 +22,15 @@ public class RepairableHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Repairable)) return;
-		if (!data.hasAttribute(REPAIR_COST)) return;
 
-		((Repairable) meta).setRepairCost((int) data.getAttribute(REPAIR_COST));
+		if (data.hasAttribute(REPAIR_COST)) ((Repairable) meta).setRepairCost((int) data.getAttribute(REPAIR_COST));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Repairable)) return;
 
-		data.setAttribute(REPAIR_COST, ((Repairable) meta).getRepairCost());
+		Repairable repairMeta = (Repairable) meta;
+		if (repairMeta.hasRepairCost()) data.setAttribute(REPAIR_COST, repairMeta.getRepairCost());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
@@ -6,41 +6,39 @@ import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.REPAIR_COST;
 
 public class RepairableHandler {
 
-	private static final String CONFIG_NAME = "repair-cost";
+	private static final String CONFIG_NAME = REPAIR_COST.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Repairable)) return meta;
-		if (!config.contains(CONFIG_NAME)) return meta;
 		if (!config.isInt(CONFIG_NAME)) return meta;
 
 		int repairCost = config.getInt(CONFIG_NAME);
-
 		((Repairable) meta).setRepairCost(repairCost);
-		if (data != null) data.setRepairCost(repairCost);
+		if (data != null) data.setItemAttribute(REPAIR_COST, repairCost);
 
 		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof Repairable)) return meta;
+		if (!data.hasItemAttribute(REPAIR_COST)) return meta;
 
-		int repairCost = data.getRepairCost();
-		if (data.getRepairCost() < 0) return meta;
-
-		((Repairable) meta).setRepairCost(repairCost);
+		((Repairable) meta).setRepairCost((int) data.getItemAttribute(REPAIR_COST));
 		return meta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
 		if (itemData == null) return null;
 		if (itemStack == null) return itemData;
-		if (!(itemStack.getItemMeta() instanceof Repairable)) return itemData;
 
-		itemData.setRepairCost(((Repairable) itemStack.getItemMeta()).getRepairCost());
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof Repairable)) return itemData;
+
+		itemData.setItemAttribute(REPAIR_COST, ((Repairable) meta).getRepairCost());
 		return itemData;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
@@ -1,45 +1,36 @@
 package com.nisovin.magicspells.util.itemreader;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Repairable;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.REPAIR_COST;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.REPAIR_COST;
 
 public class RepairableHandler {
 
 	private static final String CONFIG_NAME = REPAIR_COST.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Repairable)) return meta;
-		if (!config.isInt(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Repairable)) return;
+		if (!config.isInt(CONFIG_NAME)) return;
 
 		int repairCost = config.getInt(CONFIG_NAME);
 		((Repairable) meta).setRepairCost(repairCost);
-		if (data != null) data.setItemAttribute(REPAIR_COST, repairCost);
-
-		return meta;
+		data.setAttribute(REPAIR_COST, repairCost);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Repairable)) return meta;
-		if (!data.hasItemAttribute(REPAIR_COST)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Repairable)) return;
+		if (!data.hasAttribute(REPAIR_COST)) return;
 
-		((Repairable) meta).setRepairCost((int) data.getItemAttribute(REPAIR_COST));
-		return meta;
+		((Repairable) meta).setRepairCost((int) data.getAttribute(REPAIR_COST));
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData itemData) {
-		if (itemData == null) return null;
-		if (itemStack == null) return itemData;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof Repairable)) return;
 
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof Repairable)) return itemData;
-
-		itemData.setItemAttribute(REPAIR_COST, ((Repairable) meta).getRepairCost());
-		return itemData;
+		data.setAttribute(REPAIR_COST, ((Repairable) meta).getRepairCost());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -3,14 +3,16 @@ package com.nisovin.magicspells.util.itemreader;
 import java.util.UUID;
 
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
-import com.nisovin.magicspells.util.Util;
+import com.destroystokyo.paper.profile.PlayerProfile;
+import com.destroystokyo.paper.profile.ProfileProperty;
+
+import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
+import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.TEXTURE;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.SIGNATURE;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.SKULL_OWNER;
@@ -26,61 +28,92 @@ public class SkullHandler {
 		if (!(meta instanceof SkullMeta)) return;
 		
 		SkullMeta skullMeta = (SkullMeta) meta;
-		OfflinePlayer offlinePlayer;
 
-		if (config.isString(SKULL_OWNER_CONFIG_NAME)) {
-			offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString(config.getString(SKULL_OWNER_CONFIG_NAME)));
-
-			skullMeta.setOwningPlayer(offlinePlayer);
-			data.setAttribute(SKULL_OWNER, offlinePlayer);
-		}
-
-		String uuid = null;
-		String texture = null;
-		String signature = null;
+		String signature = null, skullOwner = null, texture = null;
+		UUID uuid = null;
 
 		if (config.isString(UUID_CONFIG_NAME)) {
-			uuid = config.getString(UUID_CONFIG_NAME);
+			String uuidString = config.getString(UUID_CONFIG_NAME);
+
+			try {
+				uuid = UUID.fromString(uuidString);
+			} catch (IllegalArgumentException e) {
+				DebugHandler.debugIllegalArgumentException(e);
+			}
+
 			data.setAttribute(MagicItemAttribute.UUID, uuid);
 		}
+
 		if (config.isString(TEXTURE_CONFIG_NAME)) {
 			texture = config.getString(TEXTURE_CONFIG_NAME);
 			data.setAttribute(TEXTURE, texture);
 		}
+
 		if (config.isString(SIGNATURE_CONFIG_NAME)) {
 			signature = config.getString(SIGNATURE_CONFIG_NAME);
 			data.setAttribute(SIGNATURE, signature);
 		}
 
-		if (texture != null && skullMeta.getOwningPlayer() != null) {
-			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
+		if (config.isString(SKULL_OWNER_CONFIG_NAME)) {
+			skullOwner = config.getString(SKULL_OWNER_CONFIG_NAME);
+			data.setAttribute(SKULL_OWNER, skullOwner);
+		}
+
+		if ((uuid != null || skullOwner != null) && texture != null) {
+			PlayerProfile profile = Bukkit.createProfile(uuid, skullOwner);
+
+			profile.setProperty(new ProfileProperty("textures", texture, signature));
+			skullMeta.setPlayerProfile(profile);
 		}
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof SkullMeta)) return;
 
-		SkullMeta skullMeta = (SkullMeta) meta;
+		String signature = null, skullOwner = null, texture = null;
+		UUID uuid = null;
 
-		if (data.hasAttribute(SKULL_OWNER)) {
-			OfflinePlayer offlinePlayer = (OfflinePlayer) data.getAttribute(SKULL_OWNER);
-			skullMeta.setOwningPlayer(offlinePlayer);
+		if (data.hasAttribute(SKULL_OWNER)) skullOwner = (String) data.getAttribute(SKULL_OWNER);
+		if (data.hasAttribute(SIGNATURE)) signature = (String) data.getAttribute(SIGNATURE);
+		if (data.hasAttribute(TEXTURE)) texture = (String) data.getAttribute(TEXTURE);
+
+		if (data.hasAttribute(MagicItemAttribute.UUID)) {
+			try {
+				uuid = UUID.fromString((String) data.getAttribute(MagicItemAttribute.UUID));
+			} catch (IllegalArgumentException e) {
+				DebugHandler.debugIllegalArgumentException(e);
+			}
 		}
 
-		String uuid = (String) data.getAttribute(MagicItemAttribute.UUID);
-		String signature = (String) data.getAttribute(SIGNATURE);
-		String texture = (String) data.getAttribute(TEXTURE);
+		if ((uuid != null || skullOwner != null) && texture != null) {
+			PlayerProfile profile = Bukkit.createProfile(uuid, skullOwner);
 
-		if (texture != null && skullMeta.getOwningPlayer() != null) {
-			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
+			profile.setProperty(new ProfileProperty("textures", texture, signature));
+			((SkullMeta) meta).setPlayerProfile(profile);
 		}
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof SkullMeta)) return;
 
-		SkullMeta skullMeta = (SkullMeta) meta;
-		if (skullMeta.hasOwner()) data.setAttribute(SKULL_OWNER, skullMeta.getOwningPlayer());
+		PlayerProfile profile = ((SkullMeta) meta).getPlayerProfile();
+		if (profile == null) return;
+
+		UUID id = profile.getId();
+		if (id != null) data.setAttribute(MagicItemAttribute.UUID, id.toString());
+
+		String name = profile.getName();
+		if (name != null) data.setAttribute(SKULL_OWNER, name);
+
+		if (profile.hasTextures()) {
+			for (ProfileProperty property : profile.getProperties()) {
+				if (property.getName().equals("textures")) {
+					data.setAttribute(TEXTURE, property.getValue());
+					if (property.isSigned()) data.setAttribute(SIGNATURE, property.getSignature());
+					break;
+				}
+			}
+		}
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -4,27 +4,26 @@ import java.util.UUID;
 
 import org.bukkit.Bukkit;
 import org.bukkit.OfflinePlayer;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SkullMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.TEXTURE;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.SIGNATURE;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.SKULL_OWNER;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.TEXTURE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.SIGNATURE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.SKULL_OWNER;
 
 public class SkullHandler {
 
 	private static final String SKULL_OWNER_CONFIG_NAME = SKULL_OWNER.toString();
-	private static final String UUID_CONFIG_NAME = ItemAttribute.UUID.toString();
+	private static final String UUID_CONFIG_NAME = MagicItemAttribute.UUID.toString();
 	private static final String SIGNATURE_CONFIG_NAME = SIGNATURE.toString();
 	private static final String TEXTURE_CONFIG_NAME = TEXTURE.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SkullMeta)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SkullMeta)) return;
 		
 		SkullMeta skullMeta = (SkullMeta) meta;
 		OfflinePlayer offlinePlayer;
@@ -33,7 +32,7 @@ public class SkullHandler {
 			offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString(config.getString(SKULL_OWNER_CONFIG_NAME)));
 
 			skullMeta.setOwningPlayer(offlinePlayer);
-			data.setItemAttribute(SKULL_OWNER, offlinePlayer);
+			data.setAttribute(SKULL_OWNER, offlinePlayer);
 		}
 
 		String uuid = null;
@@ -42,52 +41,43 @@ public class SkullHandler {
 
 		if (config.isString(UUID_CONFIG_NAME)) {
 			uuid = config.getString(UUID_CONFIG_NAME);
-			data.setItemAttribute(ItemAttribute.UUID, uuid);
+			data.setAttribute(MagicItemAttribute.UUID, uuid);
 		}
 		if (config.isString(TEXTURE_CONFIG_NAME)) {
 			texture = config.getString(TEXTURE_CONFIG_NAME);
-			data.setItemAttribute(TEXTURE, texture);
+			data.setAttribute(TEXTURE, texture);
 		}
 		if (config.isString(SIGNATURE_CONFIG_NAME)) {
 			signature = config.getString(SIGNATURE_CONFIG_NAME);
-			data.setItemAttribute(SIGNATURE, signature);
+			data.setAttribute(SIGNATURE, signature);
 		}
 
 		if (texture != null && skullMeta.getOwningPlayer() != null) {
 			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
 		}
-
-		return meta;
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SkullMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SkullMeta)) return;
 
 		SkullMeta skullMeta = (SkullMeta) meta;
 
-		OfflinePlayer offlinePlayer = (OfflinePlayer) data.getItemAttribute(SKULL_OWNER);
+		OfflinePlayer offlinePlayer = (OfflinePlayer) data.getAttribute(SKULL_OWNER);
 		if (offlinePlayer != null) skullMeta.setOwningPlayer(offlinePlayer);
 
-		String uuid = (String) data.getItemAttribute(ItemAttribute.UUID);
-		String signature = (String) data.getItemAttribute(SIGNATURE);
-		String texture = (String) data.getItemAttribute(TEXTURE);
+		String uuid = (String) data.getAttribute(MagicItemAttribute.UUID);
+		String signature = (String) data.getAttribute(SIGNATURE);
+		String texture = (String) data.getAttribute(TEXTURE);
 
 		if (texture != null && skullMeta.getOwningPlayer() != null) {
 			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
 		}
-
-		return skullMeta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SkullMeta)) return;
 
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof SkullMeta)) return data;
-
-		data.setItemAttribute(SKULL_OWNER, ((SkullMeta) meta).getOwningPlayer());
-		return data;
+		data.setAttribute(SKULL_OWNER, ((SkullMeta) meta).getOwningPlayer());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -62,8 +62,10 @@ public class SkullHandler {
 
 		SkullMeta skullMeta = (SkullMeta) meta;
 
-		OfflinePlayer offlinePlayer = (OfflinePlayer) data.getAttribute(SKULL_OWNER);
-		if (offlinePlayer != null) skullMeta.setOwningPlayer(offlinePlayer);
+		if (data.hasAttribute(SKULL_OWNER)) {
+			OfflinePlayer offlinePlayer = (OfflinePlayer) data.getAttribute(SKULL_OWNER);
+			skullMeta.setOwningPlayer(offlinePlayer);
+		}
 
 		String uuid = (String) data.getAttribute(MagicItemAttribute.UUID);
 		String signature = (String) data.getAttribute(SIGNATURE);
@@ -77,7 +79,8 @@ public class SkullHandler {
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof SkullMeta)) return;
 
-		data.setAttribute(SKULL_OWNER, ((SkullMeta) meta).getOwningPlayer());
+		SkullMeta skullMeta = (SkullMeta) meta;
+		if (skullMeta.hasOwner()) data.setAttribute(SKULL_OWNER, skullMeta.getOwningPlayer());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -11,80 +11,82 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.TEXTURE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.SIGNATURE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.SKULL_OWNER;
 
 public class SkullHandler {
 
-	private static final String SKULL_OWNER_CONFIG_NAME = "skull-owner";
-	private static final String UUID_CONFIG_NAME = "uuid";
-	private static final String TEXTURE_CONFIG_NAME = "texture";
-	private static final String SIGNATURE_CONFIG_NAME = "signature";
+	private static final String SKULL_OWNER_CONFIG_NAME = SKULL_OWNER.toString();
+	private static final String UUID_CONFIG_NAME = ItemAttribute.UUID.toString();
+	private static final String SIGNATURE_CONFIG_NAME = SIGNATURE.toString();
+	private static final String TEXTURE_CONFIG_NAME = TEXTURE.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof SkullMeta)) return meta;
 		
 		SkullMeta skullMeta = (SkullMeta) meta;
+		OfflinePlayer offlinePlayer;
 
-		OfflinePlayer offlinePlayer = null;
+		if (config.isString(SKULL_OWNER_CONFIG_NAME)) {
+			offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString(config.getString(SKULL_OWNER_CONFIG_NAME)));
 
-		if (config.contains(SKULL_OWNER_CONFIG_NAME)) {
-			offlinePlayer = Bukkit.getOfflinePlayer(UUID.fromString(config.get(SKULL_OWNER_CONFIG_NAME).toString()));
 			skullMeta.setOwningPlayer(offlinePlayer);
+			data.setItemAttribute(SKULL_OWNER, offlinePlayer);
 		}
 
 		String uuid = null;
 		String texture = null;
 		String signature = null;
 
-		if (config.contains(UUID_CONFIG_NAME) && config.isString(UUID_CONFIG_NAME)) {
+		if (config.isString(UUID_CONFIG_NAME)) {
 			uuid = config.getString(UUID_CONFIG_NAME);
+			data.setItemAttribute(ItemAttribute.UUID, uuid);
 		}
-		if (config.contains(TEXTURE_CONFIG_NAME) && config.isString(TEXTURE_CONFIG_NAME)) {
+		if (config.isString(TEXTURE_CONFIG_NAME)) {
 			texture = config.getString(TEXTURE_CONFIG_NAME);
+			data.setItemAttribute(TEXTURE, texture);
 		}
-		if (config.contains(SIGNATURE_CONFIG_NAME) && config.isString(SIGNATURE_CONFIG_NAME)) {
+		if (config.isString(SIGNATURE_CONFIG_NAME)) {
 			signature = config.getString(SIGNATURE_CONFIG_NAME);
+			data.setItemAttribute(SIGNATURE, signature);
 		}
 
 		if (texture != null && skullMeta.getOwningPlayer() != null) {
 			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
 		}
 
-		if (data != null) {
-			data.setSkullOwner(offlinePlayer);
-			data.setUUID(uuid);
-			data.setTexture(texture);
-			data.setSignature(signature);
-		}
-
-		return skullMeta;
+		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof SkullMeta)) return meta;
 
 		SkullMeta skullMeta = (SkullMeta) meta;
 
-		OfflinePlayer offlinePlayer = data.getSkullOwner();
+		OfflinePlayer offlinePlayer = (OfflinePlayer) data.getItemAttribute(SKULL_OWNER);
 		if (offlinePlayer != null) skullMeta.setOwningPlayer(offlinePlayer);
 
-		String uuid = data.getUUID();
-		String texture = data.getTexture();
-		String signature = data.getSignature();
+		String uuid = (String) data.getItemAttribute(ItemAttribute.UUID);
+		String signature = (String) data.getItemAttribute(SIGNATURE);
+		String texture = (String) data.getItemAttribute(TEXTURE);
 
 		if (texture != null && skullMeta.getOwningPlayer() != null) {
 			Util.setTexture(skullMeta, texture, signature, uuid, skullMeta.getOwningPlayer());
 		}
+
 		return skullMeta;
 	}
 
 	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
 		if (data == null) return null;
 		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof SkullMeta)) return data;
 
-		SkullMeta meta = (SkullMeta) itemStack.getItemMeta();
-		data.setSkullOwner(meta.getOwningPlayer());
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof SkullMeta)) return data;
+
+		data.setItemAttribute(SKULL_OWNER, ((SkullMeta) meta).getOwningPlayer());
 		return data;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
@@ -48,7 +48,8 @@ public class SuspiciousStewHandler {
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof SuspiciousStewMeta)) return;
 
-		data.setAttribute(POTION_EFFECTS, ((SuspiciousStewMeta) meta).getCustomEffects());
+		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
+		if (stewMeta.hasCustomEffects()) data.setAttribute(POTION_EFFECTS, stewMeta.getCustomEffects());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
@@ -4,22 +4,21 @@ import java.util.List;
 import java.util.ArrayList;
 
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.SuspiciousStewMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.POTION_EFFECTS;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.POTION_EFFECTS;
 
 public class SuspiciousStewHandler {
 
 	private static final String CONFIG_NAME = POTION_EFFECTS.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SuspiciousStewMeta)) return meta;
-		if (!config.isList(CONFIG_NAME)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SuspiciousStewMeta)) return;
+		if (!config.isList(CONFIG_NAME)) return;
 
 		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
 		stewMeta.clearCustomEffects();
@@ -33,32 +32,23 @@ public class SuspiciousStewHandler {
 			stewMeta.addCustomEffect(potionEffect, true);
 			potionEffects.add(potionEffect);
 		}
-		data.setItemAttribute(POTION_EFFECTS, potionEffects);
-
-		return meta;
+		data.setAttribute(POTION_EFFECTS, potionEffects);
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SuspiciousStewMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SuspiciousStewMeta)) return;
 
 		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
-		if (data.hasItemAttribute(POTION_EFFECTS)) {
+		if (data.hasAttribute(POTION_EFFECTS)) {
 			stewMeta.clearCustomEffects();
-			((List<PotionEffect>) data.getItemAttribute(POTION_EFFECTS)).forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
+			((List<PotionEffect>) data.getAttribute(POTION_EFFECTS)).forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
 		}
-
-		return meta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof SuspiciousStewMeta)) return;
 
-		ItemMeta meta = itemStack.getItemMeta();
-		if (!(meta instanceof SuspiciousStewMeta)) return data;
-
-		data.setItemAttribute(POTION_EFFECTS, ((SuspiciousStewMeta) meta).getCustomEffects());
-		return data;
+		data.setAttribute(POTION_EFFECTS, ((SuspiciousStewMeta) meta).getCustomEffects());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
@@ -32,7 +32,7 @@ public class SuspiciousStewHandler {
 			stewMeta.addCustomEffect(potionEffect, true);
 			potionEffects.add(potionEffect);
 		}
-		data.setAttribute(POTION_EFFECTS, potionEffects);
+		if (!potionEffects.isEmpty()) data.setAttribute(POTION_EFFECTS, potionEffects);
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
@@ -49,7 +49,10 @@ public class SuspiciousStewHandler {
 		if (!(meta instanceof SuspiciousStewMeta)) return;
 
 		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
-		if (stewMeta.hasCustomEffects()) data.setAttribute(POTION_EFFECTS, stewMeta.getCustomEffects());
+		if (stewMeta.hasCustomEffects()) {
+			List<PotionEffect> effects = stewMeta.getCustomEffects();
+			if (!effects.isEmpty()) data.setAttribute(POTION_EFFECTS, effects);
+		}
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
@@ -11,43 +11,40 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.POTION_EFFECTS;
 
 public class SuspiciousStewHandler {
 
-	private static final String CONFIG_NAME = "potion-effects";
+	private static final String CONFIG_NAME = POTION_EFFECTS.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!config.contains(CONFIG_NAME)) return meta;
-		if (!config.isList(CONFIG_NAME)) return meta;
 		if (!(meta instanceof SuspiciousStewMeta)) return meta;
+		if (!config.isList(CONFIG_NAME)) return meta;
 
 		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
 		stewMeta.clearCustomEffects();
 
 		List<String> effects = config.getStringList(CONFIG_NAME);
+		List<PotionEffect> potionEffects = new ArrayList<>();
 		for (String str : effects) {
-
 			PotionEffect potionEffect = Util.buildSuspiciousStewPotionEffect(str);
 			if (potionEffect == null) continue;
 
 			stewMeta.addCustomEffect(potionEffect, true);
-			if (data != null) {
-				if (data.getPotionEffects() == null) data.setPotionEffects(new ArrayList<>());
-				data.getPotionEffects().add(potionEffect);
-			}
+			potionEffects.add(potionEffect);
 		}
+		data.setItemAttribute(POTION_EFFECTS, potionEffects);
 
 		return meta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof SuspiciousStewMeta)) return meta;
 
 		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
-		if (data.getPotionEffects() != null) {
+		if (data.hasItemAttribute(POTION_EFFECTS)) {
 			stewMeta.clearCustomEffects();
-			data.getPotionEffects().forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
+			((List<PotionEffect>) data.getItemAttribute(POTION_EFFECTS)).forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
 		}
 
 		return meta;
@@ -56,10 +53,11 @@ public class SuspiciousStewHandler {
 	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
 		if (data == null) return null;
 		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof SuspiciousStewMeta)) return data;
 
-		SuspiciousStewMeta meta = (SuspiciousStewMeta) itemStack.getItemMeta();
-		data.setPotionEffects(meta.getCustomEffects());
+		ItemMeta meta = itemStack.getItemMeta();
+		if (!(meta instanceof SuspiciousStewMeta)) return data;
+
+		data.setItemAttribute(POTION_EFFECTS, ((SuspiciousStewMeta) meta).getCustomEffects());
 		return data;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -2,16 +2,15 @@ package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
 
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.PAGES;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.TITLE;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.AUTHOR;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.PAGES;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.TITLE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.AUTHOR;
 
 public class WrittenBookHandler {
 
@@ -19,8 +18,8 @@ public class WrittenBookHandler {
 	private static final String PAGES_CONFIG_NAME = PAGES.toString();
 	private static final String TITLE_CONFIG_NAME = TITLE.toString();
 
-	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BookMeta)) return meta;
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BookMeta)) return;
 		
 		BookMeta bookMeta = (BookMeta) meta;
 		List<String> pages;
@@ -31,14 +30,14 @@ public class WrittenBookHandler {
 			title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
 
 			bookMeta.setTitle(title);
-			data.setItemAttribute(TITLE, title);
+			data.setAttribute(TITLE, title);
 		}
 
 		if (config.isString(AUTHOR_CONFIG_NAME)) {
 			author = Util.colorize(config.getString(AUTHOR_CONFIG_NAME));
 
 			bookMeta.setAuthor(author);
-			data.setItemAttribute(AUTHOR, author);
+			data.setAttribute(AUTHOR, author);
 		}
 
 		if (config.isList(PAGES_CONFIG_NAME)) {
@@ -48,19 +47,17 @@ public class WrittenBookHandler {
 			}
 
 			bookMeta.setPages(pages);
-			data.setItemAttribute(PAGES, pages);
+			data.setAttribute(PAGES, pages);
 		}
-
-		return bookMeta;
 	}
 
-	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BookMeta)) return meta;
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BookMeta)) return;
 
 		BookMeta bookMeta = (BookMeta) meta;
-		String title = (String) data.getItemAttribute(TITLE);
-		String author = (String) data.getItemAttribute(AUTHOR);
-		List<String> pages = (List<String>) data.getItemAttribute(PAGES);
+		String title = (String) data.getAttribute(TITLE);
+		String author = (String) data.getAttribute(AUTHOR);
+		List<String> pages = (List<String>) data.getAttribute(PAGES);
 
 		if (title != null) {
 			title = Util.colorize(title);
@@ -78,21 +75,15 @@ public class WrittenBookHandler {
 			}
 			bookMeta.setPages(pages);
 		}
-
-		return bookMeta;
 	}
 
-	public static MagicItemData process(ItemStack itemStack, MagicItemData data) {
-		if (data == null) return null;
-		if (itemStack == null) return data;
-		if (!(itemStack.getItemMeta() instanceof BookMeta)) return data;
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BookMeta)) return;
 
-		BookMeta meta = (BookMeta) itemStack.getItemMeta();
-		data.setItemAttribute(AUTHOR, meta.getAuthor());
-		data.setItemAttribute(TITLE, meta.getTitle());
-		if (!meta.getPages().isEmpty()) data.setItemAttribute(PAGES, meta.getPages());
-
-		return data;
+		BookMeta bookMeta = (BookMeta) meta;
+		data.setAttribute(AUTHOR, bookMeta.getAuthor());
+		data.setAttribute(TITLE, bookMeta.getTitle());
+		if (!bookMeta.getPages().isEmpty()) data.setAttribute(PAGES, bookMeta.getPages());
 	}
 
 	public static String getTitle(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -43,8 +43,10 @@ public class WrittenBookHandler {
 				pages.set(i, Util.colorize(pages.get(i)));
 			}
 
-			bookMeta.setPages(pages);
-			data.setAttribute(PAGES, pages);
+			if (!pages.isEmpty()) {
+				bookMeta.setPages(pages);
+				data.setAttribute(PAGES, pages);
+			}
 		}
 	}
 
@@ -63,7 +65,10 @@ public class WrittenBookHandler {
 		BookMeta bookMeta = (BookMeta) meta;
 		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.getAuthor());
 		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.getTitle());
-		if (bookMeta.hasPages()) data.setAttribute(PAGES, bookMeta.getPages());
+		if (bookMeta.hasPages()) {
+			List<String> pages = bookMeta.getPages();
+			if (!pages.isEmpty()) data.setAttribute(PAGES, pages);
+		}
 	}
 
 	public static String getTitle(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -45,7 +45,7 @@ public class WrittenBookHandler {
 
 			if (!pages.isEmpty()) {
 				bookMeta.setPages(pages);
-				data.setAttribute(PAGES, pages);
+				data.setAttribute(PAGES, bookMeta.getPages());
 			}
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -22,26 +22,23 @@ public class WrittenBookHandler {
 		if (!(meta instanceof BookMeta)) return;
 		
 		BookMeta bookMeta = (BookMeta) meta;
-		List<String> pages;
-		String author;
-		String title;
 
 		if (config.isString(TITLE_CONFIG_NAME)) {
-			title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
+			String title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
 
 			bookMeta.setTitle(title);
 			data.setAttribute(TITLE, title);
 		}
 
 		if (config.isString(AUTHOR_CONFIG_NAME)) {
-			author = Util.colorize(config.getString(AUTHOR_CONFIG_NAME));
+			String author = Util.colorize(config.getString(AUTHOR_CONFIG_NAME));
 
 			bookMeta.setAuthor(author);
 			data.setAttribute(AUTHOR, author);
 		}
 
 		if (config.isList(PAGES_CONFIG_NAME)) {
-			pages = config.getStringList(PAGES_CONFIG_NAME);
+			List<String> pages = config.getStringList(PAGES_CONFIG_NAME);
 			for (int i = 0; i < pages.size(); i++) {
 				pages.set(i, Util.colorize(pages.get(i)));
 			}
@@ -55,35 +52,18 @@ public class WrittenBookHandler {
 		if (!(meta instanceof BookMeta)) return;
 
 		BookMeta bookMeta = (BookMeta) meta;
-		String title = (String) data.getAttribute(TITLE);
-		String author = (String) data.getAttribute(AUTHOR);
-		List<String> pages = (List<String>) data.getAttribute(PAGES);
-
-		if (title != null) {
-			title = Util.colorize(title);
-			bookMeta.setTitle(title);
-		}
-
-		if (author != null) {
-			author = Util.colorize(author);
-			bookMeta.setAuthor(author);
-		}
-
-		if (pages != null) {
-			for (int i = 0; i < pages.size(); i++) {
-				pages.set(i, Util.colorize(pages.get(i)));
-			}
-			bookMeta.setPages(pages);
-		}
+		if (data.hasAttribute(TITLE)) bookMeta.setTitle((String) data.getAttribute(TITLE));
+		if (data.hasAttribute(AUTHOR)) bookMeta.setAuthor((String) data.getAttribute(AUTHOR));
+		if (data.hasAttribute(PAGES)) bookMeta.setPages((List<String>) data.getAttribute(PAGES));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BookMeta)) return;
 
 		BookMeta bookMeta = (BookMeta) meta;
-		data.setAttribute(AUTHOR, bookMeta.getAuthor());
-		data.setAttribute(TITLE, bookMeta.getTitle());
-		if (!bookMeta.getPages().isEmpty()) data.setAttribute(PAGES, bookMeta.getPages());
+		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.getAuthor());
+		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.getTitle());
+		if (bookMeta.hasPages()) data.setAttribute(PAGES, bookMeta.getPages());
 	}
 
 	public static String getTitle(ItemMeta meta) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -9,53 +9,58 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.PAGES;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.TITLE;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.AUTHOR;
 
 public class WrittenBookHandler {
 
-	private static final String TITLE_CONFIG_NAME = "title";
-	private static final String AUTHOR_CONFIG_NAME = "author";
-	private static final String PAGES_CONFIG_NAME = "pages";
+	private static final String AUTHOR_CONFIG_NAME = AUTHOR.toString();
+	private static final String PAGES_CONFIG_NAME = PAGES.toString();
+	private static final String TITLE_CONFIG_NAME = TITLE.toString();
 
 	public static ItemMeta process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BookMeta)) return meta;
 		
 		BookMeta bookMeta = (BookMeta) meta;
-		String title;
-		String author;
 		List<String> pages;
+		String author;
+		String title;
 
-		if (config.contains(TITLE_CONFIG_NAME) && config.isString(TITLE_CONFIG_NAME)) {
+		if (config.isString(TITLE_CONFIG_NAME)) {
 			title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
+
 			bookMeta.setTitle(title);
-			if (data != null) data.setTitle(title);
+			data.setItemAttribute(TITLE, title);
 		}
 
-		if (config.contains(AUTHOR_CONFIG_NAME) && config.isString(AUTHOR_CONFIG_NAME)) {
+		if (config.isString(AUTHOR_CONFIG_NAME)) {
 			author = Util.colorize(config.getString(AUTHOR_CONFIG_NAME));
+
 			bookMeta.setAuthor(author);
-			if (data != null) data.setAuthor(author);
+			data.setItemAttribute(AUTHOR, author);
 		}
 
-		if (config.contains(PAGES_CONFIG_NAME) && config.isList(PAGES_CONFIG_NAME)) {
+		if (config.isList(PAGES_CONFIG_NAME)) {
 			pages = config.getStringList(PAGES_CONFIG_NAME);
 			for (int i = 0; i < pages.size(); i++) {
 				pages.set(i, Util.colorize(pages.get(i)));
 			}
+
 			bookMeta.setPages(pages);
-			if (data != null) data.setPages(pages);
+			data.setItemAttribute(PAGES, pages);
 		}
 
 		return bookMeta;
 	}
 
 	public static ItemMeta process(ItemMeta meta, MagicItemData data) {
-		if (data == null) return meta;
 		if (!(meta instanceof BookMeta)) return meta;
 
 		BookMeta bookMeta = (BookMeta) meta;
-		String title = data.getTitle();
-		String author = data.getAuthor();
-		List<String> pages = data.getPages();
+		String title = (String) data.getItemAttribute(TITLE);
+		String author = (String) data.getItemAttribute(AUTHOR);
+		List<String> pages = (List<String>) data.getItemAttribute(PAGES);
 
 		if (title != null) {
 			title = Util.colorize(title);
@@ -83,9 +88,10 @@ public class WrittenBookHandler {
 		if (!(itemStack.getItemMeta() instanceof BookMeta)) return data;
 
 		BookMeta meta = (BookMeta) itemStack.getItemMeta();
-		data.setAuthor(meta.getAuthor());
-		data.setTitle(meta.getTitle());
-		if (!meta.getPages().isEmpty()) data.setPages(meta.getPages());
+		data.setItemAttribute(AUTHOR, meta.getAuthor());
+		data.setItemAttribute(TITLE, meta.getTitle());
+		if (!meta.getPages().isEmpty()) data.setItemAttribute(PAGES, meta.getPages());
+
 		return data;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -156,7 +156,7 @@ public class MagicItemData {
         UUID(String.class),
         TEXTURE(String.class),
         SIGNATURE(String.class),
-        SKULL_OWNER(OfflinePlayer.class),
+        SKULL_OWNER(String.class),
         ENCHANTMENTS(Map.class),
         LORE(List.class),
         PAGES(List.class),
@@ -198,65 +198,105 @@ public class MagicItemData {
 
         output.append('{');
         if (hasAttribute(MagicItemAttribute.NAME)) {
-            output.append("\"name\":\"").append(escape((String) getAttribute(MagicItemAttribute.NAME))).append('"');
+            output
+                .append("\"name\":\"")
+                .append(escape((String) getAttribute(MagicItemAttribute.NAME)))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.AMOUNT)) {
-            int amount = (int) getAttribute(MagicItemAttribute.AMOUNT);
-
             if (previous) output.append(',');
-            output.append("\"amount\":").append(amount);
+
+            output
+                .append("\"amount\":")
+                .append((int) getAttribute(MagicItemAttribute.AMOUNT));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.DURABILITY)) {
             if (previous) output.append(',');
-            output.append("\"durability\":").append((int) getAttribute(MagicItemAttribute.DURABILITY));
+
+            output
+                .append("\"durability\":")
+                .append((int) getAttribute(MagicItemAttribute.DURABILITY));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.REPAIR_COST)) {
             if (previous) output.append(',');
-            output.append("\"repaircost\":").append((int) getAttribute(MagicItemAttribute.REPAIR_COST));
+
+            output
+                .append("\"repaircost\":")
+                .append((int) getAttribute(MagicItemAttribute.REPAIR_COST));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA)) {
             if (previous) output.append(',');
-            output.append("\"custommodeldata\":").append((int) getAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA));
+
+            output
+                .append("\"custommodeldata\":")
+                .append((int) getAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.POWER)) {
             if (previous) output.append(',');
-            output.append("\"power\":").append((int) getAttribute(MagicItemAttribute.POWER));
+
+            output
+                .append("\"power\":")
+                .append((int) getAttribute(MagicItemAttribute.POWER));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.UNBREAKABLE)) {
             if (previous) output.append(',');
-            output.append("\"unbreakable\":").append((boolean) getAttribute(MagicItemAttribute.UNBREAKABLE));
+
+            output
+                .append("\"unbreakable\":")
+                .append((boolean) getAttribute(MagicItemAttribute.UNBREAKABLE));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.HIDE_TOOLTIP)) {
             if (previous) output.append(',');
-            output.append("\"hidetooltip\":").append((boolean) getAttribute(MagicItemAttribute.HIDE_TOOLTIP));
+
+            output
+                .append("\"hidetooltip\":")
+                .append((boolean) getAttribute(MagicItemAttribute.HIDE_TOOLTIP));
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.COLOR)) {
             if (previous) output.append(',');
+
             Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
             String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-            output.append("\"color\":\"").append(hex).append('"');
+            output
+                .append("\"color\":\"")
+                .append(hex)
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.POTION_TYPE)) {
             if (previous) output.append(',');
-            output.append("\"potiontype\":\"").append(((PotionType) getAttribute(MagicItemAttribute.POTION_TYPE)).name()).append('"');
+
+            output
+                .append("\"potiontype\":\"")
+                .append(((PotionType) getAttribute(MagicItemAttribute.POTION_TYPE)).name())
+                .append('"');
+
             previous = true;
         }
 
@@ -301,37 +341,67 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.SKULL_OWNER)) {
             if (previous) output.append(',');
-            output.append("\"skullowner\":").append(((OfflinePlayer) getAttribute(MagicItemAttribute.SKULL_OWNER)).getUniqueId());
+
+            output
+                .append("\"skullowner\":\"")
+                .append((String) getAttribute(MagicItemAttribute.SKULL_OWNER))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.TITLE)) {
             if (previous) output.append(',');
-            output.append("\"title\":\"").append(escape((String) getAttribute(MagicItemAttribute.TITLE))).append('"');
+
+            output
+                .append("\"title\":\"")
+                .append(escape((String) getAttribute(MagicItemAttribute.TITLE)))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.AUTHOR)) {
             if (previous) output.append(',');
-            output.append("\"author\":\"").append(escape((String) getAttribute(MagicItemAttribute.AUTHOR))).append('"');
+
+            output
+                .append("\"author\":\"")
+                .append(escape((String) getAttribute(MagicItemAttribute.AUTHOR)))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.UUID)) {
             if (previous) output.append(',');
-            output.append("\"uuid\":").append(((String) getAttribute(MagicItemAttribute.UUID)));
+
+            output
+                .append("\"uuid\":\"")
+                .append(((String) getAttribute(MagicItemAttribute.UUID)))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.TEXTURE)) {
             if (previous) output.append(',');
-            output.append("\"texture\":").append(((String) getAttribute(MagicItemAttribute.TEXTURE)));
+
+            output
+                .append("\"texture\":\"")
+                .append(((String) getAttribute(MagicItemAttribute.TEXTURE)))
+                .append('"');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.SIGNATURE)) {
             if (previous) output.append(',');
-            output.append("\"signature\":").append(((String) getAttribute(MagicItemAttribute.SIGNATURE)));
+
+            output
+                .append("\"signature\":\"")
+                .append(((String) getAttribute(MagicItemAttribute.SIGNATURE)))
+                .append('"');
+
             previous = true;
         }
 
@@ -358,7 +428,11 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.FAKE_GLINT)) {
             if (previous) output.append(',');
-            output.append("\"fakeglint\":").append((boolean) getAttribute(MagicItemAttribute.FAKE_GLINT));
+
+            output
+                .append("\"fakeglint\":")
+                .append((boolean) getAttribute(MagicItemAttribute.FAKE_GLINT));
+
             previous = true;
         }
         

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -1,42 +1,96 @@
 package com.nisovin.magicspells.util.magicitems;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.List;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Objects;
+import java.util.Collection;
+
+import com.google.common.collect.Multimap;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.FireworkEffect;
-import org.bukkit.enchantments.Enchantment;
 import org.bukkit.potion.PotionType;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.enchantments.Enchantment;
+import org.bukkit.attribute.AttributeModifier;
 
-import com.google.common.collect.Multimap;
+import com.nisovin.magicspells.util.AttributeUtil.AttributeModifierData;
 
 public class MagicItemData {
 
-    private EnumMap<ItemAttribute, Object> itemAttributes = new EnumMap<>(ItemAttribute.class);
+    private EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
 
-    public Object getItemAttribute(ItemAttribute attr) {
+    public Object getAttribute(MagicItemAttribute attr) {
         return itemAttributes.get(attr);
     }
 
-    public void setItemAttribute(ItemAttribute attr, Object obj) {
+    public void setAttribute(MagicItemAttribute attr, Object obj) {
         if (obj == null) return;
         if (!attr.getDataType().isAssignableFrom(obj.getClass())) return;
 
         itemAttributes.put(attr, obj);
     }
 
-    public boolean hasItemAttribute(ItemAttribute atr) {
+    public void removeAttribute(MagicItemAttribute attr) {
+        itemAttributes.remove(attr);
+    }
+
+    public boolean hasAttribute(MagicItemAttribute atr) {
         return itemAttributes.containsKey(atr);
     }
 
-    public boolean conforms(MagicItemData data) {
-        for (ItemAttribute attr : itemAttributes.keySet())
-            if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
-                return false;
+    private boolean hasEqualAttributes(MagicItemData other) {
+        Multimap<Attribute, AttributeModifier> attrSelf = (Multimap<Attribute, AttributeModifier>) itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
+        Multimap<Attribute, AttributeModifier> attrOther = (Multimap<Attribute, AttributeModifier>) other.itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
+
+        Set<Attribute> keysSelf = attrSelf.keySet();
+        Set<Attribute> keysOther = attrOther.keySet();
+        if (!keysSelf.equals(keysOther)) return false;
+        
+        for (Attribute attr : keysSelf) {
+            Collection<AttributeModifier> modsSelf = attrSelf.get(attr);
+            Collection<AttributeModifier> modsOther = attrOther.get(attr);
+            if (modsSelf.size() != modsOther.size()) return false;
+
+            HashMap<AttributeModifierData, Integer> freq = new HashMap<>();
+            for (AttributeModifier mod : modsSelf) {
+                AttributeModifierData data = new AttributeModifierData(mod);
+                Integer count = freq.get(data);
+
+                if (count == null) count = 0;
+                freq.put(data, count + 1);
+            }
+
+            for (AttributeModifier mod : modsOther) {
+                AttributeModifierData data = new AttributeModifierData(mod);
+                Integer count = freq.get(data);
+
+                if (count == null) return false;
+                if (count == 1) freq.remove(data);
+                else freq.put(data, count - 1);
+            }
+        }
+
+        return true;
+    }
+
+    public boolean matches(MagicItemData data) {
+        if (!data.itemAttributes.keySet().containsAll(itemAttributes.keySet())) return false;
+
+        for (MagicItemAttribute attr : itemAttributes.keySet()) {
+            if (attr == MagicItemAttribute.ATTRIBUTES)
+                if (!hasEqualAttributes(data)) return false;
+            else
+                if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
+        }
 
         return true;
     }
@@ -63,118 +117,7 @@ public class MagicItemData {
         return data;
     }
 
-    @Override
-    public String toString() {
-        StringBuilder output = new StringBuilder();
-        boolean previous = false;
-
-        if (hasItemAttribute(ItemAttribute.TYPE))
-            output.append(((Material) getItemAttribute(ItemAttribute.TYPE)).name());
-
-        output.append("{");
-        if (hasItemAttribute(ItemAttribute.NAME)) {
-            output.append("name:'").append(((String) getItemAttribute(ItemAttribute.NAME)).replaceAll("'", "\\\\'")).append("'");
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.AMOUNT)) {
-            int amount = (int) getItemAttribute(ItemAttribute.AMOUNT);
-
-            if (amount > 1) {
-                if (previous) output.append(",");
-                output.append("amount:").append(amount);
-                previous = true;
-            }
-        }
-
-        if (hasItemAttribute(ItemAttribute.DURABILITY)) {
-            if (previous) output.append(",");
-            output.append("durability:").append((int) getItemAttribute(ItemAttribute.DURABILITY));
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.CUSTOM_MODEL_DATA)) {
-            int customModelData = (int) getItemAttribute(ItemAttribute.CUSTOM_MODEL_DATA);
-
-            if (customModelData > 0) {
-                if (previous) output.append(",");
-                output.append("customModelData:").append(customModelData);
-                previous = true;
-            }
-        }
-
-        if (hasItemAttribute(ItemAttribute.UNBREAKABLE)) {
-            if (previous) output.append(",");
-            output.append("unbreakable:").append((boolean) getItemAttribute(ItemAttribute.UNBREAKABLE));
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.COLOR)) {
-            if (previous) output.append(",");
-            Color color = (Color) getItemAttribute(ItemAttribute.COLOR);
-            String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-            output.append("color:\"").append(hex).append("\"");
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.POTION_TYPE)) {
-            if (previous) output.append(",");
-            output.append("potion:\"").append(((PotionType) getItemAttribute(ItemAttribute.POTION_TYPE)).name()).append("\"");
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.TITLE)) {
-            if (previous) output.append(",");
-            output.append("title:\"").append((String) getItemAttribute(ItemAttribute.TITLE)).append("\"");
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.AUTHOR)) {
-            if (previous) output.append(",");
-            output.append("author:\"").append((String) getItemAttribute(ItemAttribute.AUTHOR)).append("\"");
-            previous = true;
-        }
-
-        if (hasItemAttribute(ItemAttribute.ENCHANTMENTS)) {
-            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getItemAttribute(ItemAttribute.ENCHANTMENTS);
-
-            if (!enchantments.isEmpty()) {
-                if (previous) output.append(",");
-                output.append("enchants:{");
-                boolean previousEnchantment = false;
-                for (Enchantment enchantment : enchantments.keySet()) {
-                    if (previousEnchantment) output.append(",");
-                    output.append(enchantment.getKey().getKey()).append(":").append(enchantments.get(enchantment));
-                    previousEnchantment = true;
-                }
-                output.append("}");
-                previous = true;
-            }
-        }
-
-        if (hasItemAttribute(ItemAttribute.LORE)) {
-            List<String> lore = (List<String>) getItemAttribute(ItemAttribute.LORE);
-
-            if (!lore.isEmpty()) {
-                if (previous) output.append(",");
-                output.append("lore:[");
-                boolean previousLore = false;
-                for (String line : lore) {
-                    if (previousLore) output.append(",");
-                    output.append("\"").append(line).append("\"");
-                    previousLore = true;
-                }
-                output.append("]");
-                previous = true;
-            }
-        }
-
-        output.append("}");
-
-        return output.toString();
-    }
-
-    public enum ItemAttribute {
+    public enum MagicItemAttribute {
 
         TYPE(Material.class),
         NAME(String.class),
@@ -185,27 +128,28 @@ public class MagicItemData {
         POWER(Integer.class),
         UNBREAKABLE(Boolean.class),
         HIDE_TOOLTIP(Boolean.class),
-        COLOR(Color.class),
+        FAKE_GLINT(Boolean.class),
         POTION_TYPE(PotionType.class),
+        COLOR(Color.class),
         FIREWORK_EFFECT(FireworkEffect.class),
-        SKULL_OWNER(OfflinePlayer.class),
         TITLE(String.class),
         AUTHOR(String.class),
         UUID(String.class),
         TEXTURE(String.class),
         SIGNATURE(String.class),
+        SKULL_OWNER(OfflinePlayer.class),
         ENCHANTMENTS(Map.class),
-        ATTRIBUTES(Multimap.class),
         LORE(List.class),
         PAGES(List.class),
-        PATTERNS(List.class),
         POTION_EFFECTS(List.class),
-        FIREWORK_EFFECTS(List.class);
+        PATTERNS(List.class),
+        FIREWORK_EFFECTS(List.class),
+        ATTRIBUTES(Multimap.class);
 
         private final Class<?> dataType;
         private final String asString;
 
-        ItemAttribute(Class<?> dataType) {
+        MagicItemAttribute(Class<?> dataType) {
             this.dataType = dataType;
             asString = name().toLowerCase().replace('_', '-');
         }
@@ -219,6 +163,347 @@ public class MagicItemData {
             return asString;
         }
 
+    }
+
+    private String escape(String str) {
+        return str.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder();
+        boolean previous = false;
+
+        if (hasAttribute(MagicItemAttribute.TYPE))
+            output.append(((Material) getAttribute(MagicItemAttribute.TYPE)).name());
+
+        output.append('{');
+        if (hasAttribute(MagicItemAttribute.NAME)) {
+            output.append("\"name\":\"").append((String) getAttribute(MagicItemAttribute.NAME)).append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.AMOUNT)) {
+            int amount = (int) getAttribute(MagicItemAttribute.AMOUNT);
+
+            if (previous) output.append(',');
+            output.append("\"amount\":").append(amount);
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.DURABILITY)) {
+            if (previous) output.append(',');
+            output.append("\"durability\":").append((int) getAttribute(MagicItemAttribute.DURABILITY));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.REPAIR_COST)) {
+            if (previous) output.append(',');
+            output.append("\"repaircost\":").append((int) getAttribute(MagicItemAttribute.REPAIR_COST));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA)) {
+            if (previous) output.append(',');
+            output.append("\"custommodeldata\":").append((int) getAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.POWER)) {
+            if (previous) output.append(',');
+            output.append("\"power\":").append((int) getAttribute(MagicItemAttribute.POWER));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.UNBREAKABLE)) {
+            if (previous) output.append(',');
+            output.append("\"unbreakable\":").append((boolean) getAttribute(MagicItemAttribute.UNBREAKABLE));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.HIDE_TOOLTIP)) {
+            if (previous) output.append(',');
+            output.append("\"hidetooltip\":").append((boolean) getAttribute(MagicItemAttribute.HIDE_TOOLTIP));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.COLOR)) {
+            if (previous) output.append(',');
+            Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
+            String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+            output.append("\"color\":\"").append(hex).append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.POTION_TYPE)) {
+            if (previous) output.append(',');
+            output.append("\"potiontype\":\"").append(((PotionType) getAttribute(MagicItemAttribute.POTION_TYPE)).name()).append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
+            FireworkEffect effect = (FireworkEffect) getAttribute(MagicItemAttribute.FIREWORK_EFFECT);
+
+            if (previous) output.append(',');
+            output.append("\"fireworkeffect\":\"");
+
+            output
+                .append(effect.getType())
+                .append(' ')
+                .append(effect.hasTrail())
+                .append(' ')
+                .append(effect.hasFlicker());
+
+            boolean previousColor = false;
+            if (!effect.getColors().isEmpty()) {
+                output.append(' ');
+                for (Color color : effect.getColors()) {
+                    if (previousColor) output.append(',');
+                    String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+                    output.append(hex);
+                    previousColor = true;
+                }
+
+                if (!effect.getFadeColors().isEmpty()) {
+                    output.append(' ');
+                    previousColor = false;
+                    for (Color color : effect.getFadeColors()) {
+                        if (previousColor) output.append(',');
+                        String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+                        output.append(hex);
+                        previousColor = true;
+                    }
+                }
+            }
+
+            output.append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.SKULL_OWNER)) {
+            if (previous) output.append(',');
+            output.append("\"skullowner\":").append(((OfflinePlayer) getAttribute(MagicItemAttribute.SKULL_OWNER)).getUniqueId());
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.TITLE)) {
+            if (previous) output.append(',');
+            output.append("\"title\":\"").append((String) getAttribute(MagicItemAttribute.TITLE)).append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.AUTHOR)) {
+            if (previous) output.append(',');
+            output.append("\"author\":\"").append((String) getAttribute(MagicItemAttribute.AUTHOR)).append('"');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.UUID)) {
+            if (previous) output.append(',');
+            output.append("\"uuid\":").append(((String) getAttribute(MagicItemAttribute.UUID)));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.TEXTURE)) {
+            if (previous) output.append(',');
+            output.append("\"texture\":").append(((String) getAttribute(MagicItemAttribute.TEXTURE)));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.SIGNATURE)) {
+            if (previous) output.append(',');
+            output.append("\"signature\":").append(((String) getAttribute(MagicItemAttribute.SIGNATURE)));
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.ENCHANTMENTS)) {
+            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTMENTS);
+
+            if (previous) output.append(',');
+            output.append("\"enchantments\":{");
+            boolean previousEnchantment = false;
+            for (Enchantment enchantment : enchantments.keySet()) {
+                if (previousEnchantment) output.append(',');
+
+                output
+                    .append('"')
+                    .append(enchantment.getKey().getKey())
+                    .append("\":")
+                    .append(enchantments.get(enchantment));
+
+                previousEnchantment = true;
+            }
+            output.append('}');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.FAKE_GLINT)) {
+            if (previous) output.append(',');
+            output.append("\"fakeglint\":").append((boolean) getAttribute(MagicItemAttribute.FAKE_GLINT));
+            previous = true;
+        }
+        
+        if (hasAttribute(MagicItemAttribute.ATTRIBUTES)) {
+            if (previous) output.append(',');
+            output.append("\"attributes\":[");
+
+            Multimap<Attribute, AttributeModifier> attributes = (Multimap<Attribute, AttributeModifier>) getAttribute(MagicItemAttribute.ATTRIBUTES);
+            boolean previousAttribute = false;
+            for (Map.Entry<Attribute, AttributeModifier> entries : attributes.entries()) {
+                if (previousAttribute) output.append(',');
+
+                AttributeModifier modifier = entries.getValue();
+
+                output.append('"');
+                output.append(modifier.getName());
+                output.append(' ');
+                output.append(modifier.getAmount());
+                output.append(' ');
+                output.append(modifier.getOperation().name().toLowerCase());
+
+                EquipmentSlot slot = modifier.getSlot();
+                if (slot != null) {
+                    output.append(' ');
+                    output.append(slot.name().toLowerCase());
+                }
+
+                output.append('"');
+                previousAttribute = true;
+            }
+
+            output.append(']');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.LORE)) {
+            if (previous) output.append(',');
+            output.append("\"lore\":[");
+
+            List<String> lore = (List<String>) getAttribute(MagicItemAttribute.LORE);
+            boolean previousLore = false;
+            for (String line : lore) {
+                if (previousLore) output.append(',');
+                output.append('"').append(escape(line)).append('"');
+                previousLore = true;
+            }
+
+            output.append(']');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.PAGES)) {
+            if (previous) output.append(',');
+            output.append("\"pages\":[");
+
+            List<String> pages = (List<String>) getAttribute(MagicItemAttribute.PAGES);
+            boolean previousPages = false;
+            for (String page : pages) {
+                if (previousPages) output.append(',');
+                output.append('"').append(page).append('"');
+                previousPages = true;
+            }
+
+            output.append(']');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.PATTERNS)) {
+            List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
+
+            if (previous) output.append(',');
+            output.append("\"patterns\":[");
+            boolean previousPattern = false;
+            for (Pattern pattern : patterns) {
+                if (previousPattern) output.append(',');
+
+                output
+                    .append('"')
+                    .append(pattern.getPattern().name())
+                    .append(' ')
+                    .append(pattern.getColor().name())
+                    .append('"');
+
+                previousPattern = true;
+            }
+
+            output.append(']');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.POTION_EFFECTS)) {
+            List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
+
+            if (previous) output.append(',');
+            output.append("\"potioneffects\":[");
+            boolean previousEffect = false;
+            for (PotionEffect effect : effects) {
+                if (previousEffect) output.append(',');
+
+                output
+                    .append('"')
+                    .append(effect.getType().getName())
+                    .append(' ')
+                    .append(effect.getAmplifier())
+                    .append(' ')
+                    .append(effect.getDuration())
+                    .append('"');
+
+                previousEffect = true;
+            }
+
+            output.append(']');
+            previous = true;
+        }
+
+        if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECTS)) {
+            List<FireworkEffect> effects = (List<FireworkEffect>) getAttribute(MagicItemAttribute.FIREWORK_EFFECTS);
+
+            if (previous) output.append(',');
+            output.append("\"fireworkeffects\":[");
+            boolean previousEffect = false;
+            for (FireworkEffect effect : effects) {
+                if (previousEffect) output.append(',');
+
+                output
+                    .append('"')
+                    .append(effect.getType())
+                    .append(' ')
+                    .append(effect.hasTrail())
+                    .append(' ')
+                    .append(effect.hasFlicker());
+
+                boolean previousColor = false;
+                if (!effect.getColors().isEmpty()) {
+                    output.append(' ');
+                    for (Color color : effect.getColors()) {
+                        if (previousColor) output.append(',');
+                        String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+                        output.append(hex);
+                        previousColor = true;
+                    }
+
+                    if (!effect.getFadeColors().isEmpty()) {
+                        output.append(' ');
+                        previousColor = false;
+                        for (Color color : effect.getFadeColors()) {
+                            if (previousColor) output.append(',');
+                            String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+                            output.append(hex);
+                            previousColor = true;
+                        }
+                    }
+                }
+
+                output.append('"');
+                previousEffect = true;
+            }
+
+            output.append(']');
+        }
+
+        output.append('}');
+
+        return output.toString();
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -119,12 +119,13 @@ public class MagicItemData {
         if (this == o) return true;
         if (!(o instanceof MagicItemData)) return false;
 
-        return itemAttributes.equals(((MagicItemData) o).itemAttributes);
+        MagicItemData other = (MagicItemData) o;
+        return itemAttributes.equals(other.itemAttributes) && ignoredAttributes.equals(other.ignoredAttributes);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(itemAttributes);
+        return Objects.hash(itemAttributes, ignoredAttributes);
     }
 
     @Override

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -1,479 +1,224 @@
 package com.nisovin.magicspells.util.magicitems;
 
-import java.util.*;
+import java.util.Map;
+import java.util.List;
+import java.util.EnumMap;
+import java.util.Objects;
 
-import org.bukkit.*;
-import org.bukkit.potion.PotionType;
-import org.bukkit.potion.PotionEffect;
-import org.bukkit.attribute.Attribute;
-import org.bukkit.block.banner.Pattern;
-import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.Color;
+import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.FireworkEffect;
 import org.bukkit.enchantments.Enchantment;
-import org.bukkit.attribute.AttributeModifier;
-
-import com.nisovin.magicspells.util.Util;
+import org.bukkit.potion.PotionType;
 
 import com.google.common.collect.Multimap;
 
 public class MagicItemData {
 
-	private Material type;
-
-	private String name = null;
-
-	private int amount = 1;
-	private int durability = -1;
-	private int repairCost;
-	private int customModelData = 0;
-
-	private int power;
-
-	private boolean unbreakable;
-	private boolean hideTooltip;
-
-	private Color color = null;
-
-	private PotionType potionType = PotionType.UNCRAFTABLE;
-	private FireworkEffect fireworkEffect = null;
-	private OfflinePlayer skullOwner = null;
-
-	private String title = null;
-	private String author = null;
-
-	private String uuid = null;
-	private String texture = null;
-	private String signature = null;
-
-	private Map<Enchantment, Integer> enchantments = new HashMap<>();
-
-	private Multimap<Attribute, AttributeModifier> attributes = null;
-
-	private List<String> lore = null;
-	private List<String> pages = null;
-	private List<Pattern> patterns = null;
-	private List<PotionEffect> potionEffects = null;
-	private List<FireworkEffect> fireworkEffects = null;
-
-	public void setType(Material type) {
-		this.type = type;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public void setAmount(int amount) {
-		this.amount = amount;
-	}
-
-	public void setDurability(int durability) {
-		this.durability = durability;
-	}
-
-	public void setRepairCost(int repairCost) {
-		this.repairCost = repairCost;
-	}
-
-	public void setCustomModelData(int customModelData) {
-		this.customModelData = customModelData;
-	}
-
-	public void setPower(int power) {
-		this.power = power;
-	}
-
-	public void setUnbreakable(boolean unbreakable) {
-		this.unbreakable = unbreakable;
-	}
-
-	public void setHideTooltip(boolean hideTooltip) {
-		this.hideTooltip = hideTooltip;
-	}
-
-	public void setColor(Color color) {
-		this.color = color;
-	}
-
-	public void setPotionType(PotionType potionType) {
-		this.potionType = potionType;
-	}
-
-	public void setFireworkEffect(FireworkEffect fireworkEffect) {
-		this.fireworkEffect = fireworkEffect;
-	}
-
-	public void setSkullOwner(OfflinePlayer skullOwner) {
-		this.skullOwner = skullOwner;
-	}
-
-	public void setTitle(String title) {
-		this.title = title;
-	}
-
-	public void setAuthor(String author) {
-		this.author = author;
-	}
-
-	public void setUUID(String uuid) {
-		this.uuid = uuid;
-	}
-
-	public void setTexture(String texture) {
-		this.texture = texture;
-	}
-
-	public void setSignature(String signature) {
-		this.signature = signature;
-	}
-
-	public void setPotionEffects(List<PotionEffect> potionEffects) {
-		this.potionEffects = potionEffects;
-	}
-
-	public void setEnchantments(Map<Enchantment, Integer> enchantments) {
-		this.enchantments = enchantments;
-	}
-
-	public void setAttributes(Multimap<Attribute, AttributeModifier> attributes) {
-		this.attributes = attributes;
-	}
-
-	public void setLore(List<String> lore) {
-		this.lore = lore;
-	}
-
-	public void setPages(List<String> pages) {
-		this.pages = pages;
-	}
-
-	public void setPatterns(List<Pattern> patterns) {
-		this.patterns = patterns;
-	}
-
-	public void setFireworkEffects(List<FireworkEffect> fireworkEffects) {
-		this.fireworkEffects = fireworkEffects;
-	}
-
-	public Material getType() {
-		return type;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public int getAmount() {
-		return amount;
-	}
-
-	public int getDurability() {
-		return durability;
-	}
-
-	public int getRepairCost() {
-		return repairCost;
-	}
-
-	public int getCustomModelData() {
-		return customModelData;
-	}
-
-	public int getPower() {
-		return power;
-	}
-
-	public boolean isUnbreakable() {
-		return unbreakable;
-	}
-
-	public boolean isTooltipHidden() {
-		return hideTooltip;
-	}
-
-	public Color getColor() {
-		return color;
-	}
-
-	public PotionType getPotionType() {
-		return potionType;
-	}
-
-	public FireworkEffect getFireworkEffect() {
-		return fireworkEffect;
-	}
-
-	public OfflinePlayer getSkullOwner() {
-		return skullOwner;
-	}
-
-	public String getTitle() {
-		return title;
-	}
-
-	public String getAuthor() {
-		return author;
-	}
-
-	public String getUUID() {
-		return uuid;
-	}
-
-	public String getTexture() {
-		return texture;
-	}
-
-	public String getSignature() {
-		return signature;
-	}
-
-	public List<PotionEffect> getPotionEffects() {
-		return potionEffects;
-	}
-
-	public Map<Enchantment, Integer> getEnchantments() {
-		return enchantments;
-	}
-
-	public Multimap<Attribute, AttributeModifier> getAttributes() {
-		return attributes;
-	}
-
-	public List<String> getLore() {
-		return lore;
-	}
-
-	public List<String> getPages() {
-		return pages;
-	}
-
-	public List<Pattern> getPatterns() {
-		return patterns;
-	}
-
-	public List<FireworkEffect> getFireworkEffects() {
-		return fireworkEffects;
-	}
-
-	public boolean equals(MagicItemData data) {
-		String dataName = data.getName();
-		String internalName = name;
-		if (dataName != null) dataName = Util.decolorize(data.getName());
-		if (internalName != null) internalName = Util.decolorize(internalName);
-
-		Map<Enchantment, Integer> enchants = new HashMap<>(data.getEnchantments());
-		if (enchants.containsKey(Enchantment.FROST_WALKER) && enchants.get(Enchantment.FROST_WALKER) == 65535) enchants.clear();
-
-		return
-				enumEquals(data.getType(), type) &&
-				Objects.equals(dataName, internalName) &&
-				data.getDurability() == durability &&
-				data.getRepairCost() == repairCost &&
-				data.getCustomModelData() == customModelData &&
-				data.getPower() == power &&
-				data.isUnbreakable() == unbreakable &&
-				data.isTooltipHidden() == hideTooltip &&
-				Objects.equals(data.getColor(), color) &&
-				enumEquals(data.getPotionType(), potionType) &&
-				hasEqualPotionEffects(data.getPotionEffects(), potionEffects) &&
-				Objects.equals(data.getFireworkEffect(), fireworkEffect) &&
-				Objects.equals(data.getSkullOwner(), skullOwner) &&
-				Objects.equals(data.getTitle(), title) &&
-				Objects.equals(data.getAuthor(), author) &&
-				Objects.equals(enchants, enchantments) &&
-				Objects.equals(data.getLore(), lore) &&
-				Objects.equals(data.getPages(), pages) &&
-				Objects.equals(data.getPatterns(), patterns) &&
-				Objects.equals(data.getFireworkEffects(), fireworkEffects) &&
-				hasEqualAttributes(data.getAttributes(), attributes);
-	}
-
-	private boolean hasEqualPotionEffects(List<PotionEffect> listA, List<PotionEffect> listB) {
-		if (listA == null && listB == null) return true;
-		if (listA == null && listB != null) return false;
-		if (listA != null && listB == null) return false;
-		return listA.containsAll(listB) && listB.containsAll(listA);
-	}
-
-	private boolean hasEqualAttributes(Multimap<Attribute, AttributeModifier> mapA, Multimap<Attribute, AttributeModifier> mapB) {
-		if (mapA == null && mapB == null) return true;
-		if (mapA == null && mapB != null) return false;
-		if (mapA != null && mapB == null) return false;
-
-		if (!containsAttributes(mapA, mapB)) return false;
-		return containsAttributes(mapB, mapA);
-	}
-
-	public boolean containsAttributes(Multimap<Attribute, AttributeModifier> mapA, Multimap<Attribute, AttributeModifier> mapB) {
-		for (Attribute attr : mapA.keys()) {
-			Collection<AttributeModifier> mods = mapA.get(attr);
-			if (!mapB.containsKey(attr)) return false;
-
-			Collection<AttributeModifier> modifiers = mapB.get(attr);
-
-			for (AttributeModifier modifier : mods) {
-				double amount = modifier.getAmount();
-				String name = modifier.getName();
-				AttributeModifier.Operation operation = modifier.getOperation();
-				EquipmentSlot slot = modifier.getSlot();
-
-				boolean correctAttr = false;
-				insideLoop: for (AttributeModifier mod : modifiers) {
-					if (mod.getAmount() != amount) {
-						correctAttr = false;
-						continue;
-					}
-					if (mod.getOperation() != operation) {
-						correctAttr = false;
-						continue;
-					}
-					if (!mod.getName().equals(name)) {
-						correctAttr = false;
-						continue;
-					}
-					if (mod.getSlot() != slot) {
-						correctAttr = false;
-						continue;
-					}
-
-					correctAttr = true;
-					break insideLoop;
-				}
-
-				if (!correctAttr) return false;
-			}
-		}
-
-		return true;
-	}
-
-	public boolean enumEquals(Object o, Object object) {
-		if (o == null && object == null) return true;
-		if (o == null && object != null) return false;
-		if (o != null && object == null) return false;
-		return o == object;
-	}
-
-	@Override
-	public String toString() {
-		boolean previous = false;
-		StringBuilder output = new StringBuilder();
-		if (type != null) output.append(type.name());
-
-		output.append("{");
-		if (name != null) {
-			output.append("name:'").append(name.replaceAll("'", "\\\\'")).append("'");
-			previous = true;
-		}
-
-		if (amount > 1) {
-			if (previous) output.append(",");
-			output.append("amount:").append(amount);
-			previous = true;
-		}
-
-		if (durability > -1) {
-			if (previous) output.append(",");
-			output.append("durability:").append(durability);
-			previous = true;
-		}
-
-		if (customModelData > 0) {
-			if (previous) output.append(",");
-			output.append("customModelData:").append(customModelData);
-			previous = true;
-		}
-
-		if (unbreakable) {
-			if (previous) output.append(",");
-			output.append("unbreakable:").append(unbreakable);
-			previous = true;
-		}
-
-		if (color != null) {
-			if (previous) output.append(",");
-			String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-			output.append("color:\"").append(hex).append("\"");
-			previous = true;
-		}
-
-		if (potionType != null) {
-			if (previous) output.append(",");
-			output.append("potion:\"").append(potionType.name()).append("\"");
-			previous = true;
-		}
-
-		if (title != null) {
-			if (previous) output.append(",");
-			output.append("title:\"").append(title).append("\"");
-			previous = true;
-		}
-
-		if (author != null) {
-			if (previous) output.append(",");
-			output.append("author:\"").append(author).append("\"");
-			previous = true;
-		}
-
-		if (enchantments != null && !enchantments.isEmpty()) {
-			if (previous) output.append(",");
-			output.append("enchants:{");
-			boolean previousEnchantment = false;
-			for (Enchantment enchantment : enchantments.keySet()) {
-				if (previousEnchantment) output.append(",");
-				output.append(enchantment.getKey().getKey()).append(":").append(enchantments.get(enchantment));
-				previousEnchantment = true;
-			}
-			output.append("}");
-			previous = true;
-		}
-
-		if (lore != null && !lore.isEmpty()) {
-			if (previous) output.append(",");
-			output.append("lore:[");
-			boolean previousLore = false;
-			for (String lore : lore) {
-				if (previousLore) output.append(",");
-				output.append("\"").append(lore).append("\"");
-				previousLore = true;
-			}
-			output.append("]");
-			previous = true;
-		}
-
-		output.append("}");
-
-		return output.toString();
-	}
-
-	@Override
-	public MagicItemData clone() {
-		MagicItemData data = new MagicItemData();
-		data.setType(type);
-		data.setName(name);
-		data.setAmount(amount);
-		data.setDurability(durability);
-		data.setRepairCost(repairCost);
-		data.setCustomModelData(customModelData);
-		data.setPower(power);
-		data.setUnbreakable(unbreakable);
-		data.setHideTooltip(hideTooltip);
-		data.setColor(color);
-		data.setPotionType(potionType);
-		data.setFireworkEffect(fireworkEffect);
-		data.setSkullOwner(skullOwner);
-		data.setTitle(title);
-		data.setAuthor(author);
-		data.setUUID(uuid);
-		data.setTexture(texture);
-		data.setSignature(signature);
-		data.setEnchantments(enchantments);
-		data.setAttributes(attributes);
-		data.setLore(lore);
-		data.setPages(pages);
-		data.setPatterns(patterns);
-		data.setPotionEffects(potionEffects);
-		data.setFireworkEffects(fireworkEffects);
-		return data;
-	}
+    private EnumMap<ItemAttribute, Object> itemAttributes = new EnumMap<>(ItemAttribute.class);
+
+    public Object getItemAttribute(ItemAttribute attr) {
+        return itemAttributes.get(attr);
+    }
+
+    public void setItemAttribute(ItemAttribute attr, Object obj) {
+        if (obj == null) return;
+        if (!attr.getDataType().isAssignableFrom(obj.getClass())) return;
+
+        itemAttributes.put(attr, obj);
+    }
+
+    public boolean hasItemAttribute(ItemAttribute atr) {
+        return itemAttributes.containsKey(atr);
+    }
+
+    public boolean conforms(MagicItemData data) {
+        for (ItemAttribute attr : itemAttributes.keySet())
+            if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
+                return false;
+
+        return true;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof MagicItemData)) return false;
+
+        return itemAttributes.equals(((MagicItemData) o).itemAttributes);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(itemAttributes);
+    }
+
+    @Override
+    public MagicItemData clone() {
+        MagicItemData data = new MagicItemData();
+
+        data.itemAttributes = new EnumMap<>(itemAttributes);
+
+        return data;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder output = new StringBuilder();
+        boolean previous = false;
+
+        if (hasItemAttribute(ItemAttribute.TYPE))
+            output.append(((Material) getItemAttribute(ItemAttribute.TYPE)).name());
+
+        output.append("{");
+        if (hasItemAttribute(ItemAttribute.NAME)) {
+            output.append("name:'").append(((String) getItemAttribute(ItemAttribute.NAME)).replaceAll("'", "\\\\'")).append("'");
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.AMOUNT)) {
+            int amount = (int) getItemAttribute(ItemAttribute.AMOUNT);
+
+            if (amount > 1) {
+                if (previous) output.append(",");
+                output.append("amount:").append(amount);
+                previous = true;
+            }
+        }
+
+        if (hasItemAttribute(ItemAttribute.DURABILITY)) {
+            if (previous) output.append(",");
+            output.append("durability:").append((int) getItemAttribute(ItemAttribute.DURABILITY));
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.CUSTOM_MODEL_DATA)) {
+            int customModelData = (int) getItemAttribute(ItemAttribute.CUSTOM_MODEL_DATA);
+
+            if (customModelData > 0) {
+                if (previous) output.append(",");
+                output.append("customModelData:").append(customModelData);
+                previous = true;
+            }
+        }
+
+        if (hasItemAttribute(ItemAttribute.UNBREAKABLE)) {
+            if (previous) output.append(",");
+            output.append("unbreakable:").append((boolean) getItemAttribute(ItemAttribute.UNBREAKABLE));
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.COLOR)) {
+            if (previous) output.append(",");
+            Color color = (Color) getItemAttribute(ItemAttribute.COLOR);
+            String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+            output.append("color:\"").append(hex).append("\"");
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.POTION_TYPE)) {
+            if (previous) output.append(",");
+            output.append("potion:\"").append(((PotionType) getItemAttribute(ItemAttribute.POTION_TYPE)).name()).append("\"");
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.TITLE)) {
+            if (previous) output.append(",");
+            output.append("title:\"").append((String) getItemAttribute(ItemAttribute.TITLE)).append("\"");
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.AUTHOR)) {
+            if (previous) output.append(",");
+            output.append("author:\"").append((String) getItemAttribute(ItemAttribute.AUTHOR)).append("\"");
+            previous = true;
+        }
+
+        if (hasItemAttribute(ItemAttribute.ENCHANTMENTS)) {
+            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getItemAttribute(ItemAttribute.ENCHANTMENTS);
+
+            if (!enchantments.isEmpty()) {
+                if (previous) output.append(",");
+                output.append("enchants:{");
+                boolean previousEnchantment = false;
+                for (Enchantment enchantment : enchantments.keySet()) {
+                    if (previousEnchantment) output.append(",");
+                    output.append(enchantment.getKey().getKey()).append(":").append(enchantments.get(enchantment));
+                    previousEnchantment = true;
+                }
+                output.append("}");
+                previous = true;
+            }
+        }
+
+        if (hasItemAttribute(ItemAttribute.LORE)) {
+            List<String> lore = (List<String>) getItemAttribute(ItemAttribute.LORE);
+
+            if (!lore.isEmpty()) {
+                if (previous) output.append(",");
+                output.append("lore:[");
+                boolean previousLore = false;
+                for (String line : lore) {
+                    if (previousLore) output.append(",");
+                    output.append("\"").append(line).append("\"");
+                    previousLore = true;
+                }
+                output.append("]");
+                previous = true;
+            }
+        }
+
+        output.append("}");
+
+        return output.toString();
+    }
+
+    public enum ItemAttribute {
+
+        TYPE(Material.class),
+        NAME(String.class),
+        AMOUNT(Integer.class),
+        DURABILITY(Integer.class),
+        REPAIR_COST(Integer.class),
+        CUSTOM_MODEL_DATA(Integer.class),
+        POWER(Integer.class),
+        UNBREAKABLE(Boolean.class),
+        HIDE_TOOLTIP(Boolean.class),
+        COLOR(Color.class),
+        POTION_TYPE(PotionType.class),
+        FIREWORK_EFFECT(FireworkEffect.class),
+        SKULL_OWNER(OfflinePlayer.class),
+        TITLE(String.class),
+        AUTHOR(String.class),
+        UUID(String.class),
+        TEXTURE(String.class),
+        SIGNATURE(String.class),
+        ENCHANTMENTS(Map.class),
+        ATTRIBUTES(Multimap.class),
+        LORE(List.class),
+        PAGES(List.class),
+        PATTERNS(List.class),
+        POTION_EFFECTS(List.class),
+        FIREWORK_EFFECTS(List.class);
+
+        private final Class<?> dataType;
+        private final String asString;
+
+        ItemAttribute(Class<?> dataType) {
+            this.dataType = dataType;
+            asString = name().toLowerCase().replace('_', '-');
+        }
+
+        public Class<?> getDataType() {
+            return dataType;
+        }
+
+        @Override
+        public String toString() {
+            return asString;
+        }
+
+    }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -22,6 +22,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.attribute.AttributeModifier;
 
+import com.nisovin.magicspells.util.TxtUtil;
 import com.nisovin.magicspells.util.AttributeUtil.AttributeModifierData;
 
 public class MagicItemData {
@@ -183,10 +184,6 @@ public class MagicItemData {
 
     }
 
-    private String escape(String str) {
-        return str.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
-    }
-
     @Override
     public String toString() {
         StringBuilder output = new StringBuilder();
@@ -199,7 +196,7 @@ public class MagicItemData {
         if (hasAttribute(MagicItemAttribute.NAME)) {
             output
                 .append("\"name\":\"")
-                .append(escape((String) getAttribute(MagicItemAttribute.NAME)))
+                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.NAME)))
                 .append('"');
 
             previous = true;
@@ -280,6 +277,7 @@ public class MagicItemData {
 
             Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
             String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+
             output
                 .append("\"color\":\"")
                 .append(hex)
@@ -306,12 +304,12 @@ public class MagicItemData {
         }
 
         if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
+            if (previous) output.append(',');
+
             FireworkEffect effect = (FireworkEffect) getAttribute(MagicItemAttribute.FIREWORK_EFFECT);
 
-            if (previous) output.append(',');
-            output.append("\"fireworkeffect\":\"");
-
             output
+                .append("\"fireworkeffect\":\"")
                 .append(effect.getType())
                 .append(' ')
                 .append(effect.hasTrail())
@@ -323,8 +321,10 @@ public class MagicItemData {
                 output.append(' ');
                 for (Color color : effect.getColors()) {
                     if (previousColor) output.append(',');
+
                     String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
                     output.append(hex);
+
                     previousColor = true;
                 }
 
@@ -333,8 +333,10 @@ public class MagicItemData {
                     previousColor = false;
                     for (Color color : effect.getFadeColors()) {
                         if (previousColor) output.append(',');
+
                         String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
                         output.append(hex);
+
                         previousColor = true;
                     }
                 }
@@ -360,7 +362,7 @@ public class MagicItemData {
 
             output
                 .append("\"title\":\"")
-                .append(escape((String) getAttribute(MagicItemAttribute.TITLE)))
+                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.TITLE)))
                 .append('"');
 
             previous = true;
@@ -371,7 +373,7 @@ public class MagicItemData {
 
             output
                 .append("\"author\":\"")
-                .append(escape((String) getAttribute(MagicItemAttribute.AUTHOR)))
+                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.AUTHOR)))
                 .append('"');
 
             previous = true;
@@ -411,11 +413,11 @@ public class MagicItemData {
         }
 
         if (hasAttribute(MagicItemAttribute.ENCHANTMENTS)) {
-            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTMENTS);
-
             if (previous) output.append(',');
-            output.append("\"enchantments\":{");
+
+            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTMENTS);
             boolean previousEnchantment = false;
+            output.append("\"enchantments\":{");
             for (Enchantment enchantment : enchantments.keySet()) {
                 if (previousEnchantment) output.append(',');
 
@@ -443,73 +445,85 @@ public class MagicItemData {
         
         if (hasAttribute(MagicItemAttribute.ATTRIBUTES)) {
             if (previous) output.append(',');
-            output.append("\"attributes\":[");
 
             Multimap<Attribute, AttributeModifier> attributes = (Multimap<Attribute, AttributeModifier>) getAttribute(MagicItemAttribute.ATTRIBUTES);
             boolean previousAttribute = false;
+            output.append("\"attributes\":[");
             for (Map.Entry<Attribute, AttributeModifier> entries : attributes.entries()) {
                 if (previousAttribute) output.append(',');
 
                 AttributeModifier modifier = entries.getValue();
 
-                output.append('"');
-                output.append(modifier.getName());
-                output.append(' ');
-                output.append(modifier.getAmount());
-                output.append(' ');
-                output.append(modifier.getOperation().name().toLowerCase());
+                output
+                    .append('"')
+                    .append(modifier.getName())
+                    .append(' ')
+                    .append(modifier.getAmount())
+                    .append(' ')
+                    .append(modifier.getOperation().name().toLowerCase());
 
                 EquipmentSlot slot = modifier.getSlot();
                 if (slot != null) {
-                    output.append(' ');
-                    output.append(slot.name().toLowerCase());
+                    output
+                        .append(' ')
+                        .append(slot.name().toLowerCase());
                 }
 
                 output.append('"');
                 previousAttribute = true;
             }
-
             output.append(']');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.LORE)) {
             if (previous) output.append(',');
-            output.append("\"lore\":[");
 
             List<String> lore = (List<String>) getAttribute(MagicItemAttribute.LORE);
             boolean previousLore = false;
+            output.append("\"lore\":[");
             for (String line : lore) {
                 if (previousLore) output.append(',');
-                output.append('"').append(escape(line)).append('"');
+
+                output
+                    .append('"')
+                    .append(TxtUtil.escapeJSON(line))
+                    .append('"');
+
                 previousLore = true;
             }
-
             output.append(']');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.PAGES)) {
             if (previous) output.append(',');
-            output.append("\"pages\":[");
 
             List<String> pages = (List<String>) getAttribute(MagicItemAttribute.PAGES);
             boolean previousPages = false;
+            output.append("\"pages\":[");
             for (String page : pages) {
                 if (previousPages) output.append(',');
-                output.append('"').append(escape(page)).append('"');
+
+                output
+                    .append('"')
+                    .append(TxtUtil.escapeJSON(page))
+                    .append('"');
+
                 previousPages = true;
             }
-
             output.append(']');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.PATTERNS)) {
-            List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
-
             if (previous) output.append(',');
+
             output.append("\"patterns\":[");
+            List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
             boolean previousPattern = false;
             for (Pattern pattern : patterns) {
                 if (previousPattern) output.append(',');
@@ -523,16 +537,16 @@ public class MagicItemData {
 
                 previousPattern = true;
             }
-
             output.append(']');
+
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.POTION_EFFECTS)) {
-            List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
-
             if (previous) output.append(',');
+
             output.append("\"potioneffects\":[");
+            List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
             boolean previousEffect = false;
             for (PotionEffect effect : effects) {
                 if (previousEffect) output.append(',');
@@ -548,8 +562,8 @@ public class MagicItemData {
 
                 previousEffect = true;
             }
-
             output.append(']');
+
             previous = true;
         }
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -140,14 +140,16 @@ public class MagicItemData {
 
     @Override
     public int hashCode() {
-        return Objects.hash(itemAttributes, ignoredAttributes);
+        return Objects.hash(itemAttributes, ignoredAttributes, blacklistedAttributes);
     }
 
     @Override
     public MagicItemData clone() {
         MagicItemData data = new MagicItemData();
 
-        data.itemAttributes = new EnumMap<>(itemAttributes);
+        if (!itemAttributes.isEmpty()) data.itemAttributes.putAll(itemAttributes);
+        if (!ignoredAttributes.isEmpty()) data.ignoredAttributes.addAll(ignoredAttributes);
+        if (!blacklistedAttributes.isEmpty()) data.blacklistedAttributes.addAll(blacklistedAttributes);
 
         return data;
     }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -13,9 +13,8 @@ import com.google.common.collect.Multimap;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.FireworkEffect;
-import org.bukkit.potion.PotionType;
+import org.bukkit.potion.PotionData;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.block.banner.Pattern;
@@ -148,7 +147,7 @@ public class MagicItemData {
         UNBREAKABLE(Boolean.class),
         HIDE_TOOLTIP(Boolean.class),
         FAKE_GLINT(Boolean.class),
-        POTION_TYPE(PotionType.class),
+        POTION_DATA(PotionData.class),
         COLOR(Color.class),
         FIREWORK_EFFECT(FireworkEffect.class),
         TITLE(String.class),
@@ -289,13 +288,19 @@ public class MagicItemData {
             previous = true;
         }
 
-        if (hasAttribute(MagicItemAttribute.POTION_TYPE)) {
+        if (hasAttribute(MagicItemAttribute.POTION_DATA)) {
             if (previous) output.append(',');
 
+            PotionData potionData = (PotionData) getAttribute(MagicItemAttribute.POTION_DATA);
+
             output
-                .append("\"potiontype\":\"")
-                .append(((PotionType) getAttribute(MagicItemAttribute.POTION_TYPE)).name())
-                .append('"');
+                .append("\"potiondata\":\"")
+                .append(potionData.getType());
+
+            if (potionData.isExtended()) output.append(" extended");
+            else if (potionData.isUpgraded()) output.append(" upgraded");
+
+            output.append('"');
 
             previous = true;
         }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -198,7 +198,7 @@ public class MagicItemData {
 
         output.append('{');
         if (hasAttribute(MagicItemAttribute.NAME)) {
-            output.append("\"name\":\"").append((String) getAttribute(MagicItemAttribute.NAME)).append('"');
+            output.append("\"name\":\"").append(escape((String) getAttribute(MagicItemAttribute.NAME))).append('"');
             previous = true;
         }
 
@@ -307,13 +307,13 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.TITLE)) {
             if (previous) output.append(',');
-            output.append("\"title\":\"").append((String) getAttribute(MagicItemAttribute.TITLE)).append('"');
+            output.append("\"title\":\"").append(escape((String) getAttribute(MagicItemAttribute.TITLE))).append('"');
             previous = true;
         }
 
         if (hasAttribute(MagicItemAttribute.AUTHOR)) {
             if (previous) output.append(',');
-            output.append("\"author\":\"").append((String) getAttribute(MagicItemAttribute.AUTHOR)).append('"');
+            output.append("\"author\":\"").append(escape((String) getAttribute(MagicItemAttribute.AUTHOR))).append('"');
             previous = true;
         }
 
@@ -418,7 +418,7 @@ public class MagicItemData {
             boolean previousPages = false;
             for (String page : pages) {
                 if (previousPages) output.append(',');
-                output.append('"').append(page).append('"');
+                output.append('"').append(escape(page)).append('"');
                 previousPages = true;
             }
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -97,11 +97,10 @@ public class MagicItemDataParser {
 
 					switch (key.toLowerCase()) {
 						case "name":
-							data.setAttribute(NAME, value.getAsString());
+							data.setAttribute(NAME, Util.colorize(value.getAsString()));
 							break;
 						case "amount":
-							int amount = value.getAsInt();
-							if (amount >= 1) data.setAttribute(AMOUNT, value.getAsInt());
+							data.setAttribute(AMOUNT, value.getAsInt());
 							break;
 						case "durability":
 							data.setAttribute(DURABILITY, value.getAsInt());
@@ -173,10 +172,10 @@ public class MagicItemDataParser {
 							}
 							break;
 						case "title":
-							data.setAttribute(TITLE, value.getAsString());
+							data.setAttribute(TITLE, Util.colorize(value.getAsString()));
 							break;
 						case "author":
-							data.setAttribute(AUTHOR, value.getAsString());
+							data.setAttribute(AUTHOR, Util.colorize(value.getAsString()));
 							break;
 						case "uuid":
 							data.setAttribute(UUID, value.getAsString());
@@ -269,7 +268,7 @@ public class MagicItemDataParser {
 							List<String> lore = new ArrayList<>();
 							JsonArray jsonArray = value.getAsJsonArray();
 							for (JsonElement elementInside : jsonArray) {
-								lore.add(elementInside.getAsString());
+								lore.add(Util.colorize(elementInside.getAsString()));
 							}
 
 							data.setAttribute(LORE, lore);
@@ -280,7 +279,7 @@ public class MagicItemDataParser {
 							List<String> pages = new ArrayList<>();
 							JsonArray pageArray = value.getAsJsonArray();
 							for (JsonElement page : pageArray) {
-								pages.add(page.getAsString());
+								pages.add(Util.colorize(page.getAsString()));
 							}
 
 							data.setAttribute(PAGES, pages);
@@ -291,7 +290,7 @@ public class MagicItemDataParser {
 							List<Pattern> patterns = new ArrayList<>();
 							JsonArray patternStrings = value.getAsJsonArray();
 							for (JsonElement element : patternStrings) {
-								String patternString = element.toString();
+								String patternString = element.getAsString();
 								String[] pattern = patternString.split(" ");
 
 								if (pattern.length == 2) {

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -81,6 +81,8 @@ public class MagicItemDataParser {
 		MagicItemData data = new MagicItemData();
 		data.setAttribute(TYPE, type);
 
+		if (type.isAir()) return data;
+
 		try {
 			while (jsonReader.peek() != JsonToken.END_DOCUMENT) {
 				JsonElement jsonElement = jsonElementTypeAdapter.read(jsonReader);

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -143,7 +143,7 @@ public class MagicItemDataParser {
 
 								data.setAttribute(POTION_DATA, potionData);
 							} catch (IllegalArgumentException e) {
-								DebugHandler.debugBadEnumValue(PotionType.class, potionDataArgs[0]);
+								DebugHandler.debugIllegalArgumentException(e);
 							}
 							break;
 						case "fireworkeffect":

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -16,19 +16,31 @@ import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.stream.JsonReader;
+import com.google.common.collect.Multimap;
 import com.google.gson.JsonSyntaxException;
+import com.google.common.collect.HashMultimap;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
+import org.bukkit.Bukkit;
+import org.bukkit.DyeColor;
 import org.bukkit.Material;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.FireworkEffect;
+import org.bukkit.potion.PotionEffect;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.block.banner.Pattern;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.enchantments.Enchantment;
+import org.bukkit.block.banner.PatternType;
+import org.bukkit.attribute.AttributeModifier;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.handlers.EnchantmentHandler;
 import com.nisovin.magicspells.handlers.PotionEffectHandler;
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.ItemAttribute.*;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
 public class MagicItemDataParser {
 
@@ -49,7 +61,7 @@ public class MagicItemDataParser {
 			if (type == null) return null;
 
 			MagicItemData magicItemData = new MagicItemData();
-			magicItemData.setItemAttribute(TYPE, type);
+			magicItemData.setAttribute(TYPE, type);
 
 			return magicItemData;
 		}
@@ -65,7 +77,7 @@ public class MagicItemDataParser {
 		jsonReader.setLenient(true);
 
 		MagicItemData data = new MagicItemData();
-		data.setItemAttribute(TYPE, type);
+		data.setAttribute(TYPE, type);
 
 		try {
 			while (jsonReader.peek() != JsonToken.END_DOCUMENT) {
@@ -81,57 +93,171 @@ public class MagicItemDataParser {
 
 					switch (key.toLowerCase()) {
 						case "name":
-							data.setItemAttribute(NAME, value.getAsString());
+							data.setAttribute(NAME, value.getAsString());
 							break;
 						case "amount":
-							data.setItemAttribute(AMOUNT, value.getAsInt());
+							int amount = value.getAsInt();
+							if (amount >= 1) data.setAttribute(AMOUNT, value.getAsInt());
 							break;
 						case "durability":
-							data.setItemAttribute(DURABILITY, value.getAsInt());
+							data.setAttribute(DURABILITY, value.getAsInt());
+							break;
+						case "repaircost":
+							data.setAttribute(REPAIR_COST, value.getAsInt());
 							break;
 						case "custommodeldata":
-							data.setItemAttribute(CUSTOM_MODEL_DATA, value.getAsInt());
+							data.setAttribute(CUSTOM_MODEL_DATA, value.getAsInt());
+							break;
+						case "power":
+							data.setAttribute(POWER, value.getAsInt());
 							break;
 						case "unbreakable":
-							data.setItemAttribute(UNBREAKABLE, value.getAsBoolean());
+							data.setAttribute(UNBREAKABLE, value.getAsBoolean());
+							break;
+						case "hidetooltip":
+							data.setAttribute(HIDE_TOOLTIP, value.getAsBoolean());
 							break;
 						case "color":
 							try {
 								Color color = Color.fromRGB(Integer.parseInt(value.getAsString().replace("#", ""), 16));
-								data.setItemAttribute(COLOR, color);
+								data.setAttribute(COLOR, color);
 							} catch (NumberFormatException e) {
 								DebugHandler.debugNumberFormat(e);
 							}
 							break;
 						case "potiontype":
-							data.setItemAttribute(POTION_TYPE, PotionEffectHandler.getPotionType(value.getAsString()));
+							data.setAttribute(POTION_TYPE, PotionEffectHandler.getPotionType(value.getAsString()));
+							break;
+						case "fireworkeffect":
+							String[] effectString = value.getAsString().split(" ");
+
+							if (effectString.length >= 4) {
+								try {
+									FireworkEffect.Type fireworkType = FireworkEffect.Type.valueOf(effectString[0].toUpperCase());
+									boolean trail = Boolean.parseBoolean(effectString[1]);
+									boolean flicker = Boolean.parseBoolean(effectString[2]);
+									Color[] colors = Util.getColorsFromString(effectString[3]);
+									Color[] fadeColors = null;
+
+									if (effectString.length > 4) fadeColors = Util.getColorsFromString(effectString[4]);
+									if (fadeColors == null) fadeColors = new Color[0];
+
+									FireworkEffect effect = FireworkEffect.builder()
+										.flicker(flicker)
+										.trail(trail)
+										.with(fireworkType)
+										.withColor(colors)
+										.withFade(fadeColors)
+										.build();
+
+									data.setAttribute(FIREWORK_EFFECT, effect);
+								} catch (IllegalArgumentException e) {
+									DebugHandler.debugBadEnumValue(FireworkEffect.Type.class, effectString[0].toUpperCase());
+									MagicSpells.error("'" + value.getAsString() + "' could not be connected to a firework effect.");
+								}
+							} else MagicSpells.error("'" + value.getAsString() + "' could not be connected to a firework effect.");
+							break;
+						case "skullowner":
+							try {
+								java.util.UUID skullOwnerUUID = java.util.UUID.fromString(value.getAsString());
+								OfflinePlayer skullOwner = Bukkit.getOfflinePlayer(skullOwnerUUID);
+
+								data.setAttribute(SKULL_OWNER, skullOwner);
+							} catch (IllegalArgumentException e) {
+								DebugHandler.debugIllegalArgumentException(e);
+								MagicSpells.error("'" + value.getAsString() + "' could not be connected to a player.");
+							}
 							break;
 						case "title":
-							data.setItemAttribute(TITLE, value.getAsString());
+							data.setAttribute(TITLE, value.getAsString());
 							break;
 						case "author":
-							data.setItemAttribute(AUTHOR, value.getAsString());
+							data.setAttribute(AUTHOR, value.getAsString());
+							break;
+						case "uuid":
+							data.setAttribute(UUID, value.getAsString());
+							break;
+						case "texture":
+							data.setAttribute(TEXTURE, value.getAsString());
+							break;
+						case "signature":
+							data.setAttribute(SIGNATURE, value.getAsString());
 							break;
 						case "enchantments":
 						case "enchants":
 							if (!value.isJsonObject()) continue;
 
-							Map<Object, Object> objectMap;
+							Map<String, Object> objectMap;
 							try {
 								objectMap = gson.fromJson(value.getAsJsonObject().toString(), HashMap.class);
 
 								Map<Enchantment, Integer> enchantments = new HashMap<>();
-								for (Object o : objectMap.keySet()) {
-									Enchantment enchantment = EnchantmentHandler.getEnchantment(o.toString());
-									int v = (int) Double.parseDouble(objectMap.get(o).toString().trim());
-									enchantments.put(enchantment, v);
+								for (String enchantString : objectMap.keySet()) {
+									Enchantment enchantment = EnchantmentHandler.getEnchantment(enchantString);
+
+									if (enchantment == null) {
+										MagicSpells.error('\'' + enchantString + "' could not be connected to an enchantment");
+										continue;
+									}
+
+									double v;
+									try {
+										v = Double.parseDouble(objectMap.get(enchantString).toString().trim());
+									} catch (NumberFormatException e) {
+										DebugHandler.debugNumberFormat(e);
+										continue;
+									}
+
+									enchantments.put(enchantment, (int) v);
 								}
 
-								data.setItemAttribute(ENCHANTMENTS, enchantments);
+								if (data.hasAttribute(FAKE_GLINT)) {
+									boolean fakeGlint = (boolean) data.getAttribute(FAKE_GLINT);
+
+									if (!enchantments.isEmpty() && fakeGlint) data.removeAttribute(FAKE_GLINT);
+								}
+
+								data.setAttribute(ENCHANTMENTS, enchantments);
 							} catch (JsonSyntaxException exception) {
 								MagicSpells.error("Invalid enchantment syntax!");
 								continue;
 							}
+							break;
+						case "fakeglint":
+							if (data.hasAttribute(ENCHANTMENTS)) {
+								Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
+								boolean fakeGlint = value.getAsBoolean();
+
+								if (enchantments.isEmpty() && fakeGlint) data.setAttribute(FAKE_GLINT, true);
+							} else if (value.getAsBoolean()) data.setAttribute(FAKE_GLINT, true);
+							break;
+						case "attributes":
+							if (!value.isJsonArray()) continue;
+
+							Multimap<Attribute, AttributeModifier> itemAttributes = HashMultimap.create();
+							JsonArray attributeArray = value.getAsJsonArray();
+							for (JsonElement element : attributeArray) {
+								String[] attributeArgs = element.getAsString().split(" ");
+								if (attributeArgs.length < 2) continue;
+
+								Attribute attribute = AttributeUtil.getAttribute(attributeArgs[0]);
+								double val = Double.parseDouble(attributeArgs[1]);
+
+								AttributeModifier.Operation operation = AttributeModifier.Operation.ADD_NUMBER;
+								if (attributeArgs.length >= 3) operation = AttributeUtil.getOperation(attributeArgs[2]);
+
+								EquipmentSlot slot = null;
+								if (attributeArgs.length >= 4) {
+									try {
+										slot = EquipmentSlot.valueOf(attributeArgs[3].toUpperCase());
+									} catch (Exception ignored) {}
+								}
+
+								AttributeModifier modifier = new AttributeModifier(java.util.UUID.randomUUID(), attributeArgs[0], val, operation, slot);
+								itemAttributes.put(attribute, modifier);
+							}
+
+							data.setAttribute(ATTRIBUTES, itemAttributes);
 							break;
 						case "lore":
 							if (!value.isJsonArray()) continue;
@@ -141,7 +267,107 @@ public class MagicItemDataParser {
 							for (JsonElement elementInside : jsonArray) {
 								lore.add(elementInside.getAsString());
 							}
-							data.setItemAttribute(LORE, lore);
+
+							data.setAttribute(LORE, lore);
+							break;
+						case "pages":
+							if (!value.isJsonArray()) continue;
+
+							List<String> pages = new ArrayList<>();
+							JsonArray pageArray = value.getAsJsonArray();
+							for (JsonElement page : pageArray) {
+								pages.add(page.getAsString());
+							}
+
+							data.setAttribute(PAGES, pages);
+							break;
+						case "patterns":
+							if (!value.isJsonArray()) continue;
+
+							List<Pattern> patterns = new ArrayList<>();
+							JsonArray patternStrings = value.getAsJsonArray();
+							for (JsonElement element : patternStrings) {
+								String patternString = element.toString();
+								String[] pattern = patternString.split(" ");
+
+								if (pattern.length == 2) {
+									PatternType patternType;
+									DyeColor dyeColor;
+
+									try {
+										patternType = PatternType.valueOf(pattern[0]);
+									} catch (IllegalArgumentException e) {
+										DebugHandler.debugBadEnumValue(PatternType.class, pattern[0]);
+										MagicSpells.error("'" + patternString + "' could not be connected to a pattern.");
+										continue;
+									}
+
+									try {
+										dyeColor = DyeColor.valueOf(pattern[1]);
+									} catch (IllegalArgumentException e) {
+										DebugHandler.debugBadEnumValue(DyeColor.class, pattern[1]);
+										MagicSpells.error("'" + patternString + "' could not be connected to a pattern.");
+										continue;
+									}
+
+									patterns.add(new Pattern(dyeColor, patternType));
+								} else MagicSpells.error("'" + patternString + "' could not be connected to a pattern.");
+							}
+
+							data.setAttribute(PATTERNS, patterns);
+							break;
+						case "potioneffects":
+							if (!value.isJsonArray()) continue;
+
+							List<PotionEffect> potionEffects = new ArrayList<>();
+							JsonArray potionEffectStrings = value.getAsJsonArray();
+
+							for (JsonElement element : potionEffectStrings) {
+								String potionEffectString = element.getAsString();
+								PotionEffect eff = Util.buildPotionEffect(potionEffectString);
+
+								if (eff != null) potionEffects.add(eff);
+								else MagicSpells.error("'" + potionEffectString + "' could not be connected to a potion effect.");
+							}
+
+							data.setAttribute(POTION_EFFECTS, potionEffects);
+							break;
+						case "fireworkeffects":
+							if (!value.isJsonArray()) continue;
+
+							List<FireworkEffect> fireworkEffects = new ArrayList<>();
+							JsonArray fireworkEffectStrings = value.getAsJsonArray();
+							for (JsonElement eff : fireworkEffectStrings) {
+								String[] effString = eff.getAsString().split(" ");
+
+								if (effString.length == 4 || effString.length == 5) {
+									try {
+										FireworkEffect.Type fireworkType = FireworkEffect.Type.valueOf(effString[0].toUpperCase());
+										boolean trail = Boolean.parseBoolean(effString[1]);
+										boolean flicker = Boolean.parseBoolean(effString[2]);
+										Color[] colors = Util.getColorsFromString(effString[3]);
+										Color[] fadeColors = null;
+
+										if (effString.length > 4) fadeColors = Util.getColorsFromString(effString[4]);
+										if (fadeColors == null) fadeColors = new Color[0];
+
+										FireworkEffect effect = FireworkEffect.builder()
+											.flicker(flicker)
+											.trail(trail)
+											.with(fireworkType)
+											.withColor(colors)
+											.withFade(fadeColors)
+											.build();
+
+										fireworkEffects.add(effect);
+									} catch (IllegalArgumentException e) {
+										DebugHandler.debugBadEnumValue(FireworkEffect.Type.class, effString[0].toUpperCase());
+										MagicSpells.error("'" + eff.getAsString() + "' could not be connected to a firework effect.");
+									}
+								} else MagicSpells.error("'" + eff.getAsString() + "' could not be connected to a firework effect.");
+							}
+
+							data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
 							break;
 					}
 				}

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.util.magicitems;
 import java.util.Map;
 import java.util.Set;
 import java.util.List;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.ArrayList;
 
@@ -40,6 +41,7 @@ import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.handlers.EnchantmentHandler;
 import com.nisovin.magicspells.handlers.PotionEffectHandler;
+import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
 public class MagicItemDataParser {
@@ -368,6 +370,20 @@ public class MagicItemDataParser {
 							}
 
 							data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
+							break;
+						case "ignoredattributes":
+							if (!value.isJsonArray()) continue;
+							EnumSet<MagicItemAttribute> ignoredAttributes = data.getIgnoredAttributes();
+							JsonArray ignoredAttributeStrings = value.getAsJsonArray();
+
+							for (JsonElement element : ignoredAttributeStrings) {
+								String ignoredAttribute = element.getAsString().toUpperCase();
+								try {
+									ignoredAttributes.add(MagicItemAttribute.valueOf(ignoredAttribute));
+								} catch (IllegalArgumentException e) {
+									DebugHandler.debugBadEnumValue(MagicItemAttribute.class, ignoredAttribute);
+								}
+							}
 							break;
 					}
 				}

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -25,6 +25,8 @@ import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.FireworkEffect;
+import org.bukkit.potion.PotionData;
+import org.bukkit.potion.PotionType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.banner.Pattern;
@@ -38,7 +40,6 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.handlers.EnchantmentHandler;
-import com.nisovin.magicspells.handlers.PotionEffectHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
@@ -126,8 +127,24 @@ public class MagicItemDataParser {
 								DebugHandler.debugNumberFormat(e);
 							}
 							break;
-						case "potiontype":
-							data.setAttribute(POTION_TYPE, PotionEffectHandler.getPotionType(value.getAsString()));
+						case "potiondata":
+							String[] potionDataArgs = value.getAsString().split(" ");
+
+							try {
+								PotionType potionType = PotionType.valueOf(potionDataArgs[0].toUpperCase());
+								boolean extended = false, upgraded = false;
+
+								if (potionDataArgs.length > 1) {
+									if (potionDataArgs[1].equalsIgnoreCase("extended")) extended = true;
+									else if (potionDataArgs[1].equalsIgnoreCase("upgraded")) upgraded = true;
+								}
+
+								PotionData potionData = new PotionData(potionType, extended, upgraded);
+
+								data.setAttribute(POTION_DATA, potionData);
+							} catch (IllegalArgumentException e) {
+								DebugHandler.debugBadEnumValue(PotionType.class, potionDataArgs[0]);
+							}
 							break;
 						case "fireworkeffect":
 							String[] effectString = value.getAsString().split(" ");

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -16,6 +16,7 @@ import com.google.gson.JsonObject;
 import com.google.gson.JsonElement;
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonToken;
+import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
 import com.google.common.collect.Multimap;
 import com.google.gson.JsonSyntaxException;
@@ -105,9 +106,13 @@ public class MagicItemDataParser {
 							data.setAttribute(DURABILITY, value.getAsInt());
 							break;
 						case "repaircost":
+						case "repair-cost":
+						case "repair_cost":
 							data.setAttribute(REPAIR_COST, value.getAsInt());
 							break;
 						case "custommodeldata":
+						case "custom-model-data":
+						case "custom_model_data":
 							data.setAttribute(CUSTOM_MODEL_DATA, value.getAsInt());
 							break;
 						case "power":
@@ -117,6 +122,8 @@ public class MagicItemDataParser {
 							data.setAttribute(UNBREAKABLE, value.getAsBoolean());
 							break;
 						case "hidetooltip":
+						case "hide-tooltip":
+						case "hide_tooltip":
 							data.setAttribute(HIDE_TOOLTIP, value.getAsBoolean());
 							break;
 						case "color":
@@ -128,6 +135,11 @@ public class MagicItemDataParser {
 							}
 							break;
 						case "potiondata":
+						case "potion-data":
+						case "potion_data":
+						case "potiontype":
+						case "potion-type":
+						case "potion_type":
 							String[] potionDataArgs = value.getAsString().split(" ");
 
 							try {
@@ -147,6 +159,8 @@ public class MagicItemDataParser {
 							}
 							break;
 						case "fireworkeffect":
+						case "firework-effect":
+						case "firework_effect":
 							String[] effectString = value.getAsString().split(" ");
 
 							if (effectString.length >= 4) {
@@ -176,6 +190,8 @@ public class MagicItemDataParser {
 							} else MagicSpells.error("'" + value.getAsString() + "' could not be connected to a firework effect.");
 							break;
 						case "skullowner":
+						case "skull-owner":
+						case "skull_owner":
 							data.setAttribute(SKULL_OWNER, value.getAsString());
 							break;
 						case "title":
@@ -197,9 +213,9 @@ public class MagicItemDataParser {
 						case "enchants":
 							if (!value.isJsonObject()) continue;
 
-							Map<String, Object> objectMap;
+							Map<String, Integer> objectMap;
 							try {
-								objectMap = gson.fromJson(value.getAsJsonObject().toString(), HashMap.class);
+								objectMap = gson.fromJson(value.getAsJsonObject().toString(), new TypeToken<HashMap<String, Integer>>(){}.getType());
 
 								Map<Enchantment, Integer> enchantments = new HashMap<>();
 								for (String enchantString : objectMap.keySet()) {
@@ -210,15 +226,7 @@ public class MagicItemDataParser {
 										continue;
 									}
 
-									double v;
-									try {
-										v = Double.parseDouble(objectMap.get(enchantString).toString().trim());
-									} catch (NumberFormatException e) {
-										DebugHandler.debugNumberFormat(e);
-										continue;
-									}
-
-									enchantments.put(enchantment, (int) v);
+									enchantments.put(enchantment, objectMap.get(enchantString));
 								}
 
 								if (data.hasAttribute(FAKE_GLINT)) {
@@ -227,13 +235,15 @@ public class MagicItemDataParser {
 									if (!enchantments.isEmpty() && fakeGlint) data.removeAttribute(FAKE_GLINT);
 								}
 
-								data.setAttribute(ENCHANTMENTS, enchantments);
+								if (!enchantments.isEmpty()) data.setAttribute(ENCHANTMENTS, enchantments);
 							} catch (JsonSyntaxException exception) {
 								MagicSpells.error("Invalid enchantment syntax!");
 								continue;
 							}
 							break;
 						case "fakeglint":
+						case "fake-glint":
+						case "fake_glint":
 							if (data.hasAttribute(ENCHANTMENTS)) {
 								Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) data.getAttribute(ENCHANTMENTS);
 								boolean fakeGlint = value.getAsBoolean();
@@ -267,7 +277,7 @@ public class MagicItemDataParser {
 								itemAttributes.put(attribute, modifier);
 							}
 
-							data.setAttribute(ATTRIBUTES, itemAttributes);
+							if (!itemAttributes.isEmpty()) data.setAttribute(ATTRIBUTES, itemAttributes);
 							break;
 						case "lore":
 							if (!value.isJsonArray()) continue;
@@ -278,7 +288,7 @@ public class MagicItemDataParser {
 								lore.add(Util.colorize(elementInside.getAsString()));
 							}
 
-							data.setAttribute(LORE, lore);
+							if (!lore.isEmpty()) data.setAttribute(LORE, lore);
 							break;
 						case "pages":
 							if (!value.isJsonArray()) continue;
@@ -289,7 +299,7 @@ public class MagicItemDataParser {
 								pages.add(Util.colorize(page.getAsString()));
 							}
 
-							data.setAttribute(PAGES, pages);
+							if (!pages.isEmpty()) data.setAttribute(PAGES, pages);
 							break;
 						case "patterns":
 							if (!value.isJsonArray()) continue;
@@ -324,9 +334,11 @@ public class MagicItemDataParser {
 								} else MagicSpells.error("'" + patternString + "' could not be connected to a pattern.");
 							}
 
-							data.setAttribute(PATTERNS, patterns);
+							if (!patterns.isEmpty()) data.setAttribute(PATTERNS, patterns);
 							break;
 						case "potioneffects":
+						case "potion-effects":
+						case "potion_effects":
 							if (!value.isJsonArray()) continue;
 
 							List<PotionEffect> potionEffects = new ArrayList<>();
@@ -340,9 +352,11 @@ public class MagicItemDataParser {
 								else MagicSpells.error("'" + potionEffectString + "' could not be connected to a potion effect.");
 							}
 
-							data.setAttribute(POTION_EFFECTS, potionEffects);
+							if (!potionEffects.isEmpty()) data.setAttribute(POTION_EFFECTS, potionEffects);
 							break;
 						case "fireworkeffects":
+						case "firework-effects":
+						case "firework_effects":
 							if (!value.isJsonArray()) continue;
 
 							List<FireworkEffect> fireworkEffects = new ArrayList<>();
@@ -377,9 +391,11 @@ public class MagicItemDataParser {
 								} else MagicSpells.error("'" + eff.getAsString() + "' could not be connected to a firework effect.");
 							}
 
-							data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
+							if (!fireworkEffects.isEmpty()) data.setAttribute(FIREWORK_EFFECTS, fireworkEffects);
 							break;
 						case "ignoredattributes":
+						case "ignored-attributes":
+						case "ignored_attributes":
 							if (!value.isJsonArray()) continue;
 							EnumSet<MagicItemAttribute> ignoredAttributes = data.getIgnoredAttributes();
 							JsonArray ignoredAttributeStrings = value.getAsJsonArray();
@@ -390,6 +406,22 @@ public class MagicItemDataParser {
 									ignoredAttributes.add(MagicItemAttribute.valueOf(ignoredAttribute));
 								} catch (IllegalArgumentException e) {
 									DebugHandler.debugBadEnumValue(MagicItemAttribute.class, ignoredAttribute);
+								}
+							}
+							break;
+						case "blacklistedattributes":
+						case "blacklisted-attributes":
+						case "blacklisted_attributes":
+							if (!value.isJsonArray()) continue;
+							EnumSet<MagicItemAttribute> blacklistedAttributes = data.getBlacklistedAttributes();
+							JsonArray blacklistedAttributeStrings = value.getAsJsonArray();
+
+							for (JsonElement element : blacklistedAttributeStrings) {
+								String blacklistedAttribute = element.getAsString().toUpperCase();
+								try {
+									blacklistedAttributes.add(MagicItemAttribute.valueOf(blacklistedAttribute));
+								} catch (IllegalArgumentException e) {
+									DebugHandler.debugBadEnumValue(MagicItemAttribute.class, blacklistedAttribute);
 								}
 							}
 							break;

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -22,10 +22,8 @@ import com.google.gson.JsonSyntaxException;
 import com.google.common.collect.HashMultimap;
 
 import org.bukkit.Color;
-import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.FireworkEffect;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.attribute.Attribute;
@@ -161,15 +159,7 @@ public class MagicItemDataParser {
 							} else MagicSpells.error("'" + value.getAsString() + "' could not be connected to a firework effect.");
 							break;
 						case "skullowner":
-							try {
-								java.util.UUID skullOwnerUUID = java.util.UUID.fromString(value.getAsString());
-								OfflinePlayer skullOwner = Bukkit.getOfflinePlayer(skullOwnerUUID);
-
-								data.setAttribute(SKULL_OWNER, skullOwner);
-							} catch (IllegalArgumentException e) {
-								DebugHandler.debugIllegalArgumentException(e);
-								MagicSpells.error("'" + value.getAsString() + "' could not be connected to a player.");
-							}
+							data.setAttribute(SKULL_OWNER, value.getAsString());
 							break;
 						case "title":
 							data.setAttribute(TITLE, Util.colorize(value.getAsString()));

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -23,7 +23,6 @@ import org.bukkit.inventory.meta.EnchantmentStorageMeta;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.ItemUtil;
-import com.nisovin.magicspells.util.BlockUtils;
 import com.nisovin.magicspells.util.itemreader.*;
 import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
@@ -70,7 +69,7 @@ public class MagicItems {
 	}
 
 	public static MagicItemData getMagicItemDataFromItemStack(ItemStack itemStack) {
-		if (itemStack == null || BlockUtils.isAir(itemStack.getType())) return null;
+		if (itemStack == null) return null;
 
 		MagicItemData cached = itemStackCache.get(itemStack);
 		// We can do this because itemStackCache doesn't have any null values
@@ -82,11 +81,21 @@ public class MagicItems {
 		// type
 		data.setAttribute(TYPE, itemStack.getType());
 
-		// name
-		NameHandler.processMagicItemData(meta, data);
+		 if (itemStack.getType().isAir()) {
+		 	itemStackCache.put(itemStack, data);
+		 	return data;
+		 }
 
 		// amount
 		data.setAttribute(AMOUNT, itemStack.getAmount());
+
+		if (meta == null) {
+			itemStackCache.put(itemStack, data);
+			return data;
+		}
+
+		// name
+		NameHandler.processMagicItemData(meta, data);
 
 		// durability
 		if (ItemUtil.hasDurability(itemStack.getType())) DurabilityHandler.processMagicItemData(meta, data);
@@ -170,6 +179,8 @@ public class MagicItems {
 
 		ItemStack item = new ItemStack(type);
 		ItemMeta meta = item.getItemMeta();
+
+		if (type.isAir()) return new MagicItem(item, data);
 
 		if (data.hasAttribute(AMOUNT)) {
 			int amount = (int) data.getAttribute(AMOUNT);
@@ -301,6 +312,8 @@ public class MagicItems {
 
 			item = new ItemStack(type);
 			itemData.setAttribute(TYPE, type);
+
+			if (type.isAir()) return new MagicItem(item, itemData);
 
 			if (section.isInt("amount")) {
 				int amount = section.getInt("amount");

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.util.magicitems;
 
 import java.util.Map;
 import java.util.List;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.Collection;
 
@@ -28,6 +29,7 @@ import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.handlers.EnchantmentHandler;
 import com.nisovin.magicspells.util.managers.AttributeManager;
+import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 import com.nisovin.magicspells.util.itemreader.alternative.AlternativeReaderManager;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
@@ -269,7 +271,24 @@ public class MagicItems {
 
 			// See if this is managed by an alternative reader
 			ItemStack item = AlternativeReaderManager.deserialize(section);
-			if (item != null) return new MagicItem(item, getMagicItemDataFromItemStack(item));
+			if (item != null) {
+				MagicItem magicItem = new MagicItem(item, getMagicItemDataFromItemStack(item));
+
+				if (section.isList("ignored-attributes")) {
+					EnumSet<MagicItemAttribute> ignoredAttributes = magicItem.getMagicItemData().getIgnoredAttributes();
+					List<String> ignoredAttributeStrings = section.getStringList("ignored-attributes");
+
+					for (String attr : ignoredAttributeStrings) {
+						try {
+							ignoredAttributes.add(MagicItemAttribute.valueOf(attr.toUpperCase()));
+						} catch (IllegalArgumentException e) {
+							DebugHandler.debugBadEnumValue(MagicItemAttribute.class, attr);
+						}
+					}
+				}
+
+				return magicItem;
+			}
 
 			MagicItemData itemData = new MagicItemData();
 
@@ -425,6 +444,19 @@ public class MagicItems {
 				}
 
 				itemData.setAttribute(ATTRIBUTES, itemAttributes);
+			}
+
+			if (section.isList("ignored-attributes")) {
+				List<String> ignoredAttributeStrings = section.getStringList("ignored-attributes");
+				EnumSet<MagicItemAttribute> ignoredAttributes = itemData.getIgnoredAttributes();
+
+				for (String attr : ignoredAttributeStrings) {
+					try {
+						ignoredAttributes.add(MagicItemAttribute.valueOf(attr.toUpperCase()));
+					} catch (IllegalArgumentException e) {
+						DebugHandler.debugBadEnumValue(MagicItemAttribute.class, attr);
+					}
+				}
 			}
 
 			return new MagicItem(item, itemData);

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -76,7 +76,6 @@ public class MagicItems {
 		if (cached != null) return cached;
 
 		MagicItemData data = new MagicItemData();
-		ItemMeta meta = itemStack.getItemMeta();
 
 		// type
 		data.setAttribute(TYPE, itemStack.getType());
@@ -89,6 +88,7 @@ public class MagicItems {
 		// amount
 		data.setAttribute(AMOUNT, itemStack.getAmount());
 
+		ItemMeta meta = itemStack.getItemMeta();
 		if (meta == null) {
 			itemStackCache.put(itemStack, data);
 			return data;
@@ -191,7 +191,6 @@ public class MagicItems {
 		if (type == null) return null;
 
 		ItemStack item = new ItemStack(type);
-		ItemMeta meta = item.getItemMeta();
 
 		if (type.isAir()) return new MagicItem(item, data);
 
@@ -200,6 +199,7 @@ public class MagicItems {
 			if (amount >= 1) item.setAmount(amount);
 		}
 
+		ItemMeta meta = item.getItemMeta();
 		if (meta == null) return new MagicItem(item, data);
 
 		// Name

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -159,6 +159,13 @@ public class MagicItems {
 		return data;
 	}
 
+	public static MagicItemData getMagicItemDataFromString(String str) {
+		if (str == null) return null;
+		if (magicItems.containsKey(str)) return magicItems.get(str).getMagicItemData();
+
+		return MagicItemDataParser.parseMagicItemData(str);
+	}
+
 	public static MagicItem getMagicItemFromString(String str) {
 		if (str == null) return null;
 		if (magicItems.containsKey(str)) return magicItems.get(str);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/AttributeManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/AttributeManager.java
@@ -5,9 +5,9 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.Collection;
 
+import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.attribute.AttributeModifier;
 
@@ -16,16 +16,6 @@ import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 
 public class AttributeManager {
-
-	// get attribute operation from string
-	public AttributeModifier.Operation getAttributeOperation(String str) {
-		return AttributeUtil.AttributeOperation.getOperation(str);
-	}
-
-	// get attribute from string
-	public Attribute getAttribute(String str) {
-		return AttributeUtil.AttributeType.getAttribute(str);
-	}
 
 	// add attributes to item meta
 	public ItemMeta addMetaAttribute(ItemMeta meta, Attribute attribute, AttributeModifier modifier) {
@@ -110,13 +100,13 @@ public class AttributeManager {
 
 		String attributeOperation = args[2];
 
-		Attribute attribute = getAttribute(attributeName);
+		Attribute attribute = AttributeUtil.getAttribute(attributeName);
 		if (attribute == null) {
 			MagicSpells.error("AttributeManager has an invalid attribute defined: " + attributeName);
 			return null;
 		}
 
-		AttributeModifier.Operation operation = getAttributeOperation(attributeOperation);
+		AttributeModifier.Operation operation = AttributeUtil.getOperation(attributeOperation);
 		if (operation == null) {
 			MagicSpells.error("AttributeManager has an invalid attribute operation defined: " + attributeOperation);
 			return null;


### PR DESCRIPTION
`MagicItemData` changes:
- The attributes contained within `MagicItemData` are now listed within an enum `MagicItemAttribute` and are stored within an `EnumMap<MagicItemData, Object>`.
- New comparison method `MagicItemData#matches(MagicItemData other)`. Checks if `MagicItemData other` contains all the attributes defined on the parent `MagicItemData` and that the values of the attributes are the same. Comparison is not symmetric as a result.
- New attribute `ignored-attributes`. During comparison using `MagicItemData#matches(MagicItemData other)`, attributes defined within the parent `MagicItemData`'s  `ignored-attributes` are not compared.
- New attribute `blacklisted-attributes`. Comparison using `MagicItemData#matches(MagicItemData other)` fails when attributes defined within the parent `MagicItemData`'s blacklisted-attributes are present on `MagicItemData other`.
- New attribute `fake-glint`. Applies a fake enchantment glint to a defined `MagicItem`.
	- A fake enchantment glint is no longer applied if an empty `enchants` list is defined.
	- Is ignored if `false` or a non-empty `enchants` section is defined.
- Renamed attribute `potion-type` to `potion-data`, as it now also includes whether the base potion data of the represented item is `extended` or `upgraded`.
- Can now be created with a `Material` for which `Material#isAir()` is true, allowing for the checking of empty held items in passive triggers such as `GiveDamageListener`.
- Attribute `skull-owner` is now the name of the owner of the skull.

Modifier changes:
- `ChestContainsCondition`, `HasItemAmountCondition`, `HasItemPreciseCondition`, `HoldingPreciseCondition`, `HoveringWithCondition` and `WearingPreciseCondition` now use `MagicItemData#matches(MagicItemData other)` for comparison.
- `HasItemAmountCondition` and `HasItemPreciseCondition` now short-circuit.

Passive trigger changes:
- `DropItemListener`, `GiveDamageListener`, `HitArrowListener` `HotbarDeselectListener`, `HotbarSelectListener`, `InventoryClickListener`, `MissArrowListener`, `PickupItemListener`, `RightClickItemListener` and `TakeDamageListener` now use `MagicItemData#matches(MagicItemData other)` for comparison.
- `HotbarDeselectListener` and `HotbarSelectListener` now take a pipe separated list of `MagicItem` as an argument, instead of only one.

Spell changes:
- `DisarmSpell` now uses `MagicItemData` to check for disarmable items, rather than `Material` type.
- `UnconjureSpell` now directly uses `MagicItemData`, rather than an `ItemStack` that is later converted back into `MagicItemData`.

Miscellaneous  changes:
- `ConjureSpell`, `OffhandCooldownSpell` and `Util` now use `ItemStack#isSimilar(ItemStack other)` for comparison when adding items to inventories.
- Comparison of `CastItem` is now properly calculated. Previously, would only check for the first unignored attribute.
- `ReagentItem` now directly uses `MagicItemData` to track `ReagentItem` costs, rather than an `ItemStack` that is later converted back into `MagicItemData`.
- Usage of `PotionData` rather than `PotionType` to represent the base potion data in `MagicItemData` and `CastItem`, as `PotionType` does not support specifying whether the potion is `extended`/`upgraded`.
- Added utility method `TxtUtil#escapeJson(String)` for escaping special characters within JSON strings.

Known issues:
- Inconsistent behavior when defining a `MagicItem` with an `attributes` section, as a result of the UUIDs of created `AttributeModifier` being random when using the `MagicItem` format. Can be avoided by using spigot serialization.