### PR TITLE
Bugfixes and Additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -168,7 +168,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	protected ModifierSet targetModifiers;
 	protected ModifierSet locationModifiers;
 
-	protected Spell spellOnInterrupt;
+	protected Subspell spellOnInterrupt;
 
 	protected SpellReagents reagents;
 
@@ -662,7 +662,8 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		registerEvents();
 
 		// Other processing
-		if (spellNameOnInterrupt != null && !spellNameOnInterrupt.isEmpty()) spellOnInterrupt = MagicSpells.getSpellByInternalName(spellNameOnInterrupt);
+		if (spellNameOnInterrupt != null && !spellNameOnInterrupt.isEmpty())
+			spellOnInterrupt = initSubspell(spellNameOnInterrupt, "Spell '" + internalName + "' has an invalid spell-on-interrupt defined!");
 	}
 
 	protected boolean configKeyExists(String key) {
@@ -2086,7 +2087,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			unregisterEvents(this);
 
 			sendMessage(strInterrupted, caster, null);
-			if (spellOnInterrupt != null) spellOnInterrupt.castSpell(caster, SpellCastState.NORMAL, spellCast.getPower(), null);
+			if (spellOnInterrupt != null) {
+				if (spellOnInterrupt.isTargetedLocationSpell()) spellOnInterrupt.castAtLocation(caster, caster.getLocation(), spellCast.getPower());
+				else spellOnInterrupt.cast(caster, spellCast.getPower());
+			}
 		}
 
 	}
@@ -2177,7 +2181,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		private void interrupt() {
 			sendMessage(strInterrupted, caster, null);
 			end();
-			if (spellOnInterrupt != null) spellOnInterrupt.castSpell(caster, SpellCastState.NORMAL, spellCast.getPower(), null);
+			if (spellOnInterrupt != null) {
+				if (spellOnInterrupt.isTargetedLocationSpell()) spellOnInterrupt.castAtLocation(caster, caster.getLocation(), spellCast.getPower());
+				else spellOnInterrupt.cast(caster, spellCast.getPower());
+			}
 		}
 
 		private void end() {

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -517,7 +517,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			variableModsCast = LinkedListMultimap.create();
 			for (String s : varModsCast) {
 				try {
-					String[] data = s.split(" ");
+					String[] data = s.split(" ", 2);
 					String var = data[0];
 					VariableMod varMod = new VariableMod(data[1]);
 					variableModsCast.put(var, varMod);
@@ -530,7 +530,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			variableModsCasted = LinkedListMultimap.create();
 			for (String s : varModsCasted) {
 				try {
-					String[] data = s.split(" ");
+					String[] data = s.split(" ", 2);
 					String var = data[0];
 					VariableMod varMod = new VariableMod(data[1]);
 					variableModsCasted.put(var, varMod);
@@ -543,7 +543,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			variableModsTarget = LinkedListMultimap.create();
 			for (String s : varModsTarget) {
 				try {
-					String[] data = s.split(" ");
+					String[] data = s.split(" ", 2);
 					String var = data[0];
 					VariableMod varMod = new VariableMod(data[1]);
 					variableModsTarget.put(var, varMod);
@@ -888,9 +888,8 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 				if (action.sendMessages()) sendMessages(livingEntity, spellCast.getSpellArgs());
 				if (experience > 0 && livingEntity instanceof Player) ((Player) livingEntity).giveExp(experience);
 			} else if (state == SpellCastState.ON_COOLDOWN) {
-				String message = formatMessage(strOnCooldown, "%c", Math.round(getCooldown(livingEntity)) + "");
-				message = formatMessage(message, "%s", spellCast.getSpell().getName());
-				MagicSpells.sendMessage(message, livingEntity, spellCast.getSpellArgs());
+				MagicSpells.sendMessageAndFormat(strOnCooldown, livingEntity, spellCast.getSpellArgs(),
+					"%c", Math.round(getCooldown(livingEntity)) + "", "%s", spellCast.getSpell().getName());
 				playSpellEffects(EffectPosition.COOLDOWN, livingEntity);
 				if (soundOnCooldown != null && livingEntity instanceof Player) ((Player) livingEntity).playSound(livingEntity.getLocation(), soundOnCooldown, 1F, 1F);
 			} else if (state == SpellCastState.MISSING_REAGENTS) {
@@ -912,7 +911,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	// TODO can this safely be made varargs?
 	public void sendMessages(LivingEntity livingEntity, String[] args) {
-		sendMessage(formatMessage(strCastSelf, "%a", livingEntity.getName()), livingEntity, args);
+		sendMessage(strCastSelf, livingEntity, args, "%a", livingEntity.getName());
 		sendMessageNear(livingEntity, formatMessage(strCastOthers, "%a", livingEntity.getName()));
 	}
 
@@ -1748,7 +1747,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 * @param replacements the replacements to be made, in pairs
 	 */
 	protected void sendMessage(LivingEntity livingEntity, String message, String... replacements) {
-		sendMessage(formatMessage(message, replacements), livingEntity, null);
+		sendMessage(message, livingEntity, null, replacements);
 	}
 
 	protected void sendMessage(LivingEntity livingEntity, String message) {
@@ -1762,6 +1761,17 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 */
 	protected void sendMessage(String message, LivingEntity livingEntity, String[] args) {
 		MagicSpells.sendMessage(message, livingEntity, args);
+	}
+
+	/**
+	 * Sends a message to a player, first making the specified replacements.This method also does color replacement and has multi-line functionality.
+	 * @param message the message to send
+	 * @param livingEntity the player to send the message to
+	 * @param args the arguments of associated spell cast
+	 * @param replacements the replacements to be made, in pairs
+	 */
+	protected void sendMessage(String message, LivingEntity livingEntity, String[] args, String... replacements) {
+		MagicSpells.sendMessageAndFormat(message, livingEntity, args, replacements);
 	}
 
 	/**

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -3,11 +3,11 @@ package com.nisovin.magicspells;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
-import com.nisovin.magicspells.spells.TargetedSpell;
 import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.Spell.SpellCastState;
 import com.nisovin.magicspells.Spell.PostCastAction;
 import com.nisovin.magicspells.Spell.SpellCastResult;

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
+import com.nisovin.magicspells.spells.TargetedSpell;
 import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 
@@ -168,7 +169,12 @@ public class Subspell {
 				if (!spellTarget.isCancelled())
 					success = ((TargetedEntitySpell) spell).castAtEntity(livingEntity, target, spellCast.getPower());
 
-				if (!success) action = PostCastAction.ALREADY_HANDLED;
+				if (success) {
+					if (spell instanceof TargetedSpell) {
+						action = PostCastAction.NO_MESSAGES;
+						((TargetedSpell) spell).sendMessages(livingEntity, target, null);
+					}
+				} else action = PostCastAction.ALREADY_HANDLED;
 			}
 
 			spell.postCast(spellCast, action);
@@ -280,7 +286,12 @@ public class Subspell {
 				if (!spellLocation.isCancelled() && !spellTarget.isCancelled())
 					success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(livingEntity, from, target, spellCast.getPower());
 
-				if (!success) action = PostCastAction.ALREADY_HANDLED;
+				if (success) {
+					if (spell instanceof TargetedSpell) {
+						action = PostCastAction.NO_MESSAGES;
+						((TargetedSpell) spell).sendMessages(livingEntity, target, null);
+					}
+				} else action = PostCastAction.ALREADY_HANDLED;
 			}
 
 			spell.postCast(spellCast, action);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AbsorptionCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AbsorptionCondition.java
@@ -11,11 +11,7 @@ public class AbsorptionCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			health = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AliveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AliveCondition.java
@@ -14,11 +14,7 @@ public class AliveCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			time = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AngleCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AngleCondition.java
@@ -15,9 +15,7 @@ public class AngleCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) return false;
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			angle = Double.parseDouble(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DistanceCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DistanceCondition.java
@@ -12,11 +12,7 @@ public class DistanceCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			distanceSq = Double.parseDouble(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ElevationCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ElevationCondition.java
@@ -12,11 +12,7 @@ public class ElevationCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			y = Double.parseDouble(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/FoodCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/FoodCondition.java
@@ -13,11 +13,7 @@ public class FoodCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			food = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemAmountCondition.java
@@ -25,7 +25,7 @@ public class HasItemAmountCondition extends OperatorCondition {
 		String[] args = var.split(";");
 		if (args.length < 2) return false;
 
-		super.initialize(var);
+		if (!super.initialize(var)) return false;
 
 		try {
 			amount = Integer.parseInt(args[0].substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HealthCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HealthCondition.java
@@ -14,11 +14,7 @@ public class HealthCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		String number = var.substring(1);
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LastLifeCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LastLifeCondition.java
@@ -14,11 +14,7 @@ public class LastLifeCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			time = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevelCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevelCondition.java
@@ -13,11 +13,7 @@ public class LevelCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			level = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LightLevelCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LightLevelCondition.java
@@ -12,11 +12,7 @@ public class LightLevelCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			level = Byte.parseByte(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ManaCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ManaCondition.java
@@ -18,11 +18,7 @@ public class ManaCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		String number = var.substring(1);
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MaxManaCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MaxManaCondition.java
@@ -17,11 +17,7 @@ public class MaxManaCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		mana = MagicSpells.getManaHandler();
 		if (mana == null) return false;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MoneyCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MoneyCondition.java
@@ -13,11 +13,7 @@ public class MoneyCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			money = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OpenSlotsCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OpenSlotsCondition.java
@@ -15,11 +15,7 @@ public class OpenSlotsCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			slots = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OxygenCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OxygenCondition.java
@@ -12,11 +12,7 @@ public class OxygenCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			oxygen = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PitchCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PitchCondition.java
@@ -12,11 +12,7 @@ public class PitchCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			pitch = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PlayerCountCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PlayerCountCondition.java
@@ -12,11 +12,7 @@ public class PlayerCountCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			count = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PowerCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PowerCondition.java
@@ -17,11 +17,7 @@ public class PowerCondition extends OperatorCondition implements IModifier {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			power = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ReceivingRedstoneCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/ReceivingRedstoneCondition.java
@@ -11,11 +11,7 @@ public class ReceivingRedstoneCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			level = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/RotationCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/RotationCondition.java
@@ -12,11 +12,7 @@ public class RotationCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			rotation = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SaturationCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SaturationCondition.java
@@ -12,11 +12,7 @@ public class SaturationCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			saturation = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SlotSelectedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SlotSelectedCondition.java
@@ -12,8 +12,7 @@ public class SlotSelectedCondition extends OperatorCondition {
 
 	@Override
 	public boolean initialize(String var) {
-		if (var == null || var.length() < 2) return false;
-		if (!super.initialize(var)) return false;
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			slot = Integer.parseInt(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TargetMaxHealthCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TargetMaxHealthCondition.java
@@ -12,11 +12,7 @@ public class TargetMaxHealthCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			health = Double.parseDouble(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VariableCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VariableCondition.java
@@ -28,7 +28,7 @@ public class VariableCondition extends OperatorCondition {
 		else return false;
 
 		String number = var.substring(variableName.length());
-		super.initialize(number);
+		if (!super.initialize(number)) return false;
 
 		variable = variableName;
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/YawCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/YawCondition.java
@@ -11,11 +11,7 @@ public class YawCondition extends OperatorCondition {
 	
 	@Override
 	public boolean initialize(String var) {
-		if (var.length() < 2) {
-			return false;
-		}
-
-		super.initialize(var);
+		if (var.length() < 2 || !super.initialize(var)) return false;
 
 		try {
 			yaw = Float.parseFloat(var.substring(1));

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -33,8 +33,6 @@ import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
-import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
-import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 
 @CommandAlias("ms|magicspells")
 public class MagicCommand extends BaseCommand {
@@ -484,15 +482,9 @@ public class MagicCommand extends BaseCommand {
 			}
 			String playerName = player == null ? "-" : player.getName();
 
-			VariableMod variableMod = new VariableMod(args[2]);
-			VariableMod.Operation op = variableMod.getOperation();
+			VariableMod variableMod = new VariableMod(String.join(" ", Arrays.copyOfRange(args, 2, args.length)));
 			String oldValue = MagicSpells.getVariableManager().getStringValue(variableName, playerName);
-			if (op.equals(VariableMod.Operation.SET) && (variable instanceof PlayerStringVariable || variable instanceof GlobalStringVariable)) {
-				MagicSpells.getVariableManager().set(variableName, playerName, variableMod.getValue());
-			} else {
-				double value = variableMod.getValue(player, null);
-				MagicSpells.getVariableManager().set(variableName, playerName, op.applyTo(variable.getValue(playerName), value));
-			}
+			MagicSpells.getVariableManager().processVariableMods(variableName, variableMod, player, player, null);
 
 			String message = player == null ? "Value" : TxtUtil.getPossessiveName(playerName) + " value";
 			issuer.sendMessage(MagicSpells.getTextColor() + message + " of '" + variableName + "' was modified: '" + oldValue + "' to '" + MagicSpells.getVariableManager().getStringValue(variableName, playerName) + "'.");

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -125,7 +125,7 @@ public class BowSpell extends Spell {
 	public void onArrowLaunch(EntityShootBowEvent event) {
 		if (event.getEntity().getType() != EntityType.PLAYER) return;
 		Player shooter = (Player) event.getEntity();
-		ItemStack inHand = shooter.getEquipment().getItemInMainHand();
+		ItemStack inHand = event.getBow();
 		if (inHand == null || inHand.getType() != Material.BOW) return;
 
 		String name = inHand.getItemMeta().getDisplayName();
@@ -202,7 +202,8 @@ public class BowSpell extends Spell {
 					return;
 				}
 
-				data.groundSpell.castAtLocation(shooter, arrow.getLocation(), data.power);
+				if (data.groundSpell.isTargetedLocationSpell()) data.groundSpell.castAtLocation(shooter, arrow.getLocation(), data.power);
+				else data.groundSpell.cast(shooter, data.power);
 
 				data.casted = true;
 				arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
@@ -237,6 +238,7 @@ public class BowSpell extends Spell {
 			if (data.entitySpell.isTargetedEntityFromLocationSpell()) data.entitySpell.castAtEntityFromLocation(shooter, target.getLocation(), target, targetEvent.getPower());
 			else if (data.entitySpell.isTargetedLocationSpell()) data.entitySpell.castAtLocation(shooter, target.getLocation(), targetEvent.getPower());
 			else if (data.entitySpell.isTargetedEntitySpell()) data.entitySpell.castAtEntity(shooter, target, targetEvent.getPower());
+			else data.entitySpell.cast(shooter, targetEvent.getPower());
 
 			data.casted = true;
 			break;

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -50,6 +50,7 @@ public class BowSpell extends Spell {
 
 	private boolean cancelShot;
 	private boolean useBowForce;
+	private boolean removeArrow;
 	private boolean cancelShotOnFail;
 
 	private float minimumForce;
@@ -76,6 +77,7 @@ public class BowSpell extends Spell {
 
 		cancelShot = getConfigBoolean("cancel-shot", true);
 		useBowForce = getConfigBoolean("use-bow-force", true);
+		removeArrow = getConfigBoolean("remove-arrow", false);
 		cancelShotOnFail = getConfigBoolean("cancel-shot-on-fail", true);
 
 		minimumForce = getConfigFloat("minimum-force", 0F);
@@ -210,7 +212,7 @@ public class BowSpell extends Spell {
 			}, 0);
 			break;
 		}
-		arrow.remove();
+		if (removeArrow) arrow.remove();
 	}
 
 	@EventHandler(ignoreCancelled=true)
@@ -244,7 +246,7 @@ public class BowSpell extends Spell {
 			break;
 		}
 		arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
-		arrow.remove();
+		if (removeArrow) arrow.remove();
 	}
 
 	private static class ArrowData {

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -142,19 +142,19 @@ public class BowSpell extends Spell {
 		if (!spellbook.canCast(this)) return;
 
 		if (onCooldown(shooter)) {
-			MagicSpells.sendMessage(formatMessage(strOnCooldown, "%c", Math.round(getCooldown(shooter)) + ""), shooter, null);
+			sendMessage(strOnCooldown, shooter, null, "%c", Math.round(getCooldown(shooter)) + "");
 			event.setCancelled(cancelShotOnFail);
 			return;
 		}
 
 		if (!hasReagents(shooter)) {
-			MagicSpells.sendMessage(strMissingReagents, shooter, null);
+			sendMessage(strMissingReagents, shooter, null);
 			event.setCancelled(cancelShotOnFail);
 			return;
 		}
 
 		if (modifiers != null && !modifiers.check(shooter)) {
-			MagicSpells.sendMessage(strModifierFailed, shooter, null);
+			sendMessage(strModifierFailed, shooter, null);
 			event.setCancelled(cancelShotOnFail);
 			return;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -3,17 +3,20 @@ package com.nisovin.magicspells.spells;
 import java.util.List;
 import java.util.ArrayList;
 
+import org.apache.commons.math3.util.FastMath;
+
 import org.bukkit.Material;
-import org.bukkit.block.Block;
+import org.bukkit.entity.Arrow;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Projectile;
-import org.bukkit.entity.EntityType;
 import org.bukkit.event.EventHandler;
-import org.bukkit.inventory.ItemStack;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.EventPriority;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
@@ -24,13 +27,12 @@ import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.ValidTargetList;
 import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellCastEvent;
-import com.nisovin.magicspells.events.SpellCastedEvent;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
-
-import org.apache.commons.math3.util.FastMath;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class BowSpell extends Spell {
 
@@ -38,6 +40,8 @@ public class BowSpell extends Spell {
 
 	private List<String> bowNames;
 	private List<String> disallowedBowNames;
+
+	private ValidTargetList triggerList;
 
 	private String bowName;
 	private String spellOnShootName;
@@ -55,7 +59,7 @@ public class BowSpell extends Spell {
 
 	private float minimumForce;
 	private float maximumForce;
-	
+
 	public BowSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
@@ -70,6 +74,12 @@ public class BowSpell extends Spell {
 			disallowedBowNames = new ArrayList<>();
 			disallowedNames.forEach(str -> disallowedBowNames.add(Util.colorize(str)));
 		}
+
+		if (config.isList("spells." + internalName + ".can-trigger")) {
+			List<String> targets = getConfigStringList("can-trigger", new ArrayList<>());
+			if (targets.isEmpty()) targets.add("players");
+			triggerList = new ValidTargetList(this, targets);
+		} else triggerList = new ValidTargetList(this, getConfigString("can-trigger", "players"));
 
 		spellOnShootName = getConfigString("spell", "");
 		spellOnHitEntityName = getConfigString("spell-on-hit-entity", "");
@@ -88,7 +98,7 @@ public class BowSpell extends Spell {
 		if (maximumForce < 0F) maximumForce = 0F;
 		else if (maximumForce > 1F) maximumForce = 1F;
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -96,13 +106,8 @@ public class BowSpell extends Spell {
 		spellOnShoot = initSubspell(spellOnShootName, "BowSpell '" + internalName + "' has an invalid spell defined!");
 		spellOnHitEntity = initSubspell(spellOnHitEntityName, "BowSpell '" + internalName + "' has an invalid spell-on-hit-entity defined!");
 		spellOnHitGround = initSubspell(spellOnHitGroundName, "BowSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
-
-		if (spellOnHitGround != null && !spellOnHitGround.isTargetedLocationSpell()) {
-			MagicSpells.error("BowSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
-			spellOnHitGround = null;
-		}
 	}
-	
+
 	@Override
 	public void turnOff() {
 		super.turnOff();
@@ -125,8 +130,18 @@ public class BowSpell extends Spell {
 
 	@EventHandler
 	public void onArrowLaunch(EntityShootBowEvent event) {
-		if (event.getEntity().getType() != EntityType.PLAYER) return;
-		Player shooter = (Player) event.getEntity();
+		if (!cancelShot && event.isCancelled()) return;
+		if (!(event.getProjectile() instanceof Arrow)) return;
+
+		LivingEntity caster = event.getEntity();
+		if (!triggerList.canTarget(caster, true)) return;
+
+		if (caster instanceof Player) {
+			Spellbook spellbook = MagicSpells.getSpellbook((Player) caster);
+			if (!spellbook.hasSpell(this)) return;
+			if (!spellbook.canCast(this)) return;
+		}
+
 		ItemStack inHand = event.getBow();
 		if (inHand == null || inHand.getType() != Material.BOW) return;
 
@@ -139,125 +154,139 @@ public class BowSpell extends Spell {
 		if (minimumForce != 0 && force < minimumForce) return;
 		if (maximumForce != 0 && force > maximumForce) return;
 
-		Spellbook spellbook = MagicSpells.getSpellbook(shooter);
-		if (!spellbook.hasSpell(this)) return;
-		if (!spellbook.canCast(this)) return;
-
-		if (onCooldown(shooter)) {
-			sendMessage(strOnCooldown, shooter, null, "%c", Math.round(getCooldown(shooter)) + "");
-			event.setCancelled(cancelShotOnFail);
+		SpellCastEvent castEvent = preCast(caster, 1f, null);
+		if (castEvent == null) {
+			if (cancelShotOnFail) event.setCancelled(true);
 			return;
 		}
 
-		if (!hasReagents(shooter)) {
-			sendMessage(strMissingReagents, shooter, null);
-			event.setCancelled(cancelShotOnFail);
-			return;
-		}
+		if (castEvent.getSpellCastState() == SpellCastState.NORMAL) {
+			if (cancelShot) event.setCancelled(true);
+			if (!event.isCancelled()) {
+				Entity projectile = event.getProjectile();
 
-		if (modifiers != null && !modifiers.check(shooter)) {
-			sendMessage(strModifierFailed, shooter, null);
-			event.setCancelled(cancelShotOnFail);
-			return;
-		}
+				ArrowData arrowData = new ArrowData(castEvent.getPower(), spellOnHitEntity, spellOnHitGround, this);
+				List<ArrowData> arrowDataList = null;
+				if (projectile.hasMetadata(METADATA_KEY)) {
+					List<MetadataValue> metas = projectile.getMetadata(METADATA_KEY);
+					for (MetadataValue meta : metas) {
+						if (!MagicSpells.plugin.equals(meta.getOwningPlugin())) continue;
 
-		SpellCastEvent castEvent = new SpellCastEvent(this, shooter, SpellCastState.NORMAL, useBowForce ? event.getForce() : 1.0F, null, cooldown, reagents, 0);
-		EventUtil.call(castEvent);
-		if (castEvent.isCancelled()) return;
-
-		event.setCancelled(cancelShot);
-
-		if (!cancelShot) {
-			Entity projectile = event.getProjectile();
-			projectile.setMetadata(METADATA_KEY, new FixedMetadataValue(MagicSpells.plugin, new ArrowData(castEvent.getPower(), spellOnHitEntity, spellOnHitGround, this)));
-			playSpellEffects(EffectPosition.PROJECTILE, event.getProjectile());
-			playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, shooter.getLocation(), projectile.getLocation(), shooter, projectile);
-		}
-
-		setCooldown(shooter, cooldown);
-		removeReagents(shooter);
-		if (spellOnShoot != null) spellOnShoot.cast(shooter, castEvent.getPower());
-
-		SpellCastedEvent castedEvent = new SpellCastedEvent(this, shooter, SpellCastState.NORMAL, castEvent.getPower(), null, cooldown, reagents, PostCastAction.HANDLE_NORMALLY);
-		EventUtil.call(castedEvent);
-	}
-
-	@EventHandler
-	public void onArrowHitGround(ProjectileHitEvent event) {
-		Projectile arrow = event.getEntity();
-		if (arrow.getType() != EntityType.ARROW) return;
-		List<MetadataValue> metas = arrow.getMetadata(METADATA_KEY);
-		if (metas == null || metas.isEmpty()) return;
-		Block block = event.getHitBlock();
-		if (block == null) return;
-		for (MetadataValue meta : metas) {
-			ArrowData data = (ArrowData) meta.value();
-			if (data == null) continue;
-			if (data.groundSpell == null) continue;
-
-			MagicSpells.scheduleDelayedTask(() -> {
-				Player shooter = (Player) arrow.getShooter();
-				if (data.casted) return;
-
-				if (data.spell.getLocationModifiers() != null && !data.spell.getLocationModifiers().check(shooter, block.getLocation())) {
-					MagicSpells.sendMessage(data.spell.getStrModifierFailed(), shooter, null);
-					return;
+						arrowDataList = (List<ArrowData>) meta.value();
+						if (arrowDataList != null) arrowDataList.add(arrowData);
+						break;
+					}
 				}
 
-				if (data.groundSpell.isTargetedLocationSpell()) data.groundSpell.castAtLocation(shooter, arrow.getLocation(), data.power);
-				else data.groundSpell.cast(shooter, data.power);
+				if (arrowDataList == null) {
+					arrowDataList = new ArrayList<>();
+					arrowDataList.add(arrowData);
 
-				data.casted = true;
-				arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
-			}, 0);
-			break;
-		}
-		if (removeArrow) arrow.remove();
-	}
+					projectile.setMetadata(METADATA_KEY, new FixedMetadataValue(MagicSpells.plugin, arrowDataList));
+				}
 
-	@EventHandler(ignoreCancelled=true)
-	public void onArrowHitEntity(EntityDamageByEntityEvent event) {
-		if (event.getDamager().getType() != EntityType.ARROW) return;
-		if (!(event.getEntity() instanceof LivingEntity)) return;
-		Projectile arrow = (Projectile) event.getDamager();
-		List<MetadataValue> metas = arrow.getMetadata(METADATA_KEY);
-		if (metas == null || metas.isEmpty()) return;
-		Player shooter = (Player) arrow.getShooter();
-		LivingEntity target = (LivingEntity) event.getEntity();
-		for (MetadataValue meta : metas) {
-			ArrowData data = (ArrowData) meta.value();
-			if (data == null) continue;
-			if (data.casted) continue;
-			if (data.entitySpell == null) continue;
-
-			SpellTargetEvent targetEvent = new SpellTargetEvent(this, shooter, target, data.power);
-			EventUtil.call(targetEvent);
-			if (targetEvent.isCancelled()) {
-				event.setCancelled(true);
-				continue;
+				playSpellEffects(EffectPosition.PROJECTILE, projectile);
+				playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, caster.getLocation(), projectile.getLocation(), caster, projectile);
 			}
 
-			if (data.entitySpell.isTargetedEntityFromLocationSpell()) data.entitySpell.castAtEntityFromLocation(shooter, target.getLocation(), target, targetEvent.getPower());
-			else if (data.entitySpell.isTargetedLocationSpell()) data.entitySpell.castAtLocation(shooter, target.getLocation(), targetEvent.getPower());
-			else if (data.entitySpell.isTargetedEntitySpell()) data.entitySpell.castAtEntity(shooter, target, targetEvent.getPower());
-			else data.entitySpell.cast(shooter, targetEvent.getPower());
+			if (spellOnShoot != null) spellOnShoot.cast(caster, castEvent.getPower());
+		} else if (cancelShotOnFail) event.setCancelled(true);
 
-			data.casted = true;
+		postCast(castEvent, PostCastAction.HANDLE_NORMALLY);
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR)
+	public void onArrowHitGround(ProjectileHitEvent event) {
+		if (event.getHitBlock() == null) return;
+
+		Projectile proj = event.getEntity();
+		if (!proj.hasMetadata(METADATA_KEY)) return;
+
+		List<MetadataValue> metas = proj.getMetadata(METADATA_KEY);
+		for (MetadataValue meta : metas) {
+			if (!MagicSpells.plugin.equals(meta.getOwningPlugin())) continue;
+
+			ProjectileSource shooter = proj.getShooter();
+			if (!(shooter instanceof LivingEntity)) break;
+			LivingEntity caster = (LivingEntity) shooter;
+
+			List<ArrowData> arrowDataList = (List<ArrowData>) meta.value();
+			if (arrowDataList == null || arrowDataList.isEmpty()) break;
+
+			for (ArrowData data : arrowDataList) {
+				if (data.groundSpell == null) continue;
+
+				SpellTargetLocationEvent targetLocationEvent = new SpellTargetLocationEvent(data.spell, caster, proj.getLocation(), data.power);
+				EventUtil.call(targetLocationEvent);
+				if (targetLocationEvent.isCancelled()) {
+					break;
+				}
+
+				if (data.groundSpell.isTargetedLocationSpell())
+					data.groundSpell.castAtLocation(caster, targetLocationEvent.getTargetLocation(), targetLocationEvent.getPower());
+				else data.groundSpell.cast(caster, targetLocationEvent.getPower());
+			}
+
 			break;
 		}
-		arrow.removeMetadata(METADATA_KEY, MagicSpells.plugin);
-		if (removeArrow) arrow.remove();
+
+		proj.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+		if (removeArrow) proj.remove();
+	}
+
+	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	public void onArrowHitEntity(EntityDamageByEntityEvent event) {
+		Entity damager = event.getDamager();
+		if (!(damager instanceof Arrow)) return;
+		if (!damager.hasMetadata(METADATA_KEY)) return;
+
+		List<MetadataValue> metas = damager.getMetadata(METADATA_KEY);
+		for (MetadataValue meta : metas) {
+			if (!MagicSpells.plugin.equals(meta.getOwningPlugin())) continue;
+
+			Entity damaged = event.getEntity();
+			if (!(damaged instanceof LivingEntity)) break;
+			LivingEntity target = (LivingEntity) damaged;
+
+			ProjectileSource shooter = ((Arrow) damager).getShooter();
+			if (!(shooter instanceof LivingEntity)) break;
+			LivingEntity caster = (LivingEntity) shooter;
+
+			List<ArrowData> arrowDataList = (List<ArrowData>) meta.value();
+			if (arrowDataList == null || arrowDataList.isEmpty()) break;
+
+			for (ArrowData data : arrowDataList) {
+				if (data.entitySpell == null) continue;
+
+				SpellTargetEvent targetEvent = new SpellTargetEvent(this, caster, target, data.power);
+				EventUtil.call(targetEvent);
+				if (targetEvent.isCancelled()) {
+					continue;
+				}
+				target = targetEvent.getTarget();
+
+				if (data.entitySpell.isTargetedEntityFromLocationSpell())
+					data.entitySpell.castAtEntityFromLocation(caster, caster.getLocation(), target, targetEvent.getPower());
+				else if (data.entitySpell.isTargetedLocationSpell())
+					data.entitySpell.castAtLocation(caster, target.getLocation(), targetEvent.getPower());
+				else if (data.entitySpell.isTargetedEntitySpell())
+					data.entitySpell.castAtEntity(caster, target, targetEvent.getPower());
+				else data.entitySpell.cast(caster, targetEvent.getPower());
+			}
+
+			break;
+		}
+
+		damager.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+		if (removeArrow) damager.remove();
 	}
 
 	private static class ArrowData {
 
-		private float power;
-		private boolean casted = false;
-
-		private Spell spell;
-
-		private Subspell entitySpell;
-		private Subspell groundSpell;
+		private final Subspell entitySpell;
+		private final Subspell groundSpell;
+		private final Spell spell;
+		private final float power;
 
 		ArrowData(float power, Subspell entitySpell, Subspell groundSpell, Spell spell) {
 			this.power = power;
@@ -265,7 +294,7 @@ public class BowSpell extends Spell {
 			this.groundSpell = groundSpell;
 			this.spell = spell;
 		}
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -198,7 +198,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 		PostCastAction action = activate(livingEntity, target, power, args, state == SpellCastState.NORMAL);
 		if (targeted && action == PostCastAction.HANDLE_NORMALLY) {
-			sendMessages(livingEntity, target);
+			sendMessages(livingEntity, target, args);
 			return PostCastAction.NO_MESSAGES;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -16,12 +16,13 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
-import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.entity.EntityTeleportEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
 import org.bukkit.event.player.PlayerChangedWorldEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
@@ -62,6 +63,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	protected boolean castWithItem;
 	protected boolean castByCommand;
 	protected boolean cancelOnJoin;
+	protected boolean cancelOnMove;
 	protected boolean cancelOnDeath;
 	protected boolean cancelOnLogout;
 	protected boolean cancelOnTeleport;
@@ -108,6 +110,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		castWithItem = getConfigBoolean("can-cast-with-item", true);
 		castByCommand = getConfigBoolean("can-cast-by-command", true);
 		cancelOnJoin = getConfigBoolean("cancel-on-join", false);
+		cancelOnMove = getConfigBoolean("cancel-on-move", false);
 		cancelOnDeath = getConfigBoolean("cancel-on-death", false);
 		cancelOnLogout = getConfigBoolean("cancel-on-logout", false);
 		cancelOnTeleport = getConfigBoolean("cancel-on-teleport", false);
@@ -138,6 +141,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		if (cancelOnSpellCast) registerEvents(new SpellCastListener());
 		if (cancelOnLogout) registerEvents(new PlayerQuitListener());
 		if (cancelOnJoin) registerEvents(new PlayerJoinListener());
+		if (cancelOnMove) registerEvents(new PlayerMoveListener());
 		registerEvents(new EntityDeathListener());
 
 		if (numUses > 0 || (reagents != null && useCostInterval > 0)) useCounter = new HashMap<>();
@@ -614,6 +618,22 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		public void onJoin(PlayerJoinEvent event) {
 			LivingEntity player = getWhoToCancel(event.getPlayer());
 			if (player == null) return;
+			turnOff(player);
+		}
+
+	}
+
+	public class PlayerMoveListener implements Listener {
+
+		private static final double MOTION_TOLERANCE = 0.1;
+
+		@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+		public void onMove(PlayerMoveEvent event) {
+			LivingEntity player = getWhoToCancel(event.getPlayer());
+			if (player == null) return;
+
+			if (LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), MOTION_TOLERANCE)) return;
+
 			turnOff(player);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -249,7 +249,7 @@ public class PassiveSpell extends Spell {
 
 		if (state != SpellCastState.NORMAL && sendFailureMessages) {
 			if (state == SpellCastState.ON_COOLDOWN) {
-				MagicSpells.sendMessage(formatMessage(strOnCooldown, "%c", Math.round(getCooldown(caster)) + ""), caster, null);
+				sendMessage(strOnCooldown, caster, null, "%c", Math.round(getCooldown(caster)) + "");
 				return false;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -107,7 +107,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			if (!somethingWasDone) return noTarget(livingEntity);
 			
 			if (entTarget != null) {
-				sendMessages(livingEntity, entTarget);
+				sendMessages(livingEntity, entTarget, args);
 				return PostCastAction.NO_MESSAGES;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -1,6 +1,5 @@
 package com.nisovin.magicspells.spells;
 
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.bukkit.Effect;
@@ -10,7 +9,6 @@ import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.TxtUtil;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.ValidTargetChecker;
@@ -57,20 +55,24 @@ public abstract class TargetedSpell extends InstantSpell {
 		}
 	}
 	
-	protected void sendMessages(LivingEntity caster, LivingEntity target, String[] args) {
-		if (!(caster instanceof Player)) return;
+	public void sendMessages(LivingEntity caster, LivingEntity target, String[] args) {
+		String casterName = getTargetName(caster);
+		Player playerCaster = null;
+		if (caster instanceof Player) playerCaster = (Player) caster;
+
 		String targetName = getTargetName(target);
 		Player playerTarget = null;
 		if (target instanceof Player) playerTarget = (Player) target;
 
-		sendMessage(prepareMessage(strCastSelf, (Player) caster, playerTarget), caster, args,
-			"%a", caster.getName(), "%t", targetName);
+		if (playerCaster != null)
+			sendMessage(prepareMessage(strCastSelf, playerCaster, playerTarget), caster, args,
+				"%a", casterName, "%t", targetName);
 
 		if (playerTarget != null)
-			sendMessage(prepareMessage(strCastTarget, (Player) caster, playerTarget), playerTarget, args,
-				"%a", caster.getName(), "%t", targetName);
+			sendMessage(prepareMessage(strCastTarget, playerCaster, playerTarget), target, args,
+				"%a", casterName, "%t", targetName);
 
-		sendMessageNear(caster, playerTarget, prepareMessage(strCastOthers, (Player) caster, playerTarget), broadcastRange, args);
+		sendMessageNear(caster, playerTarget, prepareMessage(strCastOthers, playerCaster, playerTarget), broadcastRange, args);
 	}
 	
 	private String prepareMessage(String message, Player caster, Player playerTarget) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
@@ -121,7 +121,7 @@ public class BindSpell extends CommandSpell {
 			spellbook.addCastItem(spell, castItem);
 			spellbook.save();
 			MagicSpells.debug(3, "    Bind successful.");
-			sendMessage(formatMessage(strCastSelf, "%s", spell.getName()), player, args);
+			sendMessage(strCastSelf, player, args, "%s", spell.getName());
 			playSpellEffects(EffectPosition.CASTER, player);
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
@@ -101,11 +101,11 @@ public class ForgetSpell extends CommandSpell {
 				targetSpellbook.removeSpell(spell);
 				targetSpellbook.save();
 				if (!player.equals(target)) {
-					sendMessage(formatMessage(strCastTarget, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName()), target, args);
-					sendMessage(formatMessage(strCastSelf, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName()), player, args);
+					sendMessage(strCastTarget, target, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
+					sendMessage(strCastSelf, player, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
 					playSpellEffects(player, target);
 				} else {
-					sendMessage(formatMessage(strCastSelfTarget, "%s", spell.getName()), player, args);
+					sendMessage(strCastSelfTarget, player, args, "%s", spell.getName());
 					playSpellEffects(EffectPosition.CASTER, player);
 				}
 				return PostCastAction.NO_MESSAGES;
@@ -115,7 +115,7 @@ public class ForgetSpell extends CommandSpell {
 			targetSpellbook.save();
 
 			if (!player.equals(target)) {
-				sendMessage(formatMessage(strResetTarget, "%t", target.getDisplayName()), player, args);
+				sendMessage(strResetTarget, player, args, "%t", target.getDisplayName());
 				playSpellEffects(player, target);
 			} else {
 				sendMessage(strResetSelf, player, args);
@@ -159,7 +159,7 @@ public class ForgetSpell extends CommandSpell {
 		if (!all) {
 			targetSpellbook.removeSpell(spell);
 			targetSpellbook.save();
-			sendMessage(formatMessage(strCastTarget, "%a", getConsoleName(), "%s", spell.getName(), "%t", target.getDisplayName()), target, args);
+			sendMessage(strCastTarget, target, args, "%a", getConsoleName(), "%s", spell.getName(), "%t", target.getDisplayName());
 			sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", target.getDisplayName()));
 		} else {
 			targetSpellbook.removeAllSpells();

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
@@ -50,9 +50,9 @@ public class HelpSpell extends CommandSpell {
 				return PostCastAction.ALREADY_HANDLED;
 			}
 
-			sendMessage(formatMessage(strDescLine, "%s", spell.getName(), "%d", spell.getDescription()), player, args);
+			sendMessage(strDescLine, player, args, "%s", spell.getName(), "%d", spell.getDescription());
 			if (spell.getCostStr() != null && !spell.getCostStr().isEmpty()) {
-				sendMessage(formatMessage(strCostLine, "%c", spell.getCostStr()), player, args);
+				sendMessage(strCostLine, player, args, "%c", spell.getCostStr());
 			}
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -164,7 +164,7 @@ public class ScrollSpell extends CommandSpell {
 			inHand = createScroll(spell, uses, inHand);
 			player.getEquipment().setItemInMainHand(inHand);
 			
-			sendMessage(formatMessage(strCastSelf, "%s", spell.getName()), player, args);
+			sendMessage(strCastSelf, player, args, "%s", spell.getName());
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;
@@ -302,7 +302,7 @@ public class ScrollSpell extends CommandSpell {
 			}
 		}
 
-		sendMessage(formatMessage(strOnUse, "%s", spell.getName(), "%u", uses >= 0 ? uses + "" : "many"), player, MagicSpells.NULL_ARGS);
+		sendMessage(strOnUse, player, MagicSpells.NULL_ARGS, "%s", spell.getName(), "%u", uses >= 0 ? uses + "" : "many");
 	}
 	
 	@EventHandler

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
@@ -138,7 +138,7 @@ public class SpellbookSpell extends CommandSpell {
 			else bookUses.add(Integer.parseInt(args[1]));
 
 			saveSpellbooks();
-			sendMessage(formatMessage(strCastSelf, "%s", spell.getName()), player, args);
+			sendMessage(strCastSelf, player, args, "%s", spell.getName());
 			playSpellEffects(player, target.getLocation());
 			return PostCastAction.NO_MESSAGES;
 		}
@@ -183,22 +183,22 @@ public class SpellbookSpell extends CommandSpell {
 			return;
 		}
 		if (!spellbook.canLearn(spell)) {
-			sendMessage(formatMessage(strCantLearn, "%s", spell.getName()), player, MagicSpells.NULL_ARGS);
+			sendMessage(strCantLearn, player, MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		if (spellbook.hasSpell(spell)) {
-			sendMessage(formatMessage(strAlreadyKnown, "%s", spell.getName()), player, MagicSpells.NULL_ARGS);
+			sendMessage(strAlreadyKnown, player, MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		SpellLearnEvent learnEvent = new SpellLearnEvent(spell, player, LearnSource.SPELLBOOK, event.getClickedBlock());
 		EventUtil.call(learnEvent);
 		if (learnEvent.isCancelled()) {
-			sendMessage(formatMessage(strCantLearn, "%s", spell.getName()), player, MagicSpells.NULL_ARGS);
+			sendMessage(strCantLearn, player, MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		spellbook.addSpell(spell);
 		spellbook.save();
-		sendMessage(formatMessage(strLearned, "%s", spell.getName()), player, MagicSpells.NULL_ARGS);
+		sendMessage(strLearned, player, MagicSpells.NULL_ARGS, "%s", spell.getName());
 		playSpellEffects(EffectPosition.DELAYED, player);
 
 		int uses = bookUses.get(i);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
@@ -86,8 +86,8 @@ public class TeachSpell extends CommandSpell {
 			}
 			targetSpellbook.addSpell(spell);
 			targetSpellbook.save();
-			sendMessage(formatMessage(strCastTarget, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName()), target, args);
-			sendMessage(formatMessage(strCastSelf, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName()), player, args);
+			sendMessage(strCastTarget, target, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
+			sendMessage(strCastSelf, player, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
 			playSpellEffects(player, target);
 			return PostCastAction.NO_MESSAGES;
 		}
@@ -126,7 +126,7 @@ public class TeachSpell extends CommandSpell {
 		}
 		targetSpellbook.addSpell(spell);
 		targetSpellbook.save();
-		sendMessage(formatMessage(strCastTarget, "%a", getConsoleName(), "%s", spell.getName(), "%t", players.get(0).getDisplayName()), players.get(0), args);
+		sendMessage(strCastTarget, players.get(0), args, "%a", getConsoleName(), "%s", spell.getName(), "%t", players.get(0).getDisplayName());
 		sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", players.get(0).getDisplayName()));
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -155,22 +155,22 @@ public class TomeSpell extends CommandSpell {
 		if (spellbook == null) return;
 		
 		if (spellbook.hasSpell(spell)) {
-			sendMessage(formatMessage(strAlreadyKnown, "%s", spell.getName()), event.getPlayer(), MagicSpells.NULL_ARGS);
+			sendMessage(strAlreadyKnown, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		if (!spellbook.canLearn(spell)) {
-			sendMessage(formatMessage(strCantLearn, "%s", spell.getName()), event.getPlayer(), MagicSpells.NULL_ARGS);
+			sendMessage(strCantLearn, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		SpellLearnEvent learnEvent = new SpellLearnEvent(spell, event.getPlayer(), LearnSource.TOME, event.getPlayer().getEquipment().getItemInMainHand());
 		EventUtil.call(learnEvent);
 		if (learnEvent.isCancelled()) {
-			sendMessage(formatMessage(strCantLearn, "%s", spell.getName()), event.getPlayer(), MagicSpells.NULL_ARGS);
+			sendMessage(strCantLearn, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
 		spellbook.addSpell(spell);
 		spellbook.save();
-		sendMessage(formatMessage(strLearned, "%s", spell.getName()), event.getPlayer(), MagicSpells.NULL_ARGS);
+		sendMessage(strLearned, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 		if (cancelReadOnLearn) event.setCancelled(true);
 
 		if (uses > 0) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
@@ -109,7 +109,7 @@ public class UnbindSpell extends CommandSpell {
 			}
 
 			spellbook.save();
-			sendMessage(formatMessage(strCastSelf, "%s", spell.getName()), player, args);
+			sendMessage(strCastSelf, player, args, "%s", spell.getName());
 			playSpellEffects(EffectPosition.CASTER, player);
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
@@ -168,7 +168,7 @@ public class DowseSpell extends InstantSpell {
 			
 			playSpellEffects(EffectPosition.CASTER, player);
 			if (getDistance) {
-				sendMessage(formatMessage(strCastSelf, "%d", distance + ""), player, args);
+				sendMessage(strCastSelf, player, args, "%d", distance + "");
 				sendMessageNear(player, strCastOthers);
 				return PostCastAction.NO_MESSAGES;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
@@ -198,7 +198,10 @@ public class RitualSpell extends InstantSpell {
 
 			if (interrupted) {
 				stop(strRitualInterrupted);
-				if (spellOnInterrupt != null && caster.isValid()) spellOnInterrupt.castSpell(caster, SpellCastState.NORMAL, power, MagicSpells.NULL_ARGS);
+				if (spellOnInterrupt != null && caster.isValid()) {
+					if (spellOnInterrupt.isTargetedLocationSpell()) spellOnInterrupt.castAtLocation(caster, caster.getLocation(), power);
+					else spellOnInterrupt.cast(caster, power);
+				}
 			}
 			
 			if (duration >= ritualDuration) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
@@ -19,57 +19,57 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Trigger variable of a pipe separated list of items to accept
 public class LeftClickItemListener extends PassiveListener {
 
-    private final Set<MagicItemData> items = new HashSet<>();
+	private final Set<MagicItemData> items = new HashSet<>();
 
-    @Override
-    public void initialize(String var) {
-        if (var == null || var.isEmpty()) return;
+	@Override
+	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
 
-        String[] split = var.split("\\|");
-        for (String s : split) {
-            s = s.trim();
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
 
-            MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
-            if (itemData == null) {
-                MagicSpells.error("Invalid magic item '" + s + "' in leftclickitem trigger on passive spell '" + passiveSpell.getInternalName() + "'");
-                continue;
-            }
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in leftclickitem trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
-            items.add(itemData);
-        }
-    }
+			items.add(itemData);
+		}
+	}
 
-    @OverridePriority
-    @EventHandler
-    public void onLeftClick(PlayerInteractEvent event) {
-        if (event.getAction() != Action.LEFT_CLICK_AIR && event.getAction() != Action.LEFT_CLICK_BLOCK) return;
-        if (!isCancelStateOk(isCancelled(event))) return;
-        if (!event.hasItem()) return;
+	@OverridePriority
+	@EventHandler
+	public void onLeftClick(PlayerInteractEvent event) {
+		if (event.getAction() != Action.LEFT_CLICK_AIR && event.getAction() != Action.LEFT_CLICK_BLOCK) return;
+		if (!isCancelStateOk(isCancelled(event))) return;
+		if (!event.hasItem()) return;
 
-        Player caster = event.getPlayer();
-        if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
 
-        if (!items.isEmpty()) {
-            ItemStack item = event.getItem();
-            if (item == null) return;
+		if (!items.isEmpty()) {
+			ItemStack item = event.getItem();
+			if (item == null) return;
 
-            MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-            if (itemData == null || !contains(itemData)) return;
-        }
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
+		}
 
-        boolean casted = passiveSpell.activate(caster);
-        if (cancelDefaultAction(casted)) event.setCancelled(true);
-    }
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
 
-    private boolean contains(MagicItemData itemData) {
-        for (MagicItemData data : items) {
-            if (data.matches(itemData)) return true;
-        }
-        return false;
-    }
+	private boolean contains(MagicItemData itemData) {
+		for (MagicItemData data : items) {
+			if (data.matches(itemData)) return true;
+		}
+		return false;
+	}
 
-    private boolean isCancelled(PlayerInteractEvent event) {
-        return event.useInteractedBlock() == Event.Result.DENY && event.useItemInHand() == Event.Result.DENY;
-    }
+	private boolean isCancelled(PlayerInteractEvent event) {
+		return event.useInteractedBlock() == Event.Result.DENY && event.useItemInHand() == Event.Result.DENY;
+	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
@@ -1,0 +1,75 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.event.Event;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.block.Action;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.event.player.PlayerInteractEvent;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+
+// Trigger variable of a pipe separated list of items to accept
+public class LeftClickItemListener extends PassiveListener {
+
+    private final Set<MagicItemData> items = new HashSet<>();
+
+    @Override
+    public void initialize(String var) {
+        if (var == null || var.isEmpty()) return;
+
+        String[] split = var.split("\\|");
+        for (String s : split) {
+            s = s.trim();
+
+            MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+            if (itemData == null) {
+                MagicSpells.error("Invalid magic item '" + s + "' in leftclickitem trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+                continue;
+            }
+
+            items.add(itemData);
+        }
+    }
+
+    @OverridePriority
+    @EventHandler
+    public void onLeftClick(PlayerInteractEvent event) {
+        if (event.getAction() != Action.LEFT_CLICK_AIR && event.getAction() != Action.LEFT_CLICK_BLOCK) return;
+        if (!isCancelStateOk(isCancelled(event))) return;
+        if (!event.hasItem()) return;
+
+        Player caster = event.getPlayer();
+        if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+
+        if (!items.isEmpty()) {
+            ItemStack item = event.getItem();
+            if (item == null) return;
+
+            MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+            if (itemData == null || !contains(itemData)) return;
+        }
+
+        boolean casted = passiveSpell.activate(event.getPlayer());
+        if (cancelDefaultAction(casted)) event.setCancelled(true);
+    }
+
+    private boolean contains(MagicItemData itemData) {
+        for (MagicItemData data : items) {
+            if (data.matches(itemData)) return true;
+        }
+        return false;
+    }
+
+    private boolean isCancelled(PlayerInteractEvent event) {
+        return event.useInteractedBlock() == Event.Result.DENY && event.useItemInHand() == Event.Result.DENY;
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
@@ -17,49 +17,49 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Trigger variable of a pipe separated list of items to accept
 public class PlayerAnimationListener extends PassiveListener {
 
-    private final Set<MagicItemData> items = new HashSet<>();
+	private final Set<MagicItemData> items = new HashSet<>();
 
-    @Override
-    public void initialize(String var) {
-        if (var == null || var.isEmpty()) return;
+	@Override
+	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
 
-        String[] split = var.split("\\|");
-        for (String s : split) {
-            s = s.trim();
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
 
-            MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
-            if (itemData == null) {
-                MagicSpells.error("Invalid magic item '" + s + "' in playeranimate trigger on passive spell '" + passiveSpell.getInternalName() + "'");
-                continue;
-            }
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in playeranimate trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
-            items.add(itemData);
-        }
-    }
+			items.add(itemData);
+		}
+	}
 
-    @OverridePriority
-    @EventHandler
-    public void onAnimate(PlayerAnimationEvent event) {
-        if (!isCancelStateOk(event.isCancelled())) return;
+	@OverridePriority
+	@EventHandler
+	public void onAnimate(PlayerAnimationEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
 
-        Player caster = event.getPlayer();
-        if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
 
-        if (!items.isEmpty()) {
-            ItemStack item = caster.getInventory().getItemInMainHand();
-            MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-            if (itemData == null || !contains(itemData)) return;
-        }
+		if (!items.isEmpty()) {
+			ItemStack item = caster.getInventory().getItemInMainHand();
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
+		}
 
-        boolean casted = passiveSpell.activate(caster);
-        if (cancelDefaultAction(casted)) event.setCancelled(true);
-    }
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
 
-    private boolean contains(MagicItemData itemData) {
-        for (MagicItemData data : items) {
-            if (data.matches(itemData)) return true;
-        }
-        return false;
-    }
+	private boolean contains(MagicItemData itemData) {
+		for (MagicItemData data : items) {
+			if (data.matches(itemData)) return true;
+		}
+		return false;
+	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
@@ -3,12 +3,10 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
-import org.bukkit.event.Event;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.block.Action;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.event.player.PlayerAnimationEvent;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
@@ -17,7 +15,7 @@ import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 // Trigger variable of a pipe separated list of items to accept
-public class LeftClickItemListener extends PassiveListener {
+public class PlayerAnimationListener extends PassiveListener {
 
     private final Set<MagicItemData> items = new HashSet<>();
 
@@ -31,7 +29,7 @@ public class LeftClickItemListener extends PassiveListener {
 
             MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
             if (itemData == null) {
-                MagicSpells.error("Invalid magic item '" + s + "' in leftclickitem trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+                MagicSpells.error("Invalid magic item '" + s + "' in playeranimate trigger on passive spell '" + passiveSpell.getInternalName() + "'");
                 continue;
             }
 
@@ -41,18 +39,14 @@ public class LeftClickItemListener extends PassiveListener {
 
     @OverridePriority
     @EventHandler
-    public void onLeftClick(PlayerInteractEvent event) {
-        if (event.getAction() != Action.LEFT_CLICK_AIR && event.getAction() != Action.LEFT_CLICK_BLOCK) return;
-        if (!isCancelStateOk(isCancelled(event))) return;
-        if (!event.hasItem()) return;
+    public void onAnimate(PlayerAnimationEvent event) {
+        if (!isCancelStateOk(event.isCancelled())) return;
 
         Player caster = event.getPlayer();
         if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
 
         if (!items.isEmpty()) {
-            ItemStack item = event.getItem();
-            if (item == null) return;
-
+            ItemStack item = caster.getInventory().getItemInMainHand();
             MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
             if (itemData == null || !contains(itemData)) return;
         }
@@ -66,10 +60,6 @@ public class LeftClickItemListener extends PassiveListener {
             if (data.matches(itemData)) return true;
         }
         return false;
-    }
-
-    private boolean isCancelled(PlayerInteractEvent event) {
-        return event.useInteractedBlock() == Event.Result.DENY && event.useItemInHand() == Event.Result.DENY;
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
@@ -1,0 +1,40 @@
+package com.nisovin.magicspells.spells.passive;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerMoveEvent;
+
+import com.nisovin.magicspells.util.LocationUtil;
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+
+public class PlayerMoveListener extends PassiveListener {
+
+    private double tolerance = 0;
+
+    @Override
+    public void initialize(String var) {
+        if (var == null || var.isEmpty()) return;
+
+        try {
+            tolerance = Double.parseDouble(var);
+        } catch (NumberFormatException e) {
+            DebugHandler.debugNumberFormat(e);
+        }
+    }
+
+    @OverridePriority
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        if (!isCancelStateOk(event.isCancelled())) return;
+
+        Player caster = event.getPlayer();
+        if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+        if (tolerance > 0 && LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), tolerance)) return;
+
+        boolean casted = passiveSpell.activate(caster);
+        if (cancelDefaultAction(casted)) event.setCancelled(true);
+    }
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
@@ -11,30 +11,30 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class PlayerMoveListener extends PassiveListener {
 
-    private double tolerance = 0;
+	private double tolerance = 0;
 
-    @Override
-    public void initialize(String var) {
-        if (var == null || var.isEmpty()) return;
+	@Override
+	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
 
-        try {
-            tolerance = Double.parseDouble(var);
-        } catch (NumberFormatException e) {
-            DebugHandler.debugNumberFormat(e);
-        }
-    }
+		try {
+			tolerance = Double.parseDouble(var);
+		} catch (NumberFormatException e) {
+			DebugHandler.debugNumberFormat(e);
+		}
+	}
 
-    @OverridePriority
-    @EventHandler
-    public void onMove(PlayerMoveEvent event) {
-        if (!isCancelStateOk(event.isCancelled())) return;
+	@OverridePriority
+	@EventHandler
+	public void onMove(PlayerMoveEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
 
-        Player caster = event.getPlayer();
-        if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
-        if (tolerance > 0 && LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), tolerance)) return;
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+		if (tolerance > 0 && LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), tolerance)) return;
 
-        boolean casted = passiveSpell.activate(caster);
-        if (cancelDefaultAction(casted)) event.setCancelled(true);
-    }
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -57,7 +57,7 @@ public class RightClickItemListener extends PassiveListener {
 			if (itemData == null || !contains(itemData)) return;
 		}
 
-		boolean casted = passiveSpell.activate(event.getPlayer());
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CaptureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CaptureSpell.java
@@ -54,7 +54,7 @@ public class CaptureSpell extends TargetedSpell implements TargetedEntitySpell {
 			boolean ok = capture(livingEntity, target.getTarget(), target.getPower());
 			if (!ok) return noTarget(livingEntity);
 
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -58,7 +58,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			TargetInfo<LivingEntity> target = getTargetedEntity(livingEntity, power);
 			if (target == null) return noTarget(livingEntity);
 			chain(livingEntity, livingEntity.getLocation(), target.getTarget(), target.getPower());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
@@ -177,7 +177,7 @@ public class CleanseSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (target == null) return noTarget(livingEntity);
 			
 			cleanse(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -50,7 +50,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 			boolean combusted = combust(livingEntity, target.getTarget(), target.getPower());
 			if (!combusted) return noTarget(livingEntity);
 
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
@@ -37,7 +37,7 @@ public class CrippleSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (target == null) return noTarget(livingEntity);
 
 			cripple(livingEntity, target.getTarget(), power);
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
@@ -63,7 +63,7 @@ public class CrippleSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (caster != null) playSpellEffects(caster, target);
 		else playSpellEffects(EffectPosition.TARGET, target);
 		
-		if (useSlownessEffect) target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, Math.round(duration * power), strength), true);
+		if (useSlownessEffect) target.addPotionEffect(new PotionEffect(PotionEffectType.SLOW, Math.round(duration * power), strength));
 		if (applyPortalCooldown && target.getPortalCooldown() < (int) (portalCooldown * power)) target.setPortalCooldown((int) (portalCooldown * power));
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
@@ -73,7 +73,7 @@ public class DisarmSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (!disarmed) return noTarget(livingEntity, strInvalidItem);
 
 			playSpellEffects(livingEntity, realTarget);
-			sendMessages(livingEntity, realTarget);
+			sendMessages(livingEntity, realTarget, args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -104,7 +104,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 
 			boolean drained = drain(livingEntity, target.getTarget(), target.getPower());
 			if (!drained) return noTarget(livingEntity);
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
@@ -25,7 +25,7 @@ public class DummySpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			if (target == null) return noTarget(livingEntity);
 
 			playSpellEffects(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
@@ -38,7 +38,7 @@ public class EntityEditSpell extends TargetedSpell implements TargetedEntitySpel
 
 			applyAttributes(target.getTarget());
 			playSpellEffects(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySelectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySelectSpell.java
@@ -31,7 +31,7 @@ public class EntitySelectSpell extends TargetedSpell {
 			if (targetInfo == null || targetInfo.getTarget() == null) return noTarget(livingEntity);
 			
 			targets.put(livingEntity.getUniqueId(), new WeakReference<>(targetInfo.getTarget()));
-			sendMessages(livingEntity, targetInfo.getTarget());
+			sendMessages(livingEntity, targetInfo.getTarget(), args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
@@ -75,7 +75,7 @@ public class EntombSpell extends TargetedSpell implements TargetedEntitySpell {
 			power = targetInfo.getPower();
 			
 			createTomb(target, power);
-			sendMessages(livingEntity, target);
+			sendMessages(livingEntity, target, args);
 			playSpellEffects(livingEntity, target);
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -47,7 +47,7 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 			if (targetInfo == null) return noTarget(livingEntity);
 
 			toss(livingEntity, targetInfo.getTarget(), targetInfo.getPower());
-			sendMessages(livingEntity, targetInfo.getTarget());
+			sendMessages(livingEntity, targetInfo.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
@@ -67,7 +67,7 @@ public class GeyserSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (!ok) return noTarget(livingEntity);
 
 			playSpellEffects(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GripSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GripSpell.java
@@ -46,7 +46,7 @@ public class GripSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			if (target == null) return noTarget(livingEntity);
 			if (!grip(livingEntity.getLocation(), target.getTarget())) return noTarget(livingEntity, strCantGrip);
 
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
@@ -53,7 +53,7 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (cancelIfFull && target.getHealth() == Util.getMaxHealth(target)) return noTarget(livingEntity, formatMessage(strMaxHealth, "%t", getTargetName(target)));
 			boolean healed = heal(livingEntity, target, power);
 			if (!healed) return noTarget(livingEntity);
-			sendMessages(livingEntity, target);
+			sendMessages(livingEntity, target, args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -187,7 +187,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			TargetInfo<LivingEntity> target = getTargetedEntity(livingEntity, power, checker);
 			if (target == null) return noTarget(livingEntity);
 			new MissileTracker(livingEntity, target.getTarget(), target.getPower());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -169,7 +169,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(livingEntity, power);
 			if (targetInfo == null) return noTarget(livingEntity);
 			new HomingProjectileMonitor(livingEntity, targetInfo.getTarget(), targetInfo.getPower());
-			sendMessages(livingEntity, targetInfo.getTarget());
+			sendMessages(livingEntity, targetInfo.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -97,7 +97,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 			if (target == null) return noTarget(livingEntity);
 			
 			levitate(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -85,7 +85,7 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 				lightning(target.getLocation());
 				playSpellEffects(livingEntity, target.getLocation());
 				if (entityTarget != null) {
-					sendMessages(livingEntity, entityTarget);
+					sendMessages(livingEntity, entityTarget, args);
 					return PostCastAction.NO_MESSAGES;
 				}
 			} else return noTarget(livingEntity);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
@@ -38,7 +38,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (targetInfo == null) return noTarget(livingEntity);
 			LivingEntity target = targetInfo.getTarget();
 			if (target == null) return noTarget(livingEntity);
-			mount(livingEntity, target);
+			mount(livingEntity, target, args);
 		}
 
 		return PostCastAction.HANDLE_NORMALLY;
@@ -46,7 +46,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		mount(caster, target);
+		mount(caster, target, null);
 		return true;
 	}
 
@@ -55,7 +55,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 		return false;
 	}
 
-	private void mount(LivingEntity caster, LivingEntity target) {
+	private void mount(LivingEntity caster, LivingEntity target, String[] args) {
 		if (caster == null || target == null) return;
 
 		if (reverse) {
@@ -68,7 +68,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 				LivingEntity finalTarget = target;
 				MagicSpells.scheduleDelayedTask(() -> caster.removePassenger(finalTarget), duration);
 			}
-			sendMessages(caster, target);
+			sendMessages(caster, target, args);
 			return;
 		}
 
@@ -100,7 +100,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 			LivingEntity finalTarget1 = target;
 			MagicSpells.scheduleDelayedTask(() -> finalTarget1.removePassenger(caster), duration);
 		}
-		sendMessages(caster, target);
+		sendMessages(caster, target, args);
 	}
 
 	@EventHandler

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -140,7 +140,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				if (target == null) return noTarget(livingEntity);
 				new OrbitTracker(livingEntity, target.getTarget(), target.getPower());
 				playSpellEffects(livingEntity, target.getTarget());
-				sendMessages(livingEntity, target.getTarget());
+				sendMessages(livingEntity, target.getTarget(), args);
 				return PostCastAction.NO_MESSAGES;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
@@ -61,7 +61,7 @@ public class PainSpell extends TargetedSpell implements TargetedEntitySpell, Dam
 			else done = causePain(livingEntity, target.getTarget(), target.getPower());
 			if (!done) return noTarget(livingEntity);
 			
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
@@ -71,7 +71,7 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 			if (targeted) playSpellEffects(livingEntity, target);
 			else playSpellEffects(EffectPosition.CASTER, livingEntity);
 
-			sendMessages(livingEntity, target);
+			sendMessages(livingEntity, target, args);
 			return PostCastAction.NO_MESSAGES;
 		}		
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
@@ -109,7 +109,7 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 		if (effect.getType() == PotionEffectType.POISON) cause = DamageCause.POISON;
 		else if (effect.getType() == PotionEffectType.WITHER) cause = DamageCause.WITHER;
 		if (cause != null) EventUtil.call(new SpellApplyDamageEvent(this, caster, target, effect.getAmplifier(), cause, ""));
-		target.addPotionEffect(effect, true);
+		target.addPotionEffect(effect);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RegrowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RegrowSpell.java
@@ -57,7 +57,7 @@ public class RegrowSpell extends TargetedSpell implements TargetedEntitySpell {
 			boolean done = grow((Sheep) target.getTarget());
 			if (!done) return noTarget(livingEntity);
 
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -76,7 +76,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 			else {
 				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(livingEntity, power);
 				if (targetInfo == null) return noTarget(livingEntity);
-				sendMessages(livingEntity, targetInfo.getTarget());
+				sendMessages(livingEntity, targetInfo.getTarget(), args);
 				new Rewinder(livingEntity, targetInfo.getTarget(), power);
 			}
 			playSpellEffects(EffectPosition.CASTER, livingEntity);
@@ -87,7 +87,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public boolean castAtEntity(LivingEntity player, LivingEntity livingEntity, float v) {
 		new Rewinder(player, livingEntity, v);
-		sendMessages(player, livingEntity);
+		sendMessages(player, livingEntity, null);
 		playSpellEffects(EffectPosition.CASTER, player);
 		playSpellEffects(EffectPosition.TARGET, livingEntity);
 		playSpellEffectsTrail(player.getLocation(), livingEntity.getLocation());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShadowstepSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShadowstepSpell.java
@@ -46,7 +46,7 @@ public class ShadowstepSpell extends TargetedSpell implements TargetedEntitySpel
 
 			boolean done = shadowstep(livingEntity, target.getTarget());
 			if (!done) return noTarget(livingEntity, strNoLandingSpot);
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShearSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShearSpell.java
@@ -70,7 +70,7 @@ public class ShearSpell extends TargetedSpell implements TargetedEntitySpell {
 			boolean done = shear((Sheep) target.getTarget());
 			if (!done) return noTarget(livingEntity);
 
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -99,7 +99,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 			
 			silence(target.getTarget(), target.getPower());
 			playSpellEffects(livingEntity, target.getTarget());
-			sendMessages(livingEntity, target.getTarget());
+			sendMessages(livingEntity, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
@@ -71,7 +71,7 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 			power = targetInfo.getPower();
 
 			stunLivingEntity(caster, target, Math.round(duration * power));
-			sendMessages(caster, target);
+			sendMessages(caster, target, args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -108,13 +108,13 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 			if (requireAcceptance) {
 				pendingSummons.put(target, landLoc);
 				pendingTimes.put(target, System.currentTimeMillis());
-				sendMessage(formatMessage(strSummonPending, "%a", ((Player) caster).getDisplayName()), target, args);
+				sendMessage(strSummonPending, target, args, "%a", ((Player) caster).getDisplayName());
 			} else {
 				target.teleport(landLoc);
-				sendMessage(formatMessage(strSummonAccepted, "%a", ((Player) caster).getDisplayName()), target, args);
+				sendMessage(strSummonAccepted, target, args, "%a", ((Player) caster).getDisplayName());
 			}
 			
-			sendMessages(caster, target);
+			sendMessages(caster, target, args);
 			return PostCastAction.NO_MESSAGES;
 			
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchHealthSpell.java
@@ -29,7 +29,7 @@ public class SwitchHealthSpell extends TargetedSpell implements TargetedEntitySp
 			boolean ok = switchHealth(caster, target.getTarget());
 			if (!ok) return noTarget(caster);
 
-			sendMessages(caster, target.getTarget());
+			sendMessages(caster, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchSpell.java
@@ -27,7 +27,7 @@ public class SwitchSpell extends TargetedSpell implements TargetedEntitySpell {
 			
 			playSpellEffects(player, target.getTarget());
 			switchPlaces(player, target.getTarget());
-			sendMessages(player, target.getTarget());
+			sendMessages(player, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TeleportSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TeleportSpell.java
@@ -38,7 +38,7 @@ public class TeleportSpell extends TargetedSpell implements TargetedEntitySpell 
 			if (target == null) return noTarget(caster);
 			if (!teleport(caster, target.getTarget())) return noTarget(caster, strCantTeleport);
 
-			sendMessages(caster, target.getTarget());
+			sendMessages(caster, target.getTarget(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
@@ -64,7 +64,7 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (targetInfo == null) return noTarget(livingEntity);
 			LivingEntity target = targetInfo.getTarget();
 
-			sendMessages(livingEntity, target);
+			sendMessages(livingEntity, target, args);
 			glow(livingEntity, target, targetInfo.getPower());
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -153,11 +153,11 @@ public class CastItem {
 		StringBuilder output = new StringBuilder();
 		boolean previous = false;
 
-		output
-			.append(type.name())
-			.append("{");
+		output.append(type.name());
 
 		if (!MagicSpells.ignoreCastItemNames() && name != null) {
+			output.append("{");
+
 			output
 				.append("\"name\":\"")
 				.append(TxtUtil.escapeJSON(name))
@@ -168,6 +168,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemAmount()) {
 			if (previous) output.append(',');
+			else output.append("{");
 
 			output
 				.append("\"amount\":")
@@ -178,6 +179,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemDurability(type) && ItemUtil.hasDurability(type)) {
 			if (previous) output.append(',');
+			else output.append("{");
 
 			output
 				.append("\"durability\":")
@@ -188,6 +190,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemCustomModelData()) {
 			if (previous) output.append(',');
+			else output.append("{");
 
 			output
 				.append("\"custommodeldata\":")
@@ -208,6 +211,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemColor() && color != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
 
@@ -221,6 +225,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemPotionType() && potionData != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			output
 				.append("\"potiondata\":\"")
@@ -236,6 +241,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemTitle() && title != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			output
 				.append("\"title\":\"")
@@ -247,6 +253,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemAuthor() && author != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			output
 				.append("\"author\":\"")
@@ -258,6 +265,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemEnchants() && enchants != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			boolean previousEnchantment = false;
 			output.append("\"enchants\":{");
@@ -279,6 +287,7 @@ public class CastItem {
 
 		if (!MagicSpells.ignoreCastItemLore() && lore != null) {
 			if (previous) output.append(',');
+            else output.append("{");
 
 			boolean previousLore = false;
 			output.append("\"lore\":[");
@@ -292,10 +301,12 @@ public class CastItem {
 
 				previousLore = true;
 			}
+
 			output.append(']');
+			previous = true;
 		}
 
-		output.append("}");
+		if (previous) output.append("}");
 
 		return output.toString();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
@@ -30,7 +30,11 @@ public class TxtUtil {
 	}
 
 	public static String escapeJSON(String str) {
-		return str.replaceAll("\\\\", "\\\\\\\\").replaceAll("\"", "\\\\\"");
+		return str.replaceAll("[\"\\\\]", "\\\\$0");
+	}
+
+	public static String escapeMatcher(String str) {
+		return str.replaceAll("[$\\\\]", "\\\\$0");
 	}
 	
 	public static List<String> tabCompleteSpellName(CommandSender sender, String partial) {

--- a/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
@@ -4,11 +4,11 @@ import java.util.regex.Pattern;
 import java.util.function.BinaryOperator;
 import java.util.concurrent.ThreadLocalRandom;
 
+import org.apache.commons.math3.util.FastMath;
+
 import org.bukkit.entity.Player;
 
 import com.nisovin.magicspells.MagicSpells;
-
-import org.apache.commons.math3.util.FastMath;
 
 public class VariableMod {
 	
@@ -58,16 +58,16 @@ public class VariableMod {
 		}
 		
 	}
-	
+
+	private static final Pattern OPERATION_MATCHER = Pattern.compile("^[=+*/^%?]");
+
 	private VariableOwner variableOwner = VariableOwner.CASTER;
 	private String modifyingVariableName = null;
+	private double constantModifier;
+	private boolean negate = false;
 	private String value;
 	private Operation op;
-	private double constantModifier;
-	private static final Pattern OPERATION_MATCHER = Pattern.compile("^[=+*/^%?]");
-	
-	private boolean negate = false;
-	
+
 	public VariableMod(String data) {
 		op = Operation.fromPrefix(data);
 		data = OPERATION_MATCHER.matcher(data).replaceFirst("");
@@ -104,6 +104,11 @@ public class VariableMod {
 	public double getValue(Player caster, Player target, double baseValue) {
 		double secondValue = getValue(caster, target);
 		return getOperation().applyTo(baseValue, secondValue);
+	}
+
+	public String getStringValue(Player caster, Player target) {
+		String ret = MagicSpells.doTargetedVariableReplacements(caster, target, value);
+		return MagicSpells.doVariableReplacements(caster, ret);
 	}
 
 	public String getValue() {

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -210,8 +210,9 @@ public class MagicItemData {
         if (hasAttribute(MagicItemAttribute.TYPE))
             output.append(((Material) getAttribute(MagicItemAttribute.TYPE)).name());
 
-        output.append('{');
         if (hasAttribute(MagicItemAttribute.NAME)) {
+            output.append('{');
+
             output
                 .append("\"name\":\"")
                 .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.NAME)))
@@ -222,6 +223,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.AMOUNT)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"amount\":")
@@ -232,6 +234,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.DURABILITY)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"durability\":")
@@ -242,6 +245,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.REPAIR_COST)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"repair-cost\":")
@@ -252,6 +256,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"custom-model-data\":")
@@ -262,6 +267,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.POWER)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"power\":")
@@ -272,6 +278,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.UNBREAKABLE)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"unbreakable\":")
@@ -282,6 +289,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.HIDE_TOOLTIP)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"hide-tooltip\":")
@@ -292,6 +300,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.COLOR)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
             String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
@@ -306,6 +315,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.POTION_DATA)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             PotionData potionData = (PotionData) getAttribute(MagicItemAttribute.POTION_DATA);
 
@@ -323,6 +333,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             FireworkEffect effect = (FireworkEffect) getAttribute(MagicItemAttribute.FIREWORK_EFFECT);
 
@@ -366,6 +377,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.SKULL_OWNER)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"skull-owner\":\"")
@@ -377,6 +389,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.TITLE)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"title\":\"")
@@ -388,6 +401,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.AUTHOR)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"author\":\"")
@@ -399,6 +413,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.UUID)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"uuid\":\"")
@@ -410,6 +425,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.TEXTURE)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"texture\":\"")
@@ -421,6 +437,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.SIGNATURE)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"signature\":\"")
@@ -432,6 +449,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.ENCHANTMENTS)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTMENTS);
             boolean previousEnchantment = false;
@@ -453,6 +471,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.FAKE_GLINT)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output
                 .append("\"fake-glint\":")
@@ -463,6 +482,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.ATTRIBUTES)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             Multimap<Attribute, AttributeModifier> attributes = (Multimap<Attribute, AttributeModifier>) getAttribute(MagicItemAttribute.ATTRIBUTES);
             boolean previousAttribute = false;
@@ -497,6 +517,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.LORE)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             List<String> lore = (List<String>) getAttribute(MagicItemAttribute.LORE);
             boolean previousLore = false;
@@ -518,6 +539,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.PAGES)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             List<String> pages = (List<String>) getAttribute(MagicItemAttribute.PAGES);
             boolean previousPages = false;
@@ -539,6 +561,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.PATTERNS)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output.append("\"patterns\":[");
             List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
@@ -562,6 +585,7 @@ public class MagicItemData {
 
         if (hasAttribute(MagicItemAttribute.POTION_EFFECTS)) {
             if (previous) output.append(',');
+            else output.append('{');
 
             output.append("\"potion-effects\":[");
             List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
@@ -589,6 +613,8 @@ public class MagicItemData {
             List<FireworkEffect> effects = (List<FireworkEffect>) getAttribute(MagicItemAttribute.FIREWORK_EFFECTS);
 
             if (previous) output.append(',');
+            else output.append('{');
+
             output.append("\"firework-effects\":[");
             boolean previousEffect = false;
             for (FireworkEffect effect : effects) {
@@ -634,8 +660,9 @@ public class MagicItemData {
 
         if (!ignoredAttributes.isEmpty()) {
             if (previous) output.append(",");
-            output.append("\"ignored-attributes\":[");
+            else output.append('{');
 
+            output.append("\"ignored-attributes\":[");
             boolean previousAttribute = false;
             for (MagicItemAttribute attr : ignoredAttributes) {
                 if (previousAttribute) output.append(',');
@@ -654,8 +681,9 @@ public class MagicItemData {
 
         if (!blacklistedAttributes.isEmpty()) {
             if (previous) output.append(",");
-            output.append("\"blacklisted-attributes\":[");
+            else output.append('{');
 
+            output.append("\"blacklisted-attributes\":[");
             boolean previousAttribute = false;
             for (MagicItemAttribute attr : blacklistedAttributes) {
                 if (previousAttribute) output.append(',');
@@ -669,9 +697,10 @@ public class MagicItemData {
             }
 
             output.append(']');
+            previous = true;
         }
 
-        output.append('}');
+        if (previous) output.append('}');
 
         return output.toString();
     }

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -93,6 +93,7 @@ public class PassiveManager {
 		addListener("leavebed", LeaveBedListener.class);
 		addListener("leftclickblockcoord", LeftClickBlockCoordListener.class);
 		addListener("leftclickblocktype", LeftClickBlockTypeListener.class);
+		addListener("leftclickitem", LeftClickBlockTypeListener.class);
 		addListener("magicspellsloaded", MagicSpellsLoadedListener.class);
 		addListener("missarrow", MissArrowListener.class);
 		addListener("offhandswap", OffhandSwapListener.class);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -93,11 +93,12 @@ public class PassiveManager {
 		addListener("leavebed", LeaveBedListener.class);
 		addListener("leftclickblockcoord", LeftClickBlockCoordListener.class);
 		addListener("leftclickblocktype", LeftClickBlockTypeListener.class);
-		addListener("leftclickitem", LeftClickBlockTypeListener.class);
+		addListener("leftclickitem", LeftClickItemListener.class);
 		addListener("magicspellsloaded", MagicSpellsLoadedListener.class);
 		addListener("missarrow", MissArrowListener.class);
 		addListener("offhandswap", OffhandSwapListener.class);
 		addListener("pickupitem", PickupItemListener.class);
+		addListener("playeranimate", PlayerAnimationListener.class);
 		addListener("potioneffect", PotionEffectListener.class);
 		addListener("quit", QuitListener.class);
 		addListener("resourcepack", ResourcePackListener.class);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -99,6 +99,7 @@ public class PassiveManager {
 		addListener("offhandswap", OffhandSwapListener.class);
 		addListener("pickupitem", PickupItemListener.class);
 		addListener("playeranimate", PlayerAnimationListener.class);
+		addListener("playermove", PlayerMoveListener.class);
 		addListener("potioneffect", PotionEffectListener.class);
 		addListener("quit", QuitListener.class);
 		addListener("resourcepack", ResourcePackListener.class);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -569,20 +569,29 @@ public class VariableManager {
 		if (mod == null) return 0 + "";
 		if (playerToMod == null) return 0 + "";
 
-		double amount = mod.getValue(caster, target);
-		if (amount == 0 && mod.isConstantValue()) {
-			reset(var, playerToMod);
-			return amount + "";
-		}
-
 		VariableMod.Operation op = mod.getOperation();
+
 		if (op.equals(VariableMod.Operation.SET) && (variable instanceof PlayerStringVariable || variable instanceof GlobalStringVariable)) {
-			set(var, playerToMod, mod.getValue());
-			return mod.getValue();
+			String value = mod.getStringValue(caster, target);
+
+			if (value.equals(variable.getDefaultStringValue())) {
+				reset(var, playerToMod);
+			} else {
+				set(var, playerToMod, value);
+			}
+
+			return value;
 		}
 
-		set(var, playerToMod.getName(), op.applyTo(variable.getValue(playerToMod), amount));
-		return amount + "";
+		double value = op.applyTo(variable.getValue(playerToMod), mod.getValue(caster, target));
+
+		if (value == variable.getDefaultValue()) {
+			reset(var, playerToMod);
+		} else {
+			set(var, playerToMod, value);
+		}
+
+		return Double.toString(value);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/GlobalStringVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/GlobalStringVariable.java
@@ -42,7 +42,7 @@ public class GlobalStringVariable extends Variable {
 
 	@Override
 	public void reset(String player) {
-		value = "";
+		value = defaultStringValue;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerStringVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerStringVariable.java
@@ -21,9 +21,7 @@ public class PlayerStringVariable extends PlayerVariable {
 	
 	@Override
 	public String getStringValue(String player) {
-		String ret = data.get(player);
-		if (ret == null) ret = defaultStringValue;
-		return ret;
+		return data.getOrDefault(player, defaultStringValue);
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerVariable.java
@@ -22,8 +22,7 @@ public class PlayerVariable extends Variable {
 
 	@Override
 	public double getValue(String player) {
-		if (map.containsKey(player)) return map.get(player);
-		return defaultValue;
+		return map.getOrDefault(player, defaultValue);
 	}
 
 	@Override


### PR DESCRIPTION
Bugfixes:

- Operator conditions did not send an error message if an invalid/no operator was specified.
- `BowSpell` only checked the item in the caster's mainhand, rather than the bow used to fire the arrow, which could be in the offhand.
- `spell-on-hit-entity` and `spell-on-hit-ground` in `BowSpell` did not cast if they were not targeted entity spells and targeted location spells respectively.
- `spell-on-interrupt` option did not use `Subspell`.
- `cast` and `castinstead` modifier actions did not use `Subspell`.
- `PotionEffectSpell` and `CrippleSpell` forced potion effects, despite support for multiple of the same potion effect on an entity.
- Argument replacement did not function as a result of `%a` replacement preceding it.
- Argument replacement did not function in targeted spells.
- `%castervar:(varname)%` and `%targetvar:(varname)%` variable replacement did not function. 
- `%castervar:(varname)%`, `%targetvar:(varname)%` and `%t` replacement did not work in messages sent from targeted subspells on `CastMode.FULL`.
- `str-cast-target` was not sent from targeted subspells on `CastMode.FULL`.
- Variable modifiers that set a variable to 0 instead set the variable's value to its default.
- Resetting a global string variable set the value to an empty string instead of the default value.

Additions:

- Setting a string variable with variable mods now supports variable replacement.
- Variable mods now support spaces for string variables.
- New option `remove-arrow` on BowSpell; determines whether to delete the arrow after casting spells.
- New option `cancel-on-move` on BuffSpell.
- Added passive triggers `leftclickitem`, `playeranimate` and `playermove`.