### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1797,7 +1797,6 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		sendMessageNear(livingEntity, null, message, broadcastRange, MagicSpells.NULL_ARGS);
 	}
 
-	// TODO can this safely be made varargs?
 	/**
 	 * Sends a message to all players near the specified player, within the specified broadcast range.
 	 * @param livingEntity the "center" living entity used to find nearby players
@@ -1805,20 +1804,30 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 * @param range the broadcast range
 	 */
 	protected void sendMessageNear(LivingEntity livingEntity, Player ignore, String message, int range, String[] args) {
+		sendMessageNear(livingEntity, ignore, message, range, args, (String[]) null);
+	}
+
+	/**
+	 * Sends a message to all players near the specified player, within the specified broadcast range.
+	 * @param livingEntity the "center" living entity used to find nearby players
+	 * @param ignore player to ignore when sending messages
+	 * @param message the message to send
+	 * @param range the broadcast range
+	 * @param args cast arguments
+	 * @param replacements replacements to be done on message
+	 */
+	protected void sendMessageNear(LivingEntity livingEntity, Player ignore, String message, int range, String[] args, String... replacements) {
 		if (message == null) return;
 		if (message.isEmpty()) return;
 		if (Perm.SILENT.has(livingEntity)) return;
 
 		int rangeDoubled = range << 1;
-		List<Entity> entities = livingEntity.getNearbyEntities(rangeDoubled, rangeDoubled, rangeDoubled);
-		for (Entity entity : entities) {
-			if (!(entity instanceof Player)) continue;
-			if (entity == livingEntity) continue;
-			if (entity == ignore) continue;
-			for (String msg : message.split("\n")) {
-				if (msg.isEmpty()) continue;
-				entity.sendMessage(Util.colorize(MagicSpells.getTextColor() + msg));
-			}
+		Collection<Player> players = livingEntity.getLocation().getNearbyPlayers(rangeDoubled);
+		for (Player player : players) {
+			if (player == livingEntity) continue;
+			if (player == ignore) continue;
+
+			sendMessage(message, player, args, replacements);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -301,10 +301,10 @@ public class BowSpell extends Spell {
 
 					if (entitySpell.isTargetedEntityFromLocationSpell())
 						entitySpell.castAtEntityFromLocation(caster, caster.getLocation(), target, targetEvent.getPower());
-					else if (entitySpell.isTargetedLocationSpell())
-						entitySpell.castAtLocation(caster, target.getLocation(), targetEvent.getPower());
 					else if (entitySpell.isTargetedEntitySpell())
 						entitySpell.castAtEntity(caster, target, targetEvent.getPower());
+					else if (entitySpell.isTargetedLocationSpell())
+						entitySpell.castAtLocation(caster, target.getLocation(), targetEvent.getPower());
 					else entitySpell.cast(caster, targetEvent.getPower());
 
 					if (data.bowSpell.removeArrow) remove = true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -76,7 +76,8 @@ public abstract class TargetedSpell extends InstantSpell {
 			sendMessage(prepareMessage(strCastTarget, playerCaster, playerTarget), target, args,
 				"%a", casterName, "%t", targetName);
 
-		sendMessageNear(caster, playerTarget, prepareMessage(strCastOthers, playerCaster, playerTarget), broadcastRange, args);
+		sendMessageNear(caster, playerTarget, prepareMessage(strCastOthers, playerCaster, playerTarget), broadcastRange, args,
+			"%a", casterName, "%t", targetName);
 	}
 	
 	private String prepareMessage(String message, Player caster, Player playerTarget) {


### PR DESCRIPTION
- Fix subspell casting order in `BowSpell`. Previously would attempt to cast `spell-on-hit-entity` as a targeted location spell before trying to cast it as a targeted entity spell.
- `%a` and `%t` replacements and argument/variable substitution now work for `str-cast-others` for targeted spells.