### PR TITLE
Bugfixes & Additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MultiCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/MultiCondition.java
@@ -93,7 +93,19 @@ public class MultiCondition extends Condition implements IModifier {
 
 	@Override
 	public boolean check(LivingEntity livingEntity) {
-		return check(livingEntity, livingEntity);
+		int pass = 0;
+		int fail = 0;
+		for (Modifier m : modifiers) {
+			boolean check = m.check(livingEntity);
+			if (check) pass++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, livingEntity, null);
+			}
+			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
+		}
+		return passCondition.hasPassed(pass, fail);
 	}
 
 	@Override
@@ -101,9 +113,13 @@ public class MultiCondition extends Condition implements IModifier {
 		int pass = 0;
 		int fail = 0;
 		for (Modifier m : modifiers) {
-			boolean check = m.check(target);
+			boolean check = m.check(livingEntity, target);
 			if (check) pass++;
-			else fail++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, livingEntity, null);
+			}
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
 		return passCondition.hasPassed(pass, fail);
@@ -111,7 +127,19 @@ public class MultiCondition extends Condition implements IModifier {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, Location location) {
-		return false;
+		int pass = 0;
+		int fail = 0;
+		for (Modifier m : modifiers) {
+			boolean check = m.check(livingEntity, location);
+			if (check) pass++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, livingEntity, null);
+			}
+			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
+		}
+		return passCondition.hasPassed(pass, fail);
 	}
 
 	@Override
@@ -121,8 +149,11 @@ public class MultiCondition extends Condition implements IModifier {
 		for (Modifier m : modifiers) {
 			boolean check = m.apply(event);
 			if (check) pass++;
-			else fail++;
-
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, event.getCaster(), null);
+			}
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
 		return passCondition.hasPassed(pass, fail);
@@ -135,7 +166,11 @@ public class MultiCondition extends Condition implements IModifier {
 		for (Modifier m : modifiers) {
 			boolean check = m.apply(event);
 			if (check) pass++;
-			else fail++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, event.getPlayer(), null);
+			}
 
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
@@ -149,7 +184,11 @@ public class MultiCondition extends Condition implements IModifier {
 		for (Modifier m : modifiers) {
 			boolean check = m.apply(event);
 			if (check) pass++;
-			else fail++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, event.getCaster(), null);
+			}
 
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
@@ -163,7 +202,11 @@ public class MultiCondition extends Condition implements IModifier {
 		for (Modifier m : modifiers) {
 			boolean check = m.apply(event);
 			if (check) pass++;
-			else fail++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, event.getCaster(), null);
+			}
 
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
@@ -177,7 +220,11 @@ public class MultiCondition extends Condition implements IModifier {
 		for (Modifier m : modifiers) {
 			boolean check = m.apply(event);
 			if (check) pass++;
-			else fail++;
+			else {
+				fail++;
+				String msg = m.getStrModifierFailed();
+				if (msg != null) MagicSpells.sendMessage(msg, event.getPlayer(), null);
+			}
 
 			if (!passCondition.shouldContinue(pass, fail)) return passCondition.hasPassed(pass, fail);
 		}
@@ -211,7 +258,19 @@ public class MultiCondition extends Condition implements IModifier {
 				return passes == 0;
 			}
 		},
-		
+
+		NONE {
+			@Override
+			public boolean hasPassed(int passes, int fails) {
+				return passes == 0;
+			}
+
+			@Override
+			public boolean shouldContinue(int passes, int fails) {
+				return passes == 0;
+			}
+		},
+
 		XOR {
 
 			@Override

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -12,6 +12,7 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.FixedMetadataValue;
+import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
@@ -128,6 +129,9 @@ public class CastListener implements Listener {
 	public void onPlayerAnimation(PlayerAnimationEvent event) {
 		if (MagicSpells.isCastingOnAnimate()) {
 			Player player = event.getPlayer();
+
+			InventoryType type = player.getOpenInventory().getType();
+			if (type != InventoryType.CRAFTING && type != InventoryType.CREATIVE) return;
 
 			if (MagicSpells.areBowCycleButtonsReversed()) {
 				ItemStack inHand = player.getInventory().getItemInMainHand();

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -44,18 +44,40 @@ public class CastListener implements Listener {
 		if (event.getAction() == Action.RIGHT_CLICK_BLOCK) {
 			Material m = event.getClickedBlock().getType();
 			if (BlockUtils.isWoodDoor(m) ||
+					BlockUtils.isWoodFenceGate(m) ||
 					BlockUtils.isWoodTrapdoor(m) ||
+					BlockUtils.isShulkerBox(m) ||
 					BlockUtils.isWoodButton(m) ||
 					BlockUtils.isBed(m) ||
-					m == Material.CRAFTING_TABLE ||
+					m == Material.ANVIL ||
+					m == Material.BARREL ||
+					m == Material.BEACON ||
+					m == Material.BLAST_FURNACE ||
+					m == Material.BREWING_STAND ||
+					m == Material.CARTOGRAPHY_TABLE ||
 					m == Material.CHEST ||
-					m == Material.TRAPPED_CHEST ||
+					m == Material.CHIPPED_ANVIL ||
+					m == Material.COMPARATOR ||
+					m == Material.CRAFTING_TABLE ||
+					m == Material.DAYLIGHT_DETECTOR ||
+					m == Material.DAMAGED_ANVIL ||
+					m == Material.DISPENSER ||
+					m == Material.DROPPER ||
+					m == Material.ENCHANTING_TABLE ||
 					m == Material.ENDER_CHEST ||
 					m == Material.FURNACE ||
+					m == Material.GRINDSTONE ||
 					m == Material.HOPPER ||
 					m == Material.LEVER ||
+					m == Material.LOOM ||
+					m == Material.NOTE_BLOCK ||
+					m == Material.POLISHED_BLACKSTONE_BUTTON ||
+					m == Material.REPEATER ||
+					m == Material.SMITHING_TABLE ||
+					m == Material.SMOKER ||
+					m == Material.STONECUTTER ||
 					m == Material.STONE_BUTTON ||
-					m == Material.ENCHANTING_TABLE) {
+					m == Material.TRAPPED_CHEST) {
 				noInteract = true;
 			} else if (event.hasItem() && event.getItem().getType().isBlock()) {
 				noInteract = true;

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -77,13 +77,13 @@ public class CastListener implements Listener {
 		}
 
 		if (isEventCycleAction(event) && (MagicSpells.isCyclingSpellsOnOffhandAction() || event.getHand() == EquipmentSlot.HAND)) {
-			ItemStack inHand = player.getEquipment().getItemInMainHand();
+			ItemStack inHand = player.getInventory().getItemInMainHand();
 			
-			if (inHand != null && isBow(inHand.getType())) {
+			if (isBow(inHand.getType())) {
 				if (!MagicSpells.canBowCycleSpellsSneaking() && player.isSneaking()) return;
 			}
 			
-			if ((inHand != null && !BlockUtils.isAir(inHand.getType())) || MagicSpells.canCastWithFist()) {
+			if ((!BlockUtils.isAir(inHand.getType())) || MagicSpells.canCastWithFist()) {
 				// Cycle spell
 				Spell spell;
 				if (!player.isSneaking()) spell = MagicSpells.getSpellbook(player).nextSpell(inHand);
@@ -126,7 +126,16 @@ public class CastListener implements Listener {
 
 	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerAnimation(PlayerAnimationEvent event) {
-		if (MagicSpells.isCastingOnAnimate()) castSpell(event.getPlayer());
+		if (MagicSpells.isCastingOnAnimate()) {
+			Player player = event.getPlayer();
+
+			if (MagicSpells.areBowCycleButtonsReversed()) {
+				ItemStack inHand = player.getInventory().getItemInMainHand();
+				if (isBow(inHand.getType())) return;
+			}
+
+			castSpell(player);
+		}
 	}
 	
 	@EventHandler

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -103,7 +103,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 		if (!spellNameOnBreak.isEmpty()) {
 			spellOnBreak = new Subspell(spellNameOnBreak);
-			if (!spellOnBreak.process() || !spellOnBreak.isTargetedLocationSpell()) {
+			if (!spellOnBreak.process()) {
 				MagicSpells.error("PulserSpell '" + internalName + "' has an invalid spell-on-break defined");
 				spellOnBreak = null;
 			}
@@ -298,7 +298,10 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			if (!block.getWorld().isChunkLoaded(block.getX() >> 4, block.getZ() >> 4)) block.getChunk().load();
 			block.setType(Material.AIR);
 			playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation());
-			if (spellOnBreak != null) spellOnBreak.castAtLocation(caster, location, power);
+			if (spellOnBreak != null) {
+				if (spellOnBreak.isTargetedLocationSpell()) spellOnBreak.castAtLocation(caster, location, power);
+				else spellOnBreak.cast(caster, power);
+			}
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
@@ -131,6 +131,8 @@ public class BlockUtils {
 			case SPRUCE_DOOR:
 			case DARK_OAK_DOOR:
 			case BIRCH_DOOR:
+			case CRIMSON_DOOR:
+			case WARPED_DOOR:
 				return true;
 		}
 		return false;
@@ -144,6 +146,8 @@ public class BlockUtils {
 			case SPRUCE_BUTTON:
 			case DARK_OAK_BUTTON:
 			case BIRCH_BUTTON:
+			case CRIMSON_BUTTON:
+			case WARPED_BUTTON:
 				return true;
 		}
 		return false;
@@ -157,6 +161,8 @@ public class BlockUtils {
 			case SPRUCE_PRESSURE_PLATE:
 			case DARK_OAK_PRESSURE_PLATE:
 			case BIRCH_PRESSURE_PLATE:
+			case CRIMSON_PRESSURE_PLATE:
+			case WARPED_PRESSURE_PLATE:
 				return true;
 		}
 		return false;
@@ -170,6 +176,49 @@ public class BlockUtils {
 			case SPRUCE_TRAPDOOR:
 			case BIRCH_TRAPDOOR:
 			case DARK_OAK_TRAPDOOR:
+			case CRIMSON_TRAPDOOR:
+			case WARPED_TRAPDOOR:
+				return true;
+		}
+		return false;
+	}
+
+	public static boolean isWoodFenceGate(Material m) {
+		switch (m) {
+			case OAK_FENCE_GATE:
+			case ACACIA_FENCE_GATE:
+			case JUNGLE_FENCE_GATE:
+			case SPRUCE_FENCE_GATE:
+			case BIRCH_FENCE_GATE:
+			case DARK_OAK_FENCE_GATE:
+			case CRIMSON_FENCE_GATE:
+			case WARPED_FENCE_GATE:
+				return true;
+		}
+		return false;
+	}
+
+	public static boolean isShulkerBox(Material m) {
+		switch (m) {
+			case BLACK_SHULKER_BOX:
+			case BLUE_SHULKER_BOX:
+			case BROWN_SHULKER_BOX:
+			case CYAN_SHULKER_BOX:
+			case GRAY_SHULKER_BOX:
+			case GREEN_SHULKER_BOX:
+			case LIGHT_BLUE_SHULKER_BOX:
+			case LIGHT_GRAY_SHULKER_BOX:
+			case LIME_SHULKER_BOX:
+			case MAGENTA_SHULKER_BOX:
+			case ORANGE_SHULKER_BOX:
+			case PINK_SHULKER_BOX:
+			case PURPLE_SHULKER_BOX:
+			case RED_SHULKER_BOX:
+			case SHULKER_BOX:
+			case SHULKER_SHELL:
+			case SHULKER_SPAWN_EGG:
+			case WHITE_SHULKER_BOX:
+			case YELLOW_SHULKER_BOX:
 				return true;
 		}
 		return false;


### PR DESCRIPTION
Bugfixes:
- No longer cast on animate with bows if option `reverse-bow-cycle-buttons` is `true`.
- No longer cast on animate if the player has an inventory open (such as when opening or dropping items from containers).
- `MultiCondition` did not send modifier fail strings.
- `MultiCondition#check(LivingEntity, Location)` is now properly implemented.

Additions:
- Added more blocks to the list of interactable blocks in `CastListener`.
- `spell-on-break` in `PulserSpell` no longer needs to be a `TargetedLocationSpell`.
- New `MultiCondition` pass condition, `NONE`. Passes if none of the modifier checks pass.