### PR TITLE
Refactored GlowSpell using GlowAPI

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -15,7 +15,6 @@ repositories {
 dependencies {
     shadow group: "org.apache.commons", name: "commons-math3", version: "3.6.1"
     shadow "com.elmakers.mine.bukkit:EffectLib:9.0"
-    shadow "com.github.Xezard:XGlow:c886344de3"
     shadow "com.github.PaperMC:PaperLib:master-SNAPSHOT"
     shadow "co.aikar:acf-paper:0.5.0-SNAPSHOT"
     shadow "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
@@ -33,6 +32,7 @@ dependencies {
     implementation "com.github.EngineHub:WorldGuard:528ba32a93"
     implementation "com.github.PlaceholderAPI:PlaceholderAPI:c2ab9f5b85"
     implementation "com.github.TechFortress:GriefPrevention:master-SNAPSHOT"
+    implementation "com.github.metalshark:GlowAPI:2.0.0"
 }
 
 shadowJar {

--- a/core/src/main/java/com/nisovin/magicspells/events/BuffEndEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/BuffEndEvent.java
@@ -1,0 +1,62 @@
+package com.nisovin.magicspells.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.entity.LivingEntity;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.spells.BuffSpell;
+
+/**
+ * This event is fired whenever a buff spell ends.
+ */
+public class BuffEndEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+
+	private final LivingEntity caster;
+	private final LivingEntity target;
+	private final BuffSpell buffSpell;
+
+	public BuffEndEvent(LivingEntity target, BuffSpell buffSpell) {
+		this.caster = buffSpell.getLastCaster(target);
+		this.target = target;
+		this.buffSpell = buffSpell;
+	}
+
+	/**
+	 * Gets the caster of the buff
+	 * @return the caster
+	 */
+	public LivingEntity getCaster() {
+		return caster;
+	}
+
+	/**
+	 * Gets the target of the buff
+	 * @return the target
+	 */
+	public LivingEntity getTarget() {
+		return target;
+	}
+
+	/**
+	 * Gets the buff spell which started
+	 * @return the spell
+	 */
+	public BuffSpell getBuffSpell() {
+		return buffSpell;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/events/BuffStartEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/BuffStartEvent.java
@@ -1,0 +1,62 @@
+package com.nisovin.magicspells.events;
+
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+import org.bukkit.entity.LivingEntity;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.spells.BuffSpell;
+
+/**
+ * This event is fired whenever a buff spell starts.
+ */
+public class BuffStartEvent extends Event {
+
+	private static final HandlerList handlers = new HandlerList();
+
+	private final LivingEntity caster;
+	private final LivingEntity target;
+	private final BuffSpell buffSpell;
+
+	public BuffStartEvent(LivingEntity target, BuffSpell buffSpell) {
+		this.caster = buffSpell.getLastCaster(target);
+		this.target = target;
+		this.buffSpell = buffSpell;
+	}
+
+	/**
+	 * Gets the caster of the buff
+	 * @return the caster
+	 */
+	public LivingEntity getCaster() {
+		return caster;
+	}
+
+	/**
+	 * Gets the target of the buff
+	 * @return the target
+	 */
+	public LivingEntity getTarget() {
+		return target;
+	}
+
+	/**
+	 * Gets the buff spell which started
+	 * @return the spell
+	 */
+	public BuffSpell getBuffSpell() {
+		return buffSpell;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return handlers;
+	}
+
+	public static HandlerList getHandlerList() {
+		return handlers;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -263,7 +263,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 			float dur = duration;
 			if (powerAffectsDuration) dur *= power;
-			durationEndTime.put(livingEntity.getUniqueId(), System.currentTimeMillis() + Math.round(dur * TimeUtil.MILLISECONDS_PER_SECOND));
+			setDuration(livingEntity, dur);
 
 			MagicSpells.scheduleDelayedTask(() -> {
 				if (isExpired(livingEntity)) turnOff(livingEntity);
@@ -274,6 +274,11 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 		BuffManager manager = MagicSpells.getBuffManager();
 		if (manager != null) manager.addBuff(livingEntity, this);
+	}
+
+	public void setDuration(LivingEntity livingEntity, float duration) {
+		long endTime = System.currentTimeMillis() + Math.round(duration * TimeUtil.MILLISECONDS_PER_SECOND);
+		durationEndTime.put(livingEntity.getUniqueId(), endTime);
 	}
 
 	public float getDuration(LivingEntity livingEntity) {

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/BuffManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/BuffManager.java
@@ -9,6 +9,9 @@ import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.BuffSpell;
+import com.nisovin.magicspells.events.BuffEndEvent;
+import com.nisovin.magicspells.events.BuffStartEvent;
+import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 
 public class BuffManager {
@@ -32,6 +35,7 @@ public class BuffManager {
 		buffs.add(spell);
 
 		monitor.run();
+		EventUtil.call(new BuffStartEvent(entity, spell));
 	}
 
 	public void removeBuff(LivingEntity entity, BuffSpell spell) {
@@ -39,6 +43,7 @@ public class BuffManager {
 		if (buffs == null) return;
 		buffs.remove(spell);
 		if (buffs.isEmpty()) activeBuffs.remove(entity);
+		EventUtil.call(new BuffEndEvent(entity, spell));
 	}
 
 	public Map<LivingEntity, Set<BuffSpell>> getActiveBuffs() {

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordXVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordXVariable.java
@@ -11,8 +11,11 @@ public class BedCoordXVariable extends MetaVariable {
 	@Override
 	public double getValue(String player) {
 		Player p = PlayerNameUtils.getPlayerExact(player);
-		if (p != null) return p.getBedSpawnLocation().getX();
-		return 0D;
+		if (p == null) return 0D;
+
+		Location bedSpawnLocation = p.getBedSpawnLocation();
+		if (bedSpawnLocation != null) return bedSpawnLocation.getX();
+		return p.getWorld().getSpawnLocation().getX();
 	}
 	
 	@Override
@@ -21,6 +24,7 @@ public class BedCoordXVariable extends MetaVariable {
 		if (p == null) return;
 
 		Location to = p.getBedSpawnLocation();
+		if (to == null) return;
 		to.setX(amount);
 		p.setBedSpawnLocation(to, true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordYVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordYVariable.java
@@ -11,8 +11,11 @@ public class BedCoordYVariable extends MetaVariable {
 	@Override
 	public double getValue(String player) {
 		Player p = PlayerNameUtils.getPlayerExact(player);
-		if (p != null) return p.getBedSpawnLocation().getY();
-		return 0D;
+		if (p == null) return 0D;
+
+		Location bedSpawnLocation = p.getBedSpawnLocation();
+		if (bedSpawnLocation != null) return bedSpawnLocation.getY();
+		return p.getWorld().getSpawnLocation().getY();
 	}
 	
 	@Override
@@ -21,6 +24,7 @@ public class BedCoordYVariable extends MetaVariable {
 		if (p == null) return;
 
 		Location to = p.getBedSpawnLocation();
+		if (to == null) return;
 		to.setY(amount);
 		p.setBedSpawnLocation(to, true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordZVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/BedCoordZVariable.java
@@ -11,8 +11,11 @@ public class BedCoordZVariable extends MetaVariable {
 	@Override
 	public double getValue(String player) {
 		Player p = PlayerNameUtils.getPlayerExact(player);
-		if (p != null) return p.getBedSpawnLocation().getZ();
-		return 0D;
+		if (p == null) return 0D;
+
+		Location bedSpawnLocation = p.getBedSpawnLocation();
+		if (bedSpawnLocation != null) return bedSpawnLocation.getZ();
+		return p.getWorld().getSpawnLocation().getZ();
 	}
 	
 	@Override
@@ -21,6 +24,7 @@ public class BedCoordZVariable extends MetaVariable {
 		if (p == null) return;
 
 		Location to = p.getBedSpawnLocation();
+		if (to == null) return;
 		to.setZ(amount);
 		p.setBedSpawnLocation(to, true);
 	}


### PR DESCRIPTION
* Added `BuffStartEvent` and `BuffEndEvent`.
* The Glow spell has been refactored to use the [GlowAPI](https://github.com/metalshark/GlowAPI/) plugin. Removed `async`, `update-period`, and `colors` properties, added `visible-to-target` and `color`.

### New documentation:
* Glow Spell (Targeted Entity Spell, `.targeted.ext.GlowSpell`):
  * `toggle` - (Boolean, false)
  * `duration` - (Integer, 0) - In server ticks. 0 defines everlasting duration.
  * `client-side` - (Boolean, false)
  * `visible-to-target` - (Boolean, false)
  * `color` - (String, white) - [List of colors](https://github.com/metalshark/GlowAPI/blob/master/src/main/java/org/inventivetalent/glow/GlowAPI.java#L74).