### PR TITLE
Use namespace key instead of type for spawn egg items

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
@@ -38,7 +38,7 @@ public class MobUtil {
 	}
 
 	public static ItemStack getEggItemForEntityType(EntityType type) {
-		Material eggMaterial = Util.getMaterial(type.name() + "_SPAWN_EGG");
+		Material eggMaterial = Util.getMaterial(type.getKey().getKey() + "_SPAWN_EGG");
 		if (eggMaterial == null) return null;
 
 		return new ItemStack(eggMaterial);


### PR DESCRIPTION
- Namespace key works for all current spawn egg material types. Type name fails for mobs such as mooshrooms.