### PR TITLE
New Pathfind Util + HasScoreboard reversion

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
@@ -25,7 +25,7 @@ public class HasScoreboardTagCondition extends Condition {
 
     @Override
     public boolean check(LivingEntity caster, LivingEntity target) {
-        return checkTags(target);
+        return checkTags(caster);
     }
 
     @Override
@@ -33,10 +33,11 @@ public class HasScoreboardTagCondition extends Condition {
         return false;
     }
 
-    private boolean checkTags(LivingEntity entity) {
+    // TODO: Add functionality to check both caster and target variables
+    private boolean checkTags(LivingEntity caster) {
         String localTag = tag;
-        if (entity instanceof Player && localTag.contains("%")) localTag = MagicSpells.doVariableReplacements((Player) entity, localTag);
-        return entity.getScoreboardTags().contains(localTag);
+        if (localTag.contains("%")) localTag = MagicSpells.doVariableReplacements((Player) caster, localTag);
+        return caster.getScoreboardTags().contains(localTag);
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/ai/PathToGoal.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ai/PathToGoal.java
@@ -1,0 +1,75 @@
+package com.nisovin.magicspells.util.ai;
+
+import java.util.EnumSet;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Mob;
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.LivingEntity;
+
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
+
+import com.nisovin.magicspells.MagicSpells;
+
+public class PathToGoal implements Goal<Mob> {
+
+    private final Mob mob;
+
+    private LivingEntity target;
+    private double speed;
+
+    public PathToGoal(@NotNull Mob mob, @NotNull LivingEntity target, double speed) {
+        this.target = target;
+        this.speed = speed;
+        this.mob = mob;
+    }
+
+    public void setTarget(LivingEntity target) {
+        this.target = target;
+    }
+
+    public void setSpeed(double speed) {
+        this.speed = speed;
+    }
+
+    @Override
+    public boolean shouldActivate() {
+        return target != null && target.isValid() && !target.isDead();
+    }
+
+    @Override
+    public boolean shouldStayActive() {
+        if (target == null || !target.isValid() || target.isDead()) return false;
+
+        Location mobLocation = mob.getLocation();
+        Location targetLocation = target.getLocation();
+        return mobLocation.getWorld().equals(targetLocation.getWorld()) && mobLocation.distanceSquared(targetLocation) > 4;
+    }
+
+    @Override
+    public void stop() {
+        target = null;
+    }
+
+    @Override
+    public void tick() {
+        mob.getPathfinder().moveTo(target, speed);
+    }
+
+    @NotNull
+    @Override
+    public GoalKey<Mob> getKey() {
+        return GoalKey.of(Mob.class, new NamespacedKey(MagicSpells.getInstance(), "pathto"));
+    }
+
+    @NotNull
+    @Override
+    public EnumSet<GoalType> getTypes() {
+        return EnumSet.of(GoalType.MOVE);
+    }
+
+}


### PR DESCRIPTION
Pathfinding util allows entities to pathfind towards a target.

`HasScoreboardTag` modifier has been reverted to normal usage. Please do not make sudden changes like this as it breaks servers.