### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -428,11 +428,6 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	@Override
 	protected abstract void turnOff();
 
-	@Override
-	public boolean isBeneficialDefault() {
-		return true;
-	}
-
 	public boolean isTargeted() {
 		return targeted;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -46,6 +46,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 	private final int capPerPlayer;
 
 	private double maxDistanceSquared;
+	private final int maxDuration;
 
 	private final boolean marker;
 	private final boolean gravity;
@@ -127,6 +128,8 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
 		maxDistanceSquared = getConfigDouble("max-distance", 30);
 		maxDistanceSquared *= maxDistanceSquared;
+
+		maxDuration = getConfigInt("max-duration", 0);
 
 		marker = getConfigBoolean("marker", false);
 		gravity = getConfigBoolean("gravity", false);
@@ -247,8 +250,17 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
 	private void createTotem(LivingEntity caster, Location loc, float power) {
 		Location loc2 = loc.clone();
-		if (centerStand == true) loc2 = loc.clone().add(0.5, 0, 0.5);
-		totems.add(new Totem(caster, loc2, power));
+		if (centerStand) loc2 = loc.clone().add(0.5, 0, 0.5);
+
+		Totem totem = new Totem(caster, loc2, power);
+		totems.add(totem);
+		if (maxDuration > 0) {
+			MagicSpells.scheduleDelayedTask(() -> {
+				totem.stop();
+				totems.remove(totem);
+			}, maxDuration);
+		}
+
 		ticker.start();
 		if (caster != null) playSpellEffects(caster, loc2);
 		else playSpellEffects(EffectPosition.TARGET, loc2);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -37,28 +37,28 @@ import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
-	private Set<Totem> totems;
-	private PulserTicker ticker;
+	private final Set<Totem> totems;
+	private final PulserTicker ticker;
 
-	private int yOffset;
-	private int interval;
-	private int totalPulses;
-	private int capPerPlayer;
+	private final int yOffset;
+	private final int interval;
+	private final int totalPulses;
+	private final int capPerPlayer;
 
 	private double maxDistanceSquared;
 
-	private boolean marker;
-	private boolean gravity;
-	private boolean visibility;
-	private boolean targetable;
-	private boolean totemNameVisible;
-	private boolean onlyCountOnSuccess;
-	private boolean centerStand;
-	private boolean allowCasterTarget;
-	private boolean silenced;
+	private final boolean marker;
+	private final boolean gravity;
+	private final boolean visibility;
+	private final boolean targetable;
+	private final boolean totemNameVisible;
+	private final boolean onlyCountOnSuccess;
+	private final boolean centerStand;
+	private final boolean allowCasterTarget;
+	private final boolean silenced;
 
-	private String strAtCap;
-	private String totemName;
+	private final String strAtCap;
+	private final String totemName;
 
 	private ItemStack helmet;
 	private ItemStack chestplate;
@@ -67,10 +67,10 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 	private ItemStack mainHand;
 	private ItemStack offHand;
 
-	private List<String> spellNames;
+	private final List<String> spellNames;
 	private List<TargetedLocationSpell> spells;
 
-	private String spellNameOnBreak;
+	private final String spellNameOnBreak;
 	private TargetedLocationSpell spellOnBreak;
 
 	public TotemSpell(MagicConfig config, String spellName) {
@@ -223,7 +223,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		else if (yOffset < 0) block = block.getRelative(BlockFace.DOWN, yOffset);
 
 		if (BlockUtils.isAir(block.getType()) || block.getType() == Material.SNOW || block.getType() == Material.TALL_GRASS) {
-			if (centerStand == false) {
+			if (!centerStand) {
 				Location loc = target.clone();
 				createTotem(caster, loc, power);
 			} else createTotem(caster, block.getLocation(), power);
@@ -231,7 +231,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 		block = block.getRelative(BlockFace.UP);
 		if (BlockUtils.isAir(block.getType()) || block.getType() == Material.SNOW || block.getType() == Material.TALL_GRASS) {
-			if (centerStand == false) {
+			if (!centerStand) {
 				Location loc = target.clone();
 				createTotem(caster, loc, power);
 			} else createTotem(caster, block.getLocation(), power);
@@ -288,12 +288,11 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
 	private class Totem {
 
-		private LivingEntity caster;
-		private LivingEntity armorStand;
+		private final LivingEntity caster;
+		private final LivingEntity armorStand;
 		private Location totemLocation;
-		private EntityEquipment totemEquipment;
 
-		private float power;
+		private final float power;
 		private int pulseCount;
 
 		private Totem(LivingEntity caster, Location loc, float power) {
@@ -308,15 +307,17 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 				else armorStand.setCustomName(Util.colorize(totemName));
 				armorStand.setCustomNameVisible(totemNameVisible);
 			}
-			totemEquipment = armorStand.getEquipment();
+			EntityEquipment totemEquipment = armorStand.getEquipment();
 			armorStand.setGravity(gravity);
 			armorStand.addScoreboardTag("MS_Totem");
-			if (mainHand != null) totemEquipment.setItemInMainHand(mainHand);
-			if (offHand != null) totemEquipment.setItemInOffHand(offHand);
-			if (helmet != null) totemEquipment.setHelmet(helmet);
-			if (chestplate != null) totemEquipment.setChestplate(chestplate);
-			if (leggings != null) totemEquipment.setLeggings(leggings);
-			if (boots != null) totemEquipment.setBoots(boots);
+			if (totemEquipment != null) {
+				if (mainHand != null) totemEquipment.setItemInMainHand(mainHand);
+				if (offHand != null) totemEquipment.setItemInOffHand(offHand);
+				if (helmet != null) totemEquipment.setHelmet(helmet);
+				if (chestplate != null) totemEquipment.setChestplate(chestplate);
+				if (leggings != null) totemEquipment.setLeggings(leggings);
+				if (boots != null) totemEquipment.setBoots(boots);
+			}
 			((ArmorStand) armorStand).setVisible(visibility);
 			((ArmorStand) armorStand).setMarker(marker);
 			armorStand.setSilent(silenced);

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicEnumSetPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicEnumSetPrompt.java
@@ -1,16 +1,16 @@
 package com.nisovin.magicspells.util.prompt;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
+import com.nisovin.magicspells.MagicSpells;
+
+import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.FixedSetPrompt;
 import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.conversations.ConversationContext;
-import org.bukkit.conversations.FixedSetPrompt;
-import org.bukkit.conversations.Prompt;
-
-import com.nisovin.magicspells.MagicSpells;
 
 public class MagicEnumSetPrompt extends FixedSetPrompt {
 
@@ -68,12 +68,8 @@ public class MagicEnumSetPrompt extends FixedSetPrompt {
 		List<String> parsedValues = getEnumValues(enumClass);
 		
 		MagicEnumSetPrompt ret = new MagicEnumSetPrompt(parsedValues);
-		
 		ret.responder = new MagicPromptResponder(section);
-
-		String promptText = section.getString("prompt-text", "");
-		ret.promptText = promptText;
-
+		ret.promptText = section.getString("prompt-text", "");
 		return ret;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicFixedSetPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicFixedSetPrompt.java
@@ -1,12 +1,12 @@
 package com.nisovin.magicspells.util.prompt;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.ArrayList;
 
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.conversations.ConversationContext;
-import org.bukkit.conversations.FixedSetPrompt;
 import org.bukkit.conversations.Prompt;
+import org.bukkit.conversations.FixedSetPrompt;
+import org.bukkit.conversations.ConversationContext;
+import org.bukkit.configuration.ConfigurationSection;
 
 public class MagicFixedSetPrompt extends FixedSetPrompt {
 
@@ -36,14 +36,11 @@ public class MagicFixedSetPrompt extends FixedSetPrompt {
 	public static MagicFixedSetPrompt fromConfigSection(ConfigurationSection section) {
 		// Get the options
 		List<String> options = section.getStringList("options");
-		if (options == null || options.isEmpty()) return null;
+		if (options.isEmpty()) return null;
+
 		MagicFixedSetPrompt ret = new MagicFixedSetPrompt(options);
-		
 		ret.responder = new MagicPromptResponder(section);
-
-		String promptText = section.getString("prompt-text", "");
-		ret.promptText = promptText;
-
+		ret.promptText = section.getString("prompt-text", "");
 		return ret;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
@@ -10,20 +10,20 @@ import com.nisovin.magicspells.MagicSpells;
 
 public class MagicPromptResponder {
 
-	boolean saveToVariable;
 	String variableName;
 	
 	public MagicPromptResponder(ConfigurationSection section) {
 		variableName = section.getString("variable-name", null);
-		saveToVariable = MagicSpells.getVariableManager().getVariable(variableName) != null;
 	}
 	
 	public Prompt acceptValidatedInput(ConversationContext paramConversationContext, String paramString) {
 		String playerName = null;
 		Conversable who = ConversationContextUtil.getConversable(paramConversationContext.getAllSessionData());
 		if (who instanceof Player) playerName = ((Player)who).getName();
-		
-		if (saveToVariable) MagicSpells.getVariableManager().set(variableName, playerName, paramString);
+
+		// Try to save response to a variable.
+		MagicSpells.getVariableManager().set(variableName, playerName, paramString);
+
 		return Prompt.END_OF_CONVERSATION;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
@@ -1,10 +1,10 @@
 package com.nisovin.magicspells.util.prompt;
 
-import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.entity.Player;
+import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.Conversable;
 import org.bukkit.conversations.ConversationContext;
-import org.bukkit.conversations.Prompt;
-import org.bukkit.entity.Player;
+import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.MagicSpells;
 

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicRegexPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicRegexPrompt.java
@@ -2,10 +2,10 @@ package com.nisovin.magicspells.util.prompt;
 
 import java.util.regex.Pattern;
 
-import org.bukkit.configuration.ConfigurationSection;
-import org.bukkit.conversations.ConversationContext;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.RegexPrompt;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.conversations.ConversationContext;
 
 public class MagicRegexPrompt extends RegexPrompt {
 	
@@ -36,13 +36,10 @@ public class MagicRegexPrompt extends RegexPrompt {
 		// Handle the regex
 		String regexp = section.getString("regexp", null);
 		if (regexp == null || regexp.isEmpty()) return null;
+
 		MagicRegexPrompt ret = new MagicRegexPrompt(regexp);
-		
 		ret.responder = new MagicPromptResponder(section);
-
-		String promptText = section.getString("prompt-text", "");
-		ret.promptText = promptText;
-
+		ret.promptText = section.getString("prompt-text", "");
 		return ret;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/PromptType.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/PromptType.java
@@ -1,10 +1,10 @@
 package com.nisovin.magicspells.util.prompt;
 
-import java.util.HashMap;
 import java.util.Map;
+import java.util.HashMap;
 
-import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.conversations.Prompt;
+import org.bukkit.configuration.ConfigurationSection;
 
 public enum PromptType {
 
@@ -14,35 +14,33 @@ public enum PromptType {
 		public Prompt constructPrompt(ConfigurationSection section) {
 			return MagicRegexPrompt.fromConfigSection(section);
 		}
-		
+
 	},
-	
-	FIXED_SET_PROMOT("fixed-set") {
+	FIXED_SET_PROMPT("fixed-set") {
 
 		@Override
 		public Prompt constructPrompt(ConfigurationSection section) {
 			return MagicFixedSetPrompt.fromConfigSection(section);
 		}
-		
+
 	},
-	
 	ENUM_SET_PROMPT("enum") {
 
 		@Override
 		public Prompt constructPrompt(ConfigurationSection section) {
 			return MagicEnumSetPrompt.fromConfigSection(section);
 		}
-		
+
 		@Override
 		public void unload() {
 			MagicEnumSetPrompt.unload();
 		}
-		
+
 	}
-	
+
 	;
 	
-	private String[] labels;
+	private final String[] labels;
 	
 	private static boolean initialized = false;
 	private static Map<String, PromptType> nameMap = null;


### PR DESCRIPTION
## Short description:
- Added `max-duration` to Totem spell.
- Fixed ConversationSpell variable saving.
- Fixed targeting with Buff spell.

---
## Long description:
Commit [d9acfb0](https://github.com/TheComputerGeek2/MagicSpells/commit/d9acfb00cfc2db26eb901d5b06ff7a1c85b3e081) removes boolean check which checks if the variable exists because the call to `MagicSpells#getVariableManager` produces a NullPointerException during constructor call. Instead of being moved to the local method, the check was also removed because it is redundant - the later call to `VariableManager#set` checks the same.

Commit [44b7e71](https://github.com/TheComputerGeek2/MagicSpells/commit/44b7e716ba0052ba50d019998321efd2a1fcffec) potentially fixes a bug instead of reverting a feature. This type of override isn't being used in Targeted spells for their targeting. Moreover, this bug, introduced during ["Nisovin era"](https://github.com/TheComputerGeek2/MagicSpells/commit/dd11a6311a9986e2a4ad1b98bd06d45be2f6aac9#diff-7c5956e56f03bbe595681789d5f010d55e1876a82f3302e2fc39b4cce2f42a22R242), was never encountered until [this commit](https://github.com/TheComputerGeek2/MagicSpells/commit/fc5a0728184231e44ca282bf73f9634eb21ea168#diff-8276d13db1c3bd9b5ce899dcd242769e771bb67f8af6f01b3c732a2f7d9c6425R1380), which fixes targeting with scoreboard teams, causing the targeting to fail on [this line](https://github.com/TheComputerGeek2/MagicSpells/commit/fc5a0728184231e44ca282bf73f9634eb21ea168#diff-8276d13db1c3bd9b5ce899dcd242769e771bb67f8af6f01b3c732a2f7d9c6425R1387). It seems like there's simply no reason to have Buff spells override the default beneficial value.