### PR TITLE
SpellSelectedCondition & DataCondition

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DataCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DataCondition.java
@@ -1,0 +1,95 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.function.Function;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+import com.nisovin.magicspells.util.data.DataLivingEntity;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+public class DataCondition extends OperatorCondition {
+
+	private static final Pattern DATA_PATTERN = Pattern.compile("([.\\w]+)([<>=:])(.+)");
+
+	private Function<? super LivingEntity, String> dataElement;
+	private String compare;
+
+	private boolean constantValue;
+	private double value;
+
+	private boolean doTargetedReplacement = false;
+	private boolean doVarReplacement = false;
+
+	@Override
+	public boolean initialize(String var) {
+		Matcher matcher = DATA_PATTERN.matcher(var);
+		if (!matcher.matches()) return false;
+
+		if (!super.initialize(matcher.group(2))) return false;
+
+		dataElement = DataLivingEntity.getDataFunction(matcher.group(1));
+		if (dataElement == null) return false;
+
+		compare = matcher.group(3).replace("__", " ");
+
+		try {
+			value = Double.parseDouble(compare);
+			constantValue = true;
+		} catch (NumberFormatException e) {
+			constantValue = false;
+		}
+
+		if (compare.contains("%var") || compare.contains("%playervar")) doVarReplacement = true;
+		if (compare.contains("%castervar") || compare.contains("%targetvar")) doTargetedReplacement = true;
+
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		return check(caster, caster);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		if (dataElement == null) return false;
+
+		String localCompare = compare;
+
+		Player playerCaster = caster instanceof Player ? (Player) caster : null;
+		if (doVarReplacement) {
+			localCompare = MagicSpells.doVariableReplacements(playerCaster, localCompare);
+		}
+
+		if (doTargetedReplacement) {
+			Player playerTarget = target instanceof Player ? (Player) target : null;
+			localCompare = MagicSpells.doTargetedVariableReplacements(playerCaster, playerTarget, localCompare);
+		}
+
+		String data = dataElement.apply(target);
+		try {
+			double dataDouble = Double.parseDouble(data);
+			double localDouble = constantValue ?  value : Double.parseDouble(localCompare);
+
+			if (equals) return dataDouble == localDouble;
+			if (lessThan) return dataDouble < localDouble;
+			if (moreThan) return dataDouble > localDouble;
+		} catch (NumberFormatException e) {
+			if (equals) return Objects.equals(data, localCompare);
+		}
+
+		return false;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return check(caster, caster);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
@@ -1,0 +1,79 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.bukkit.inventory.ItemStack;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
+import com.nisovin.magicspells.castmodifiers.Condition;
+
+public class SpellSelectedCondition extends Condition {
+
+	private SpellFilter filter;
+
+	@Override
+	public boolean initialize(String var) {
+		if (var == null || var.isEmpty()) return false;
+
+		List<String> spells = new ArrayList<>();
+		List<String> deniedSpells = new ArrayList<>();
+		List<String> tagList = new ArrayList<>();
+		List<String> deniedTagList = new ArrayList<>();
+
+		String[] split = var.split(",");
+		for (String s : split) {
+			boolean denied = false;
+			s = s.trim();
+
+			if (s.startsWith("!")) {
+				s = s.substring(1);
+				denied = true;
+			}
+
+			if (s.toLowerCase().startsWith("tag:")) {
+				if (denied) {
+					deniedTagList.add(s.substring(4));
+				} else {
+					tagList.add(s.substring(4));
+				}
+			} else {
+				if (denied) {
+					deniedSpells.add(s);
+				} else {
+					spells.add(s);
+				}
+			}
+		}
+
+		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity) {
+		if (!(livingEntity instanceof Player)) return false;
+
+		Player player = (Player) livingEntity;
+		Spellbook spellbook = MagicSpells.getSpellbook(player);
+		ItemStack item = player.getInventory().getItemInMainHand();
+
+		return filter != null && filter.check(spellbook.getActiveSpell(item));
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity, LivingEntity target) {
+		return check(livingEntity);
+	}
+
+	@Override
+	public boolean check(LivingEntity livingEntity, Location location) {
+		return check(livingEntity);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
@@ -68,7 +68,7 @@ public class SpellSelectedCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		return check(livingEntity);
+		return check(target);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
@@ -15,6 +15,7 @@ import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 
 public class UnconjureSpell extends InstantSpell {
 
@@ -127,7 +128,12 @@ public class UnconjureSpell extends InstantSpell {
 		public UnconjuredItem(String itemString) {
 			String[] splits = itemString.split(" ");
 			magicItemData = MagicItems.getMagicItemDataFromString(splits[0]);
-			if (magicItemData == null || splits.length == 1) return;
+			if (magicItemData == null) return;
+
+			magicItemData = magicItemData.clone();
+			magicItemData.getIgnoredAttributes().add(MagicItemAttribute.AMOUNT);
+
+			if (splits.length == 1) return;
 
 			try {
 				amount = Integer.parseInt(splits[1]);

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
@@ -8,6 +8,7 @@ import java.util.HashSet;
 import java.util.Collection;
 
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 
 public class SpellReagents {
 	
@@ -223,7 +224,9 @@ public class SpellReagents {
 		private int amount;
 
 		public ReagentItem(MagicItemData magicItemData, int amount) {
-			this.magicItemData = magicItemData;
+			this.magicItemData = magicItemData.clone();
+			magicItemData.getIgnoredAttributes().add(MagicItemAttribute.AMOUNT);
+
 			this.amount = amount;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -47,6 +47,7 @@ public class ConditionManager {
 
 	private void initialize() {
 		addCondition("advancement", AdvancementCondition.class);
+		addCondition("data", DataCondition.class);
 		addCondition("displayname", DisplayNameCondition.class);
 		addCondition("hoveringwith", HoveringWithCondition.class);
 		addCondition("day", DayCondition.class);
@@ -138,6 +139,7 @@ public class ConditionManager {
 		addCondition("targeting", TargetingCondition.class);
 		addCondition("power", PowerCondition.class);
 		addCondition("spelltag", SpellTagCondition.class);
+		addCondition("spellselected", SpellSelectedCondition.class);
 		addCondition("beneficial", SpellBeneficialCondition.class);
 		addCondition("customname", CustomNameCondition.class);
 		addCondition("customnamevisible", CustomNameVisibleCondition.class);


### PR DESCRIPTION
- Added SpellSelectedCondition - accepts a comma separated list of spells and spell tags. Tags are prepended by `tag:`, and blacklisted elements are prepended by `!`. Passes if caster/target have a spell selected that matches the supplied filter.
- Added DataCondition - checks if the specified data element is lesser than, greater than or equal to the value supplied. `__` can be used to substitute for spaces in the value. Supports variable replacement, including targeted variable replacement using `%castervar` and `%targetvar`.
- `MagicItemData` used for checking reagents or in UnconjureSpell now automatically ignore amount when matching.