### PR TITLE
SkinSpell bugfix

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1361,7 +1361,7 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(player);
 			}
 
-			matcher.appendReplacement(buf, TxtUtil.escapeMatcher(value));
+			matcher.appendReplacement(buf, Matcher.quoteReplacement(value));
 		}
 
 		return matcher.appendTail(buf).toString();
@@ -1395,7 +1395,7 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(variableOwnerName);
 			}
 
-			matcher.appendReplacement(buf, TxtUtil.escapeMatcher(value));
+			matcher.appendReplacement(buf, Matcher.quoteReplacement(value));
 		}
 
 		return matcher.appendTail(buf).toString();
@@ -1431,7 +1431,7 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(varOwner);
 			}
 
-			matcher.appendReplacement(buf, TxtUtil.escapeMatcher(value));
+			matcher.appendReplacement(buf, Matcher.quoteReplacement(value));
 		}
 
 		return matcher.appendTail(buf).toString();
@@ -1451,7 +1451,7 @@ public class MagicSpells extends JavaPlugin {
 			String newValue = matcher.group(2);
 			if (args != null && argIndex >= 0 && argIndex < args.length) newValue = args[argIndex];
 
-			matcher.appendReplacement(buf, TxtUtil.escapeMatcher(newValue));
+			matcher.appendReplacement(buf, Matcher.quoteReplacement(newValue));
 		}
 
 		return matcher.appendTail(buf).toString();

--- a/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
@@ -32,10 +32,6 @@ public class TxtUtil {
 	public static String escapeJSON(String str) {
 		return str.replaceAll("[\"\\\\]", "\\\\$0");
 	}
-
-	public static String escapeMatcher(String str) {
-		return str.replaceAll("[$\\\\]", "\\\\$0");
-	}
 	
 	public static List<String> tabCompleteSpellName(CommandSender sender, String partial) {
 		List<String> matches = new ArrayList<>();

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -684,7 +684,8 @@ public class Util {
 	}
 
 	public static void setSkin(Player player, String skin, String signature) {
-		setTexture(player.getPlayerProfile(), skin, signature);
+		PlayerProfile profile = setTexture(player.getPlayerProfile(), skin, signature);
+		player.setPlayerProfile(profile);
 	}
 
 	public static void setTexture(SkullMeta meta, String texture, String signature, String uuid, OfflinePlayer offlinePlayer) {


### PR DESCRIPTION
- `Util#setSkin` did not properly change the player's skin.
- Removed redundant utility method `TxtUtil#escapeMatcher`, as it can be replaced with `Matcher#quoteReplacement`.