### PR TITLE
BowSpell additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -145,6 +145,7 @@ public class MagicSpells extends JavaPlugin {
 	private boolean castWithRightClick;
 	private boolean reverseBowCycleButtons;
 	private boolean bowCycleSpellsSneaking;
+	private boolean castBoundBowSpellsFromOffhand;
 	private boolean allowCycleToNoSpell;
 
 	private boolean checkScoreboardTeams;
@@ -262,6 +263,7 @@ public class MagicSpells extends JavaPlugin {
 		separatePlayerSpellsPerWorld = config.getBoolean(path + "separate-player-spells-per-world", false);
 		allowCycleToNoSpell = config.getBoolean(path + "allow-cycle-to-no-spell", false);
 		reverseBowCycleButtons = config.getBoolean(path + "reverse-bow-cycle-buttons", false);
+		castBoundBowSpellsFromOffhand = config.getBoolean(path + "cast-bound-bow-spells-from-offhand", false);
 		bowCycleSpellsSneaking = config.getBoolean(path + "bow-cycle-spells-sneaking", false);
 		alwaysShowMessageOnCycle = config.getBoolean(path + "always-show-message-on-cycle", false);
 		onlyCycleToCastableSpells = config.getBoolean(path + "only-cycle-to-castable-spells", true);
@@ -983,6 +985,10 @@ public class MagicSpells extends JavaPlugin {
 
 	public static boolean canBowCycleSpellsSneaking() {
 		return plugin.bowCycleSpellsSneaking;
+	}
+
+	public static boolean castBoundBowSpellsFromOffhand() {
+		return plugin.castBoundBowSpellsFromOffhand;
 	}
 
 	public static boolean tabCompleteInternalNames() {

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -132,6 +132,7 @@ public class CastListener implements Listener {
 	@EventHandler
 	public void onPlayerShootBow(EntityShootBowEvent event) {
 		if (!(event.getEntity() instanceof Player)) return;
+		if (event.getHand() == EquipmentSlot.OFF_HAND && !MagicSpells.castBoundBowSpellsFromOffhand()) return;
 
 		Player player = (Player) event.getEntity();
 		ItemStack bow = event.getBow();

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -20,6 +20,7 @@ import org.bukkit.event.player.PlayerAnimationEvent;
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.BowSpell;
 import com.nisovin.magicspells.util.BlockUtils;
 
 public class CastListener implements Listener {
@@ -131,29 +132,49 @@ public class CastListener implements Listener {
 	@EventHandler
 	public void onPlayerShootBow(EntityShootBowEvent event) {
 		if (!(event.getEntity() instanceof Player)) return;
+
 		Player player = (Player) event.getEntity();
-		castSpell(player);
+		ItemStack bow = event.getBow();
+		if (bow == null) return;
+
+		Spellbook spellbook = MagicSpells.getSpellbook(player);
+		Spell spell = spellbook.getActiveSpell(bow);
+
+		if (spell instanceof BowSpell) {
+			BowSpell bowSpell = (BowSpell) spell;
+
+			if (bowSpell.canCastWithItem() && bowSpell.isBindRequired() && checkGlobalCooldown(player, spell))
+				bowSpell.handleBowCast(event);
+		} else castSpell(player, spell);
+
 		event.getProjectile().setMetadata("bow-draw-strength", new FixedMetadataValue(plugin, event.getForce()));
 	}
 
 	private void castSpell(Player player) {
-		ItemStack inHand = player.getEquipment().getItemInMainHand();
-		if (!MagicSpells.canCastWithFist() && (inHand == null || BlockUtils.isAir(inHand.getType()))) return;
+		ItemStack inHand = player.getInventory().getItemInMainHand();
+		if (!MagicSpells.canCastWithFist() && BlockUtils.isAir(inHand)) return;
 
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
-		if (spellbook == null) return;
-
 		Spell spell = spellbook.getActiveSpell(inHand);
-		if (spell == null) return;
-		if (!spell.canCastWithItem()) return;
 
-		// First check global cooldown
-		if (MagicSpells.getGlobalCooldown() > 0 && !spell.isIgnoringGlobalCooldown()) {
-			if (noCastUntil.containsKey(player.getName()) && noCastUntil.get(player.getName()) > System.currentTimeMillis()) return;
-			noCastUntil.put(player.getName(), System.currentTimeMillis() + MagicSpells.getGlobalCooldown());
-		}
+		castSpell(player, spell);
+	}
+
+	private void castSpell(Player player, Spell spell) {
+		if (spell == null || !spell.canCastWithItem()) return;
+		if (!checkGlobalCooldown(player, spell)) return;
+
 		// Cast spell
 		spell.cast(player);
+	}
+
+	private boolean checkGlobalCooldown(Player player, Spell spell) {
+		if (MagicSpells.getGlobalCooldown() > 0 && !spell.isIgnoringGlobalCooldown()) {
+			if (noCastUntil.containsKey(player.getName()) && noCastUntil.get(player.getName()) > System.currentTimeMillis()) return false;
+			noCastUntil.put(player.getName(), System.currentTimeMillis() + MagicSpells.getGlobalCooldown());
+		}
+
+		return true;
 	}
 
 	private void showIcon(Player player, int slot, ItemStack icon) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -53,7 +53,6 @@ public class BowSpell extends Spell {
 	private Subspell spellOnHitEntity;
 	private Subspell spellOnHitGround;
 
-	private boolean canBind;
 	private boolean cancelShot;
 	private boolean denyOffhand;
 	private boolean removeArrow;
@@ -89,7 +88,7 @@ public class BowSpell extends Spell {
 		spellOnHitEntityName = getConfigString("spell-on-hit-entity", "");
 		spellOnHitGroundName = getConfigString("spell-on-hit-ground", "");
 
-		canBind = getConfigBoolean("can-bind", false);
+		bindable = getConfigBoolean("bindable", false);
 		cancelShot = getConfigBoolean("cancel-shot", true);
 		denyOffhand = getConfigBoolean("deny-offhand", false);
 		removeArrow = getConfigBoolean("remove-arrow", false);
@@ -136,7 +135,7 @@ public class BowSpell extends Spell {
 
 	@Override
 	public boolean canCastWithItem() {
-		return canBind;
+		return bindable;
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -14,6 +14,7 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.MetadataValue;
+import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.projectiles.ProjectileSource;
 import org.bukkit.event.entity.ProjectileHitEvent;
@@ -54,6 +55,7 @@ public class BowSpell extends Spell {
 
 	private boolean canBind;
 	private boolean cancelShot;
+	private boolean denyOffhand;
 	private boolean removeArrow;
 	private boolean requireBind;
 	private boolean useBowForce;
@@ -89,6 +91,7 @@ public class BowSpell extends Spell {
 
 		canBind = getConfigBoolean("can-bind", false);
 		cancelShot = getConfigBoolean("cancel-shot", true);
+		denyOffhand = getConfigBoolean("deny-offhand", false);
 		removeArrow = getConfigBoolean("remove-arrow", false);
 		requireBind = getConfigBoolean("require-bind", false);
 		useBowForce = getConfigBoolean("use-bow-force", true);
@@ -148,6 +151,7 @@ public class BowSpell extends Spell {
 	public void handleBowCast(EntityShootBowEvent event) {
 		if (!cancelShot && event.isCancelled()) return;
 		if (!(event.getProjectile() instanceof Arrow)) return;
+		if (denyOffhand && event.getHand() == EquipmentSlot.OFF_HAND) return;
 
 		LivingEntity caster = event.getEntity();
 		if (!triggerList.canTarget(caster, true)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -154,7 +154,7 @@ public class BowSpell extends Spell {
 		if (minimumForce != 0 && force < minimumForce) return;
 		if (maximumForce != 0 && force > maximumForce) return;
 
-		SpellCastEvent castEvent = preCast(caster, 1f, null);
+		SpellCastEvent castEvent = preCast(caster, useBowForce ? event.getForce() : 1f, null);
 		if (castEvent == null) {
 			if (cancelShotOnFail) event.setCancelled(true);
 			return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -213,7 +213,7 @@ public class BowSpell extends Spell {
 		postCast(castEvent, PostCastAction.HANDLE_NORMALLY);
 	}
 
-	public class ShootListener implements Listener {
+	private class ShootListener implements Listener {
 
 		@EventHandler
 		public void onArrowLaunch(EntityShootBowEvent event) {
@@ -222,7 +222,7 @@ public class BowSpell extends Spell {
 
 	}
 
-	public static class HitListener implements Listener {
+	private static class HitListener implements Listener {
 
 		@EventHandler(priority = EventPriority.MONITOR)
 		public void onArrowHitGround(ProjectileHitEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -91,7 +91,7 @@ public class BowSpell extends Spell {
 		cancelShotOnFail = getConfigBoolean("cancel-shot-on-fail", true);
 
 		minimumForce = getConfigFloat("minimum-force", 0F);
-		maximumForce = getConfigFloat("maximum-force", 0F);
+		maximumForce = getConfigFloat("maximum-force", 1F);
 
 		if (minimumForce < 0F) minimumForce = 0F;
 		else if (minimumForce > 1F) minimumForce = 1F;
@@ -150,11 +150,10 @@ public class BowSpell extends Spell {
 		if (disallowedBowNames != null && disallowedBowNames.contains(name)) return;
 		if (bowName != null && !bowName.isEmpty() && !bowName.equals(name)) return;
 
-		float force = (float) (FastMath.floor(event.getForce() * 100F) / 100F);
-		if (minimumForce != 0 && force < minimumForce) return;
-		if (maximumForce != 0 && force > maximumForce) return;
+		float force = event.getForce();
+		if (force < minimumForce || force > maximumForce) return;
 
-		SpellCastEvent castEvent = preCast(caster, useBowForce ? event.getForce() : 1f, null);
+		SpellCastEvent castEvent = preCast(caster, useBowForce ? force : 1f, null);
 		if (castEvent == null) {
 			if (cancelShotOnFail) event.setCancelled(true);
 			return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -182,7 +182,7 @@ public class BowSpell extends Spell {
 			if (!event.isCancelled()) {
 				Entity projectile = event.getProjectile();
 
-				ArrowData arrowData = new ArrowData(castEvent.getPower(), spellOnHitEntity, spellOnHitGround, this);
+				ArrowData arrowData = new ArrowData(this, castEvent.getPower());
 				List<ArrowData> arrowDataList = null;
 				if (projectile.hasMetadata(METADATA_KEY)) {
 					List<MetadataValue> metas = projectile.getMetadata(METADATA_KEY);
@@ -243,7 +243,8 @@ public class BowSpell extends Spell {
 				if (arrowDataList == null || arrowDataList.isEmpty()) break;
 
 				for (ArrowData data : arrowDataList) {
-					if (data.groundSpell == null) continue;
+					Subspell groundSpell = data.bowSpell.spellOnHitGround;
+					if (groundSpell == null) continue;
 
 					SpellTargetLocationEvent targetLocationEvent = new SpellTargetLocationEvent(data.bowSpell, caster, proj.getLocation(), data.power);
 					EventUtil.call(targetLocationEvent);
@@ -251,9 +252,9 @@ public class BowSpell extends Spell {
 						break;
 					}
 
-					if (data.groundSpell.isTargetedLocationSpell())
-						data.groundSpell.castAtLocation(caster, targetLocationEvent.getTargetLocation(), targetLocationEvent.getPower());
-					else data.groundSpell.cast(caster, targetLocationEvent.getPower());
+					if (groundSpell.isTargetedLocationSpell())
+						groundSpell.castAtLocation(caster, targetLocationEvent.getTargetLocation(), targetLocationEvent.getPower());
+					else groundSpell.cast(caster, targetLocationEvent.getPower());
 
 					if (data.bowSpell.removeArrow) remove = true;
 				}
@@ -288,7 +289,8 @@ public class BowSpell extends Spell {
 				if (arrowDataList == null || arrowDataList.isEmpty()) break;
 
 				for (ArrowData data : arrowDataList) {
-					if (data.entitySpell == null) continue;
+					Subspell entitySpell = data.bowSpell.spellOnHitEntity;
+					if (entitySpell == null) continue;
 
 					SpellTargetEvent targetEvent = new SpellTargetEvent(data.bowSpell, caster, target, data.power);
 					EventUtil.call(targetEvent);
@@ -297,13 +299,13 @@ public class BowSpell extends Spell {
 					}
 					target = targetEvent.getTarget();
 
-					if (data.entitySpell.isTargetedEntityFromLocationSpell())
-						data.entitySpell.castAtEntityFromLocation(caster, caster.getLocation(), target, targetEvent.getPower());
-					else if (data.entitySpell.isTargetedLocationSpell())
-						data.entitySpell.castAtLocation(caster, target.getLocation(), targetEvent.getPower());
-					else if (data.entitySpell.isTargetedEntitySpell())
-						data.entitySpell.castAtEntity(caster, target, targetEvent.getPower());
-					else data.entitySpell.cast(caster, targetEvent.getPower());
+					if (entitySpell.isTargetedEntityFromLocationSpell())
+						entitySpell.castAtEntityFromLocation(caster, caster.getLocation(), target, targetEvent.getPower());
+					else if (entitySpell.isTargetedLocationSpell())
+						entitySpell.castAtLocation(caster, target.getLocation(), targetEvent.getPower());
+					else if (entitySpell.isTargetedEntitySpell())
+						entitySpell.castAtEntity(caster, target, targetEvent.getPower());
+					else entitySpell.cast(caster, targetEvent.getPower());
 
 					if (data.bowSpell.removeArrow) remove = true;
 				}
@@ -319,16 +321,12 @@ public class BowSpell extends Spell {
 
 	private static class ArrowData {
 
-		private final Subspell entitySpell;
-		private final Subspell groundSpell;
 		private final BowSpell bowSpell;
 		private final float power;
 
-		ArrowData(float power, Subspell entitySpell, Subspell groundSpell, BowSpell bowSpell) {
-			this.power = power;
-			this.entitySpell = entitySpell;
-			this.groundSpell = groundSpell;
+		ArrowData(BowSpell bowSpell, float power) {
 			this.bowSpell = bowSpell;
+			this.power = power;
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -262,8 +262,8 @@ public class BowSpell extends Spell {
 				break;
 			}
 
-			if (remove) proj.remove();
 			proj.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+			if (remove) proj.remove();
 		}
 
 		@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
@@ -312,8 +312,8 @@ public class BowSpell extends Spell {
 				break;
 			}
 
-			if (remove) damager.remove();
 			damager.removeMetadata(METADATA_KEY, MagicSpells.plugin);
+			if (remove) damager.remove();
 		}
 
 	}

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -24,6 +24,7 @@ allow-cast-with-fist: false
 cast-with-left-click: true
 cast-with-right-click: false
 cycle-spells-with-offhand-action: false
+cast-bound-bow-spells-from-offhand: false
 ignore-default-bindings: false
 ignore-cast-item-enchants: true
 ignore-cast-item-names: false


### PR DESCRIPTION
Bugfixes:
- `use-bow-force` was accidentally removed.
- Casting triggered when shooting a bow now uses the bow that was shot from, instead of the item in the caster's mainhand.

Additions:
- Added option `cast-bound-bow-spells-from-offhand`. Disables casting triggered by shooting a bow in the offhand.
- Added option `deny-offhand` to `BowSpell`. Disables casting a `BowSpell` with a bow in the offhand.
- Added option `require-bind` to `BowSpell`. When `require-bind` is true, a `BowSpell` can only be cast when the spell is cast from a bow that has the `BowSpell` as its currently selected spell. `BowSpell` now uses already existing option `bindable` to determine if the spell is bindable, and is by default `false`.