### PR TITLE
CleanseSpell cleanup

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
@@ -206,7 +206,6 @@ public class CleanseSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (fire) target.setFireTicks(0);
 
 		for (PotionEffectType type : potionEffectTypes) {
-			target.addPotionEffect(new PotionEffect(type, 0, 0, true));
 			target.removePotionEffect(type);
 		}
 


### PR DESCRIPTION
- Remove unnecessary potion effect addition in `CleanseSpell`, which caused flickering potion effects.