### PR TITLE
Passive trigger fixes and cleanup, options to hide or remove boss bars in BossBarEffect

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
@@ -38,7 +38,6 @@ public class BossBarEffect extends SpellEffect {
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		namespaceKey = config.getString("namespace-key");
-
 		if (namespaceKey != null && !MagicSpells.getBossBarManager().isNamespaceKey(namespaceKey)) {
 			MagicSpells.error("Wrong namespace-key defined! '" + namespaceKey + "'");
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
@@ -31,17 +31,23 @@ public class BossBarEffect extends SpellEffect {
 	private int duration;
 	private double progress;
 
+	private boolean remove;
+	private boolean visible;
 	private boolean broadcast;
 
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		namespaceKey = config.getString("namespace-key");
+		remove = config.getBoolean("remove", false);
+		if (remove) return;
+
 		title = config.getString("title", "");
 		color = config.getString("color", "red");
 		style = config.getString("style", "solid");
 		strVar = config.getString("variable", "");
 		maxValue = config.getDouble("max-value", 100);
 		maxVar = config.getString("max-variable", "");
+		visible = config.getBoolean("visible", true);
 
 		if (namespaceKey != null && !MagicSpells.getBossBarManager().isNamespaceKey(namespaceKey)) {
 			MagicSpells.error("Wrong namespace-key defined! '" + namespaceKey + "'");
@@ -72,7 +78,9 @@ public class BossBarEffect extends SpellEffect {
 	@Override
 	public void initializeModifiers() {
 		super.initializeModifiers();
-		
+
+		if (remove) return;
+
 		variable = MagicSpells.getVariableManager().getVariable(strVar);
 		if (variable == null && !strVar.isEmpty()) {
 			MagicSpells.error("Wrong variable defined! '" + strVar + "'");
@@ -93,31 +101,23 @@ public class BossBarEffect extends SpellEffect {
 	}
 
 	private void createBar(Player player) {
-		Bar bar = MagicSpells.getBossBarManager().getBar(player, namespaceKey);
-		String newTitle = Util.doVarReplacementAndColorize(player, title);
-		if (maxVariable == null) {
-			// Not doing max variable replacement
-			if (variable == null) bar.set(newTitle, progress, barStyle, barColor);
-			else {
-				double diff = variable.getValue(player) / maxValue;
-				if (diff >= 0 && diff <= 1) bar.set(newTitle, diff, barStyle, barColor);
-			}
-		} else {
-			// Doing max variable replacement
-			if (variable == null) {
-				double diff = progress / maxVariable.getValue(player);
-				if (diff >= 0 && diff <= 1) bar.set(newTitle, diff, barStyle, barColor);
-			} else {
-				// Doing double replacement!
-				double diff = variable.getValue(player) / maxVariable.getValue(player);
-				if (maxVariable.getValue(player) <= variable.getValue(player)) {
-					bar.set(newTitle, 1, barStyle, barColor);
-				}
-				if (maxVariable.getValue(player) > variable.getValue(player)) {
-					if (diff >= 0 && diff <= 1) bar.set(newTitle, diff, barStyle, barColor);
-				}
-			}
+		Bar bar = MagicSpells.getBossBarManager().getBar(player, namespaceKey, !remove);
+		if (remove) {
+			if (bar != null) bar.remove();
+			return;
 		}
+
+		double progress = this.progress;
+		if (variable != null) {
+			progress = variable.getValue(player) / (maxVariable == null ? maxValue : maxVariable.getValue(player));
+
+			if (progress < 0d) progress = 0d;
+			if (progress > 1d) progress = 1d;
+		}
+
+		String title = Util.doVarReplacementAndColorize(player, this.title);
+		bar.set(title, progress, barStyle, barColor, visible);
+
 		if (duration > 0) MagicSpells.scheduleDelayedTask(bar::remove, duration);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BossBarEffect.java
@@ -38,6 +38,11 @@ public class BossBarEffect extends SpellEffect {
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		namespaceKey = config.getString("namespace-key");
+
+		if (namespaceKey != null && !MagicSpells.getBossBarManager().isNamespaceKey(namespaceKey)) {
+			MagicSpells.error("Wrong namespace-key defined! '" + namespaceKey + "'");
+		}
+
 		remove = config.getBoolean("remove", false);
 		if (remove) return;
 
@@ -48,10 +53,6 @@ public class BossBarEffect extends SpellEffect {
 		maxValue = config.getDouble("max-value", 100);
 		maxVar = config.getString("max-variable", "");
 		visible = config.getBoolean("visible", true);
-
-		if (namespaceKey != null && !MagicSpells.getBossBarManager().isNamespaceKey(namespaceKey)) {
-			MagicSpells.error("Wrong namespace-key defined! '" + namespaceKey + "'");
-		}
 
 		try {
 			barColor = BarColor.valueOf(color.toUpperCase());

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BlockBreakListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BlockBreakListener.java
@@ -29,29 +29,19 @@ public class BlockBreakListener extends PassiveListener {
 			materials.add(m);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onBlockBreak(BlockBreakEvent event) {
-		Player player = event.getPlayer();
-		Block block = event.getBlock();
-
-		if (!hasSpell(player)) return;
-
-		// all blocks if its empty
-		if (materials.isEmpty()) {
-			if (!isCancelStateOk(event.isCancelled())) return;
-			boolean casted = passiveSpell.activate(player, block.getLocation().add(0.5, 0.5, 0.5));
-			if (cancelDefaultAction(casted)) event.setCancelled(true);
-
-			return;
-		}
-
-		// check if block type is valid
-		if (!materials.contains(block.getType())) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player, event.getBlock().getLocation().add(0.5, 0.5, 0.5));
+
+		Player player = event.getPlayer();
+		if (!hasSpell(player) || !canTrigger(player)) return;
+
+		Block block = event.getBlock();
+		if (!materials.isEmpty() && !materials.contains(block.getType())) return;
+
+		boolean casted = passiveSpell.activate(player, block.getLocation().add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BlockPlaceListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BlockPlaceListener.java
@@ -16,7 +16,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class BlockPlaceListener extends PassiveListener {
 
 	private final EnumSet<Material> materials = EnumSet.noneOf(Material.class);
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
@@ -29,27 +29,19 @@ public class BlockPlaceListener extends PassiveListener {
 			materials.add(m);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onBlockPlace(BlockPlaceEvent event) {
-		Player player = event.getPlayer();
-		Block block = event.getBlock();
-		if (!hasSpell(player)) return;
-
-		// all blocks if its empty
-		if (materials.isEmpty()) {
-			if (!isCancelStateOk(event.isCancelled())) return;
-			boolean casted = passiveSpell.activate(player, block.getLocation().add(0.5, 0.5, 0.5));
-			if (cancelDefaultAction(casted)) event.setCancelled(true);
-			return;
-		}
-
-		// check if block type is valid
-		if (!materials.contains(block.getType())) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player, event.getBlock().getLocation().add(0.5, 0.5, 0.5));
+
+		Player player = event.getPlayer();
+		if (!hasSpell(player) || !canTrigger(player)) return;
+
+		Block block = event.getBlock();
+		if (!materials.isEmpty() && !materials.contains(block.getType())) return;
+
+		boolean casted = passiveSpell.activate(player, block.getLocation().add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
@@ -3,59 +3,61 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
-import org.bukkit.entity.Player;
+import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.inventory.CraftItemEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class CraftListener extends PassiveListener {
 
-	private final Set<ItemStack> items = new HashSet<>();
+	private final Set<MagicItemData> items = new HashSet<>();
 
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
-		for (String itemString : var.split(",")) {
-			MagicItem magicItem = MagicItems.getMagicItemFromString(itemString.trim());
-			if (magicItem == null) continue;
+		for (String s : var.split("\\|")) {
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid damage cause or magic item '" + s + "' in craft trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
-			ItemStack item = magicItem.getItemStack();
-			if (item == null) continue;
-
-			items.add(item);
+			items.add(itemData);
 		}
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onCraft(CraftItemEvent event) {
-		ItemStack item = event.getCurrentItem();
-		if (item == null || item.getType().isAir()) return;
+		if (!isCancelStateOk(event.isCancelled())) return;
 
-		Player player = (Player) event.getWhoClicked();
-		if (!hasSpell(player)) return;
+		HumanEntity caster = event.getWhoClicked();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
-		// all items
-		if (items.isEmpty()) {
-			if (!isCancelStateOk(event.isCancelled())) return;
-			boolean casted = passiveSpell.activate(player);
-			if (cancelDefaultAction(casted)) event.setCancelled(true);
+		if (!items.isEmpty()) {
+			ItemStack item = event.getCurrentItem();
+			if (item == null) return;
 
-			return;
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
 		}
 
-		// doesn't contain the item
-		if (!items.contains(item)) return;
-
-		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	private boolean contains(MagicItemData itemData) {
+		for (MagicItemData data : items) {
+			if (data.matches(itemData)) return true;
+		}
+		return false;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
@@ -25,7 +25,7 @@ public class CraftListener extends PassiveListener {
 		for (String s : var.split("\\|")) {
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
 			if (itemData == null) {
-				MagicSpells.error("Invalid damage cause or magic item '" + s + "' in craft trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				MagicSpells.error("Invalid magic item '" + s + "' in craft trigger on passive spell '" + passiveSpell.getInternalName() + "'");
 				continue;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
@@ -29,6 +29,9 @@ public class CraftListener extends PassiveListener {
 				continue;
 			}
 
+			itemData = itemData.clone();
+			itemData.getIgnoredAttributes().add(MagicItemData.MagicItemAttribute.AMOUNT);
+
 			items.add(itemData);
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/DeathListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/DeathListener.java
@@ -14,13 +14,13 @@ public class DeathListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDeath(EntityDeathEvent event) {
 		LivingEntity entity = event.getEntity();
-		if (!canTrigger(entity)) return;
-		if (!hasSpell(entity)) return;
+		if (!hasSpell(entity) || !canTrigger(entity)) return;
+
 		passiveSpell.activate(entity);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/EnterBedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/EnterBedListener.java
@@ -14,16 +14,17 @@ public class EnterBedListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDeath(PlayerBedEnterEvent event) {
-		Player player = event.getPlayer();
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
+
+		Player player = event.getPlayer();
+		if (!hasSpell(player) || !canTrigger(player)) return;
+
 		boolean casted = passiveSpell.activate(player);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
@@ -19,17 +19,15 @@ public class FatalDamageListener extends PassiveListener {
 	@EventHandler
 	void onDamage(EntityDamageEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-
-		if (event.getFinalDamage() < entity.getHealth()) return;
-		if (!canTrigger(entity)) return;
-		if (!hasSpell(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
 
-		event.setCancelled(true);
+		LivingEntity caster = (LivingEntity) event.getEntity();
+
+		if (event.getFinalDamage() < caster.getHealth()) return;
+		if (!canTrigger(caster) || !hasSpell(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FoodLevelChangeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FoodLevelChangeListener.java
@@ -1,17 +1,39 @@
 package com.nisovin.magicspells.spells.passive;
 
+import java.util.Set;
+import java.util.HashSet;
+
 import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.entity.FoodLevelChangeEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class FoodLevelChangeListener extends PassiveListener {
 
+	private final Set<MagicItemData> items = new HashSet<>();
+
 	@Override
 	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
 
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in foodlevelchange trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
+
+			items.add(itemData);
+		}
 	}
 
 	@OverridePriority
@@ -22,8 +44,23 @@ public class FoodLevelChangeListener extends PassiveListener {
 		HumanEntity caster = event.getEntity();
 		if (!canTrigger(caster) || !hasSpell(caster)) return;
 
+		if (!items.isEmpty()) {
+			ItemStack item = event.getItem();
+			if (item == null) return;
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+			if (itemData == null || !contains(itemData)) return;
+		}
+
 		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	private boolean contains(MagicItemData itemData) {
+		for (MagicItemData data : items) {
+			if (data.matches(itemData)) return true;
+		}
+		return false;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
@@ -53,7 +53,7 @@ public class GiveDamageListener extends PassiveListener {
 			items.add(itemData);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDamage(EntityDamageByEntityEvent event) {
@@ -77,7 +77,7 @@ public class GiveDamageListener extends PassiveListener {
 		boolean casted = passiveSpell.activate(caster, attacked);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
-	
+
 	private LivingEntity getAttacker(EntityDamageByEntityEvent event) {
 		Entity e = event.getDamager();
 		if (e instanceof LivingEntity) return (LivingEntity) e;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
@@ -14,9 +14,9 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class InventoryClickListener extends PassiveListener {
 
-	MagicItemData itemCurrent = null;
-	MagicItemData itemCursor = null;
-	InventoryAction action = null;
+	private MagicItemData itemCurrent = null;
+	private MagicItemData itemCursor = null;
+	private InventoryAction action = null;
 
 	@Override
 	public void initialize(String var) {
@@ -24,7 +24,13 @@ public class InventoryClickListener extends PassiveListener {
 
 		String[] splits = var.split(" ");
 
-		if (!splits[0].equals("null")) action = InventoryAction.valueOf(splits[0].toUpperCase());
+		if (!splits[0].equals("null")) {
+			try {
+				action = InventoryAction.valueOf(splits[0].toUpperCase());
+			} catch (IllegalArgumentException e) {
+				MagicSpells.error("Invalid inventory action '" + splits[0] + "' in inventoryclick trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+			}
+		}
 
 		if (splits.length > 1 && !splits[1].isEmpty() && !splits[1].equals("null")) {
 			itemCurrent = MagicItems.getMagicItemDataFromString(splits[1]);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryCloseListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryCloseListener.java
@@ -28,12 +28,12 @@ public class InventoryCloseListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
-		HumanEntity player = event.getPlayer();
-		String inventoryName = event.getView().getTitle();
-		if (!inventoryNames.isEmpty() && !inventoryNames.contains(inventoryName)) return;
+		if (!inventoryNames.isEmpty() && !inventoryNames.contains(event.getView().getTitle())) return;
 
-		if (!hasSpell(player)) return;
-		passiveSpell.activate(player);
+		HumanEntity caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		passiveSpell.activate(caster);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
@@ -29,14 +29,12 @@ public class InventoryOpenListener extends PassiveListener {
 	@EventHandler
 	public void onInventoryOpen(InventoryOpenEvent event) {
 		if (!isCancelStateOk(event.isCancelled())) return;
+		if (!inventoryNames.isEmpty() && !inventoryNames.contains(event.getView().getTitle())) return;
 
-		String inventoryName = event.getView().getTitle();
-		if (!inventoryNames.isEmpty() && !inventoryNames.contains(inventoryName)) return;
+		HumanEntity caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
-		HumanEntity player = event.getPlayer();
-		if (!hasSpell(player) || !canTrigger(player)) return;
-
-		boolean casted = passiveSpell.activate(player);
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
@@ -28,12 +28,16 @@ public class InventoryOpenListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onInventoryOpen(InventoryOpenEvent event) {
-		HumanEntity player = event.getPlayer();
+		if (!isCancelStateOk(event.isCancelled())) return;
+
 		String inventoryName = event.getView().getTitle();
 		if (!inventoryNames.isEmpty() && !inventoryNames.contains(inventoryName)) return;
 
-		if (!hasSpell(player)) return;
-		passiveSpell.activate(player);
+		HumanEntity player = event.getPlayer();
+		if (!hasSpell(player) || !canTrigger(player)) return;
+
+		boolean casted = passiveSpell.activate(player);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/JoinListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/JoinListener.java
@@ -14,13 +14,14 @@ public class JoinListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
-		Player player = event.getPlayer();
-		if (!hasSpell(player)) return;
-		passiveSpell.activate(player);
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		passiveSpell.activate(caster);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/JumpListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/JumpListener.java
@@ -35,12 +35,12 @@ public class JumpListener extends PassiveListener {
 		handleEvent(event.getPlayer(), event);
 	}
 
-	private void handleEvent(LivingEntity entity, Cancellable event) {
-		if (!hasSpell(entity)) return;
+	private void handleEvent(LivingEntity caster, Cancellable event) {
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
@@ -39,12 +39,12 @@ public class KillListener extends PassiveListener {
 	@EventHandler
 	public void onDeath(EntityDeathEvent event) {
 		if (!isCancelStateOk(event.isCancelled())) return;
-
-		LivingEntity killer = event.getEntity().getKiller();
-		if (killer == null || !hasSpell(killer) || !canTrigger(killer)) return;
 		if (!types.isEmpty() && !types.contains(event.getEntityType())) return;
 
-		boolean casted = passiveSpell.activate(killer, event.getEntity());
+		LivingEntity caster = event.getEntity().getKiller();
+		if (caster == null || !hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster, event.getEntity());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
@@ -7,6 +7,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDeathEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MobUtil;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
@@ -25,7 +26,10 @@ public class KillListener extends PassiveListener {
 		String[] split = var.replace(" ", "").split(",");
 		for (String s : split) {
 			EntityType type = MobUtil.getEntityType(s);
-			if (type == null) continue;
+			if (type == null) {
+				MagicSpells.error("Invalid entity type '" + s + "' in kill trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
 			types.add(type);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/KillListener.java
@@ -17,7 +17,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class KillListener extends PassiveListener {
 
 	private final EnumSet<EntityType> types = EnumSet.noneOf(EntityType.class);
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
@@ -30,17 +30,18 @@ public class KillListener extends PassiveListener {
 			types.add(type);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDeath(EntityDeathEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
+
 		LivingEntity killer = event.getEntity().getKiller();
-		if (killer == null) return;
-		if (!hasSpell(killer)) return;
-		if (!canTrigger(killer)) return;
+		if (killer == null || !hasSpell(killer) || !canTrigger(killer)) return;
 		if (!types.isEmpty() && !types.contains(event.getEntityType())) return;
 
-		passiveSpell.activate(killer, event.getEntity());
+		boolean casted = passiveSpell.activate(killer, event.getEntity());
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeaveBedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeaveBedListener.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spells.passive;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerBedLeaveEvent;
 
@@ -13,12 +14,17 @@ public class LeaveBedListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDeath(PlayerBedLeaveEvent event) {
-		if (!hasSpell(event.getPlayer())) return;
-		passiveSpell.activate(event.getPlayer());
+		if (!isCancelStateOk(event.isCancelled())) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(event.getPlayer());
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
@@ -1,5 +1,8 @@
 package com.nisovin.magicspells.spells.passive;
 
+import java.util.Set;
+import java.util.HashSet;
+
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event;
@@ -19,11 +22,12 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // And x, y, and z are integers
 public class LeftClickBlockCoordListener extends PassiveListener {
 
-	private MagicLocation magicLocation;
+	private final Set<MagicLocation> locations = new HashSet<>();
 
 	@Override
 	public void initialize(String var) {
 		String[] split = var.split(";");
+
 		for (String s : split) {
 			try {
 				String[] data = s.split(",");
@@ -31,7 +35,9 @@ public class LeftClickBlockCoordListener extends PassiveListener {
 				int x = Integer.parseInt(data[1]);
 				int y = Integer.parseInt(data[2]);
 				int z = Integer.parseInt(data[3]);
-				magicLocation = new MagicLocation(world, x, y, z);
+
+				MagicLocation location = new MagicLocation(world, x, y, z);
+				locations.add(location);
 			} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 				MagicSpells.error("Invalid coords on leftclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
@@ -52,7 +58,7 @@ public class LeftClickBlockCoordListener extends PassiveListener {
 
 		Location location = event.getClickedBlock().getLocation();
 		MagicLocation loc = new MagicLocation(location.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
-		if (!magicLocation.equals(loc)) return;
+		if (!locations.contains(loc)) return;
 
 		boolean casted = passiveSpell.activate(caster, location.add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
@@ -32,7 +32,7 @@ public class LeftClickBlockCoordListener extends PassiveListener {
 				int y = Integer.parseInt(data[2]);
 				int z = Integer.parseInt(data[3]);
 				magicLocation = new MagicLocation(world, x, y, z);
-			} catch (NumberFormatException e) {
+			} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 				MagicSpells.error("Invalid coords on leftclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockCoordListener.java
@@ -1,9 +1,11 @@
 package com.nisovin.magicspells.spells.passive;
 
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -18,7 +20,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class LeftClickBlockCoordListener extends PassiveListener {
 
 	private MagicLocation magicLocation;
-	
+
 	@Override
 	public void initialize(String var) {
 		String[] split = var.split(";");
@@ -28,24 +30,31 @@ public class LeftClickBlockCoordListener extends PassiveListener {
 				String world = data[0];
 				int x = Integer.parseInt(data[1]);
 				int y = Integer.parseInt(data[2]);
-				int z = Integer.parseInt(data[3]);				
+				int z = Integer.parseInt(data[3]);
 				magicLocation = new MagicLocation(world, x, y, z);
 			} catch (NumberFormatException e) {
-				MagicSpells.error("Invalid coords on leftClickBlockCoord trigger for spell '" + passiveSpell.getInternalName() + "'");
+				MagicSpells.error("Invalid coords on leftclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onLeftClick(PlayerInteractEvent event) {
 		if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
+		if (!isCancelStateOk(isCancelled(event))) return;
+
+		Block block = event.getClickedBlock();
+		if (block == null) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
 		Location location = event.getClickedBlock().getLocation();
 		MagicLocation loc = new MagicLocation(location.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
 		if (!magicLocation.equals(loc)) return;
-		if (!isCancelStateOk(isCancelled(event))) return;
-		if (!hasSpell(event.getPlayer())) return;
-		boolean casted = passiveSpell.activate(event.getPlayer(), location.add(0.5, 0.5, 0.5));
+
+		boolean casted = passiveSpell.activate(caster, location.add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockTypeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickBlockTypeListener.java
@@ -3,9 +3,11 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.EnumSet;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.util.Util;
@@ -25,7 +27,7 @@ public class LeftClickBlockTypeListener extends PassiveListener {
 			s = s.trim();
 			Material m = Util.getMaterial(s);
 			if (m == null) {
-				MagicSpells.error("Invalid type on leftClickBlockType trigger '" + var + "' on passive spell '" + passiveSpell.getInternalName() + "'");
+				MagicSpells.error("Invalid block type on leftclickblocktype trigger '" + var + "' on passive spell '" + passiveSpell.getInternalName() + "'");
 				continue;
 			}
 
@@ -37,13 +39,18 @@ public class LeftClickBlockTypeListener extends PassiveListener {
 	@EventHandler
 	public void onLeftClick(PlayerInteractEvent event) {
 		if (event.getAction() != Action.LEFT_CLICK_BLOCK) return;
-		if (!materials.isEmpty() && !materials.contains(event.getClickedBlock().getType())) return;
-
-		if (!hasSpell(event.getPlayer())) return;
 		if (!isCancelStateOk(isCancelled(event))) return;
-		boolean casted = passiveSpell.activate(event.getPlayer(), event.getClickedBlock().getLocation().add(0.5, 0.5, 0.5));
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		Block block = event.getClickedBlock();
+		if (block == null) return;
+
+		if (!materials.isEmpty() && !materials.contains(block.getType())) return;
+
+		boolean casted = passiveSpell.activate(event.getPlayer(), block.getLocation().add(0.5, 0.5, 0.5));
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 	private boolean isCancelled(PlayerInteractEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MagicSpellsLoadedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MagicSpellsLoadedListener.java
@@ -19,13 +19,9 @@ public class MagicSpellsLoadedListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onLoaded(MagicSpellsLoadedEvent e) {
-		for (World world : Bukkit.getWorlds()) {
-			for (LivingEntity livingEntity : world.getLivingEntities()) {
-				if (!canTrigger(livingEntity)) continue;
-				if (!hasSpell(livingEntity)) continue;
-				passiveSpell.activate(livingEntity);
-			}
-		}
+		for (World world : Bukkit.getWorlds())
+			for (LivingEntity livingEntity : world.getLivingEntities())
+				if (hasSpell(livingEntity) && canTrigger(livingEntity)) passiveSpell.activate(livingEntity);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/ManaChangeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/ManaChangeListener.java
@@ -24,8 +24,7 @@ public class ManaChangeListener extends PassiveListener {
 			try {
 				reasons.add(ManaChangeReason.valueOf(datum.toUpperCase()));
 			} catch (IllegalArgumentException e) {
-				MagicSpells.error("Invalid mana change reason '" + datum + "' in manachange trigger on passive spell '"
-					+ passiveSpell.getName() + "'");
+				MagicSpells.error("Invalid mana change reason '" + datum + "' in manachange trigger on passive spell '" + passiveSpell.getName() + "'");
 			}
 		}
 	}
@@ -33,10 +32,11 @@ public class ManaChangeListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onManaChange(ManaChangeEvent event) {
+		if (!reasons.isEmpty() && !reasons.contains(event.getReason())) return;
+
 		Player caster = event.getPlayer();
 		if (!canTrigger(caster) || !hasSpell(caster)) return;
 
-		if (!reasons.isEmpty() && !reasons.contains(event.getReason())) return;
 		passiveSpell.activate(caster);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/OffhandSwapListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/OffhandSwapListener.java
@@ -13,17 +13,17 @@ public class OffhandSwapListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSwap(PlayerSwapHandItemsEvent event) {
-		Player player = event.getPlayer();
-		if (!hasSpell(player)) return;
-		
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PickupItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PickupItemListener.java
@@ -18,7 +18,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class PickupItemListener extends PassiveListener {
 
 	private final Set<MagicItemData> items = new HashSet<>();
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
@@ -36,7 +36,7 @@ public class PickupItemListener extends PassiveListener {
 			items.add(itemData);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onPickup(EntityPickupItemEvent event) {
@@ -48,7 +48,7 @@ public class PickupItemListener extends PassiveListener {
 		if (!items.isEmpty()) {
 			ItemStack item = event.getItem().getItemStack();
 			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
-			if (!contains(itemData)) return;
+			if (itemData == null || !contains(itemData)) return;
 		}
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerMoveListener.java
@@ -11,7 +11,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class PlayerMoveListener extends PassiveListener {
 
-	private double tolerance = 0;
+	private double tolerance = -1;
 
 	@Override
 	public void initialize(String var) {
@@ -31,7 +31,7 @@ public class PlayerMoveListener extends PassiveListener {
 
 		Player caster = event.getPlayer();
 		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
-		if (tolerance > 0 && LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), tolerance)) return;
+		if (tolerance >= 0 && LocationUtil.distanceLessThan(event.getFrom(), event.getTo(), tolerance)) return;
 
 		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PotionEffectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PotionEffectListener.java
@@ -2,10 +2,12 @@ package com.nisovin.magicspells.spells.passive;
 
 import java.util.List;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.ArrayList;
 
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.event.entity.EntityPotionEffectEvent;
 import org.bukkit.event.entity.EntityPotionEffectEvent.*;
@@ -15,84 +17,87 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class PotionEffectListener extends PassiveListener {
 
-	private PotionTrigger trigger;
+	private List<PotionEffectType> types;
+	private EnumSet<Action> actions;
+	private EnumSet<Cause> causes;
 
 	@Override
 	public void initialize(String var) {
-		List<PotionEffectType> types = new ArrayList<>();
-		List<Action> actions = new ArrayList<>();
-		List<Cause> causes = new ArrayList<>();
+		types = new ArrayList<>();
+		actions = EnumSet.noneOf(Action.class);
+		causes = EnumSet.noneOf(Cause.class);
 
 		if (var != null && !var.isEmpty()) {
 			var = var.toUpperCase();
 			String[] splits = var.split(" ");
 			if (!splits[0].equals("*")) { //Asterisks are wildcards, for when you want the parameter to pass on *any* value
 				for (String s : splits[0].split(",")) { //Each parameter can accept a list of options, separated by commas
-					if (PotionEffectType.getByName(s) != null) { types.add(PotionEffectType.getByName(s)); }
-					else MagicSpells.error("PotionEffect Passive " + passiveSpell.getInternalName() + " has an invalid effect defined: " + s + "!");
+					PotionEffectType type = PotionEffectType.getByName(s);
+
+					if (type != null) {
+						types.add(type);
+					} else {
+						MagicSpells.error("Invalid effect '" + s + "' in potioneffect trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+					}
 				}
-			} else types = Arrays.asList(PotionEffectType.values()); //It's dirty, but it works. If a wildcard is used, dump every value into the list.
+			} else
+				types = Arrays.asList(PotionEffectType.values()); //It's dirty, but it works. If a wildcard is used, dump every value into the list.
 
 			if (splits.length > 1 && !splits[1].equals("*")) {
 				for (String s : splits[1].split(",")) {
-					try { actions.add(Action.valueOf(s)); }
-					catch (IllegalArgumentException e) {MagicSpells.error("PotionEffect Passive " + passiveSpell.getInternalName() + " has an invalid action defined: " + s + "!");}
+					try {
+						Action action = Action.valueOf(s);
+						actions.add(action);
+					} catch (IllegalArgumentException e) {
+						MagicSpells.error("Invalid action '" + s + "' in potioneffect trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+					}
 				}
-			} else actions = Arrays.asList(Action.values());
+			} else actions = EnumSet.allOf(Action.class);
 
 			if (splits.length > 1 && !splits[2].equals("*")) {
 				for (String s : splits[2].split(",")) {
-					try { causes.add(Cause.valueOf(s)); }
-					catch (IllegalArgumentException e) {MagicSpells.error("PotionEffect Passive " + passiveSpell.getInternalName() + " has an invalid cause defined: " + s + "!");}
+					try {
+						Cause cause = Cause.valueOf(s);
+						causes.add(cause);
+					} catch (IllegalArgumentException e) {
+						MagicSpells.error("Invalid cause '" + s + "' in potioneffect trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+					}
 				}
-			} else causes = Arrays.asList(Cause.values());
+			} else causes = EnumSet.allOf(Cause.class);
 		}
-
-		trigger = new PotionTrigger(types, actions, causes);
 	}
 
 	@EventHandler
 	public void onPotionEffect(EntityPotionEffectEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-		if (!hasSpell(entity)) return;
-		if (!canTrigger(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		if (!trigger.actions.contains(event.getAction()) || !trigger.causes.contains(event.getCause())) return;
 
-		PotionEffectType thisEffect = null;
+		if (!actions.contains(event.getAction()) || !causes.contains(event.getCause())) return;
+
+		LivingEntity entity = (LivingEntity) event.getEntity();
+		if (!hasSpell(entity) || !canTrigger(entity)) return;
+
+		PotionEffectType type = null;
+		PotionEffect effect;
 		switch (event.getAction()) { //The effect used by the event is referenced differently based on the action, so unfortunately this is needed
 			case ADDED:
-				thisEffect = event.getNewEffect().getType();
+				effect = event.getNewEffect();
+				if (effect != null) type = effect.getType();
 				break;
 			case CHANGED:
-				thisEffect = event.getModifiedType();
+				type = event.getModifiedType();
 				break;
 			case REMOVED:
 			case CLEARED:
-				thisEffect = event.getOldEffect().getType();
+				effect = event.getOldEffect();
+				if (effect != null) type = effect.getType();
 				break;
 		}
 
-		if (thisEffect == null || !trigger.types.contains(thisEffect)) return;
+		if (type == null || !types.contains(type)) return;
+
 		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
-	}
-
-	private static class PotionTrigger {
-
-		private List<PotionEffectType> types;
-		private List<Action> actions;
-		private List<Cause> causes;
-
-		PotionTrigger(List<PotionEffectType> types, List<Action> actions, List<Cause> causes) {
-			this.types = types;
-			this.actions = actions;
-			this.causes = causes;
-		}
-
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/QuitListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/QuitListener.java
@@ -14,13 +14,14 @@ public class QuitListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
-		Player player = event.getPlayer();
-		if (!hasSpell(player)) return;
-		passiveSpell.activate(player);
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		passiveSpell.activate(caster);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RegainHealthListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RegainHealthListener.java
@@ -25,8 +25,7 @@ public class RegainHealthListener extends PassiveListener {
 			try {
 				reasons.add(RegainReason.valueOf(datum.toUpperCase()));
 			} catch (IllegalArgumentException e) {
-				MagicSpells.error("Invalid health regain reason '" + datum + "' in regainhealth trigger on passive spell '"
-					+ passiveSpell.getName() + "'");
+				MagicSpells.error("Invalid health regain reason '" + datum + "' in regainhealth trigger on passive spell '" + passiveSpell.getName() + "'");
 			}
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/ResourcePackListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/ResourcePackListener.java
@@ -2,10 +2,12 @@ package com.nisovin.magicspells.spells.passive;
 
 import java.util.EnumSet;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent;
 import org.bukkit.event.player.PlayerResourcePackStatusEvent.Status;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -17,33 +19,41 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class ResourcePackListener extends PassiveListener {
 
 	private final EnumSet<Status> packStatus = EnumSet.noneOf(Status.class);
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
-		switch (var.toLowerCase()) {
-			case "successfully_loaded":
-			case "loaded":
-				packStatus.add(Status.SUCCESSFULLY_LOADED);
-				break;
-			case "declined":
-				packStatus.add(Status.DECLINED);
-				break;
-			case "failed_download":
-			case "failed":
-				packStatus.add(Status.FAILED_DOWNLOAD);
-				break;
-			case "accepted":
-				packStatus.add(Status.ACCEPTED);
-				break;
+
+		String[] split = var.split(",");
+		for (String s : split) {
+			s = s.trim().toUpperCase();
+
+			switch (s) {
+				case "LOADED":
+					packStatus.add(Status.SUCCESSFULLY_LOADED);
+					break;
+				case "FAILED":
+					packStatus.add(Status.FAILED_DOWNLOAD);
+					break;
+				default:
+					try {
+						Status status = Status.valueOf(s);
+						packStatus.add(status);
+					} catch (IllegalArgumentException e) {
+						MagicSpells.error("Invalid resource pack status '" + s + "' in resourcepack trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+					}
+			}
 		}
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onPlayerResourcePack(PlayerResourcePackStatusEvent event) {
-		if (!hasSpell(event.getPlayer())) return;
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
 		if (!packStatus.isEmpty() && !packStatus.contains(event.getStatus())) return;
+
 		passiveSpell.activate(event.getPlayer());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/ResourcePackListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/ResourcePackListener.java
@@ -49,10 +49,10 @@ public class ResourcePackListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onPlayerResourcePack(PlayerResourcePackStatusEvent event) {
+		if (!packStatus.isEmpty() && !packStatus.contains(event.getStatus())) return;
+
 		Player caster = event.getPlayer();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
-
-		if (!packStatus.isEmpty() && !packStatus.contains(event.getStatus())) return;
 
 		passiveSpell.activate(event.getPlayer());
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
@@ -19,10 +19,10 @@ public class RespawnListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onRespawn(PlayerRespawnEvent event) {
-		final Player caster = event.getPlayer();
+		Player caster = event.getPlayer();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
-		MagicSpells.scheduleDelayedTask(() -> passiveSpell.activate(caster), 1);
+		passiveSpell.activate(caster);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
@@ -12,16 +12,17 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class RespawnListener extends PassiveListener {
 
 	@Override
-	public void initialize( String var) {
+	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onRespawn(PlayerRespawnEvent event) {
-		final Player player = event.getPlayer();
-		if (!hasSpell(player)) return;
-		MagicSpells.scheduleDelayedTask(() -> passiveSpell.activate(player), 1);
+		final Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		MagicSpells.scheduleDelayedTask(() -> passiveSpell.activate(caster), 1);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
@@ -1,5 +1,8 @@
 package com.nisovin.magicspells.spells.passive;
 
+import java.util.Set;
+import java.util.HashSet;
+
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.event.Event;
@@ -18,11 +21,12 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // Where "world" is a string and x, y, and z are integers
 public class RightClickBlockCoordListener extends PassiveListener {
 
-	private MagicLocation magicLocation;
+	private final Set<MagicLocation> locations = new HashSet<>();
 
 	@Override
 	public void initialize(String var) {
 		String[] split = var.split(";");
+
 		for (String s : split) {
 			try {
 				String[] data = s.split(",");
@@ -30,7 +34,9 @@ public class RightClickBlockCoordListener extends PassiveListener {
 				int x = Integer.parseInt(data[1]);
 				int y = Integer.parseInt(data[2]);
 				int z = Integer.parseInt(data[3]);
-				magicLocation = new MagicLocation(world, x, y, z);
+
+				MagicLocation location = new MagicLocation(world, x, y, z);
+				locations.add(location);
 			} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 				MagicSpells.error("Invalid coords on rightclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
@@ -51,7 +57,7 @@ public class RightClickBlockCoordListener extends PassiveListener {
 
 		Location location = event.getClickedBlock().getLocation();
 		MagicLocation loc = new MagicLocation(location.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
-		if (!magicLocation.equals(loc)) return;
+		if (!locations.contains(loc)) return;
 
 		boolean casted = passiveSpell.activate(caster, location.add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
@@ -31,7 +31,7 @@ public class RightClickBlockCoordListener extends PassiveListener {
 				int y = Integer.parseInt(data[2]);
 				int z = Integer.parseInt(data[3]);
 				magicLocation = new MagicLocation(world, x, y, z);
-			} catch (NumberFormatException e) {
+			} catch (NumberFormatException | ArrayIndexOutOfBoundsException e) {
 				MagicSpells.error("Invalid coords on rightclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockCoordListener.java
@@ -1,10 +1,11 @@
 package com.nisovin.magicspells.spells.passive;
 
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
-import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -31,24 +32,28 @@ public class RightClickBlockCoordListener extends PassiveListener {
 				int z = Integer.parseInt(data[3]);
 				magicLocation = new MagicLocation(world, x, y, z);
 			} catch (NumberFormatException e) {
-				MagicSpells.error("Invalid coords on rightClickBlockCoord trigger for spell '" + passiveSpell.getInternalName() + "'");
+				MagicSpells.error("Invalid coords on rightclickblockcoord trigger for spell '" + passiveSpell.getInternalName() + "'");
 			}
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onRightClick(PlayerInteractEvent event) {
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+		if (!isCancelStateOk(isCancelled(event))) return;
+
+		Block block = event.getClickedBlock();
+		if (block == null) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
 		Location location = event.getClickedBlock().getLocation();
 		MagicLocation loc = new MagicLocation(location.getWorld().getName(), location.getBlockX(), location.getBlockY(), location.getBlockZ());
-
-		if (event.getHand() != EquipmentSlot.HAND) return;
 		if (!magicLocation.equals(loc)) return;
 
-		if (!isCancelStateOk(isCancelled(event))) return;
-		if (!hasSpell(event.getPlayer())) return;
-		boolean casted = passiveSpell.activate(event.getPlayer(), location.add(0.5, 0.5, 0.5));
+		boolean casted = passiveSpell.activate(caster, location.add(0.5, 0.5, 0.5));
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockTypeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickBlockTypeListener.java
@@ -3,9 +3,11 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.EnumSet;
 
 import org.bukkit.Material;
+import org.bukkit.block.Block;
 import org.bukkit.event.Event;
-import org.bukkit.event.EventHandler;
+import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
+import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.util.Util;
@@ -25,7 +27,7 @@ public class RightClickBlockTypeListener extends PassiveListener {
 			s = s.trim();
 			Material m = Util.getMaterial(s);
 			if (m == null) {
-				MagicSpells.error("Invalid type on rightClickBlockType trigger '" + var + "' on passive spell '" + passiveSpell.getInternalName() + "'");
+				MagicSpells.error("Invalid block type on rightclickblocktype trigger '" + var + "' on passive spell '" + passiveSpell.getInternalName() + "'");
 				continue;
 			}
 
@@ -37,13 +39,18 @@ public class RightClickBlockTypeListener extends PassiveListener {
 	@EventHandler
 	public void onRightClick(PlayerInteractEvent event) {
 		if (event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-		if (!materials.isEmpty() && !materials.contains(event.getClickedBlock().getType())) return;
-
-		if (!hasSpell(event.getPlayer())) return;
 		if (!isCancelStateOk(isCancelled(event))) return;
-		boolean casted = passiveSpell.activate(event.getPlayer(), event.getClickedBlock().getLocation().add(0.5, 0.5, 0.5));
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		Block block = event.getClickedBlock();
+		if (block == null) return;
+
+		if (!materials.isEmpty() && !materials.contains(block.getType())) return;
+
+		boolean casted = passiveSpell.activate(event.getPlayer(), block.getLocation().add(0.5, 0.5, 0.5));
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 	private boolean isCancelled(PlayerInteractEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -20,7 +20,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class RightClickItemListener extends PassiveListener {
 
 	private final Set<MagicItemData> items = new HashSet<>();
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
@@ -38,7 +38,7 @@ public class RightClickItemListener extends PassiveListener {
 			items.add(itemData);
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onRightClick(PlayerInteractEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SheepShearListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SheepShearListener.java
@@ -47,7 +47,7 @@ public class SheepShearListener extends PassiveListener {
 		Sheep target = (Sheep) event.getEntity();
 		if (!dyeColors.isEmpty() && !dyeColors.contains(target.getColor())) return;
 
-		boolean casted = passiveSpell.activate(caster);
+		boolean casted = passiveSpell.activate(caster, target);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SheepShearListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SheepShearListener.java
@@ -4,10 +4,12 @@ import java.util.EnumSet;
 
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Sheep;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerShearEntityEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -15,31 +17,37 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class SheepShearListener extends PassiveListener {
 
 	private final EnumSet<DyeColor> dyeColors = EnumSet.noneOf(DyeColor.class);
-	
+
 	@Override
 	public void initialize(String var) {
 		if (var == null || var.isEmpty()) return;
 
-		try {
-			DyeColor color = DyeColor.valueOf(var.toUpperCase());
-			dyeColors.add(color);
-		} catch (Exception e) {
-			// ignored
+		String[] split = var.split(",");
+		for (String s : split) {
+			try {
+				DyeColor color = DyeColor.valueOf(s.trim().toUpperCase());
+				dyeColors.add(color);
+			} catch (IllegalArgumentException e) {
+				MagicSpells.error("Invalid dye color '" + s + "' in sheepshear trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+			}
 		}
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSheepShear(PlayerShearEntityEvent event) {
-		if (!(event.getEntity() instanceof Sheep)) return;
-		Sheep sheep = (Sheep) event.getEntity();
-		Player pl = event.getPlayer();
-		if (!hasSpell(pl)) return;
-
-		if (!dyeColors.isEmpty() && !dyeColors.contains(sheep.getColor())) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(pl);
+
+		Entity entity = event.getEntity();
+		if (!(entity instanceof Sheep)) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		Sheep target = (Sheep) event.getEntity();
+		if (!dyeColors.isEmpty() && !dyeColors.contains(target.getColor())) return;
+
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/ShootListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/ShootListener.java
@@ -20,10 +20,10 @@ public class ShootListener extends PassiveListener {
 	public void onShoot(final EntityShootBowEvent event) {
 		if (!isCancelStateOk(event.isCancelled())) return;
 
-		LivingEntity shooter = event.getEntity();
-		if (!hasSpell(shooter) || !canTrigger(shooter)) return;
+		LivingEntity caster = event.getEntity();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
-		boolean casted = passiveSpell.activate(shooter, event.getForce());
+		boolean casted = passiveSpell.activate(caster, event.getForce());
 		if (cancelDefaultAction(casted)) {
 			event.setCancelled(true);
 			event.getProjectile().remove();

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/ShootListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/ShootListener.java
@@ -14,20 +14,20 @@ public class ShootListener extends PassiveListener {
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onShoot(final EntityShootBowEvent event) {
-		LivingEntity shooter = event.getEntity();
-
-		if (!hasSpell(shooter)) return;
-		if (!canTrigger(shooter)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
+
+		LivingEntity shooter = event.getEntity();
+		if (!hasSpell(shooter) || !canTrigger(shooter)) return;
+
 		boolean casted = passiveSpell.activate(shooter, event.getForce());
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
-		event.getProjectile().remove();
+		if (cancelDefaultAction(casted)) {
+			event.setCancelled(true);
+			event.getProjectile().remove();
+		}
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
@@ -31,13 +31,11 @@ public class SignBookListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onBookEdit(PlayerEditBookEvent event) {
-		if (isCancelStateOk(event.isCancelled())) return;
+		if (!isCancelStateOk(event.isCancelled())) return;
+		if (!event.isSigning()) return;
 
 		Player player = event.getPlayer();
 		if (!hasSpell(player) || !canTrigger(player)) return;
-
-		BookMeta meta = event.getNewBookMeta();
-		if (!meta.hasAuthor()) return;
 
 		if (text.isEmpty()) {
 			boolean casted = passiveSpell.activate(player);
@@ -45,6 +43,7 @@ public class SignBookListener extends PassiveListener {
 			return;
 		}
 
+		BookMeta meta = event.getNewBookMeta();
 		List<String> pages = meta.getPages();
 		for (String page : pages) {
 			if (text.contains(page)) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastListener.java
@@ -54,20 +54,20 @@ public class SpellCastListener extends PassiveListener {
 
 		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSpellCast(SpellCastEvent event) {
-		LivingEntity caster = event.getCaster();
 		if (event.getSpellCastState() != SpellCastState.NORMAL) return;
-		if (!hasSpell(caster)) return;
-		if (!canTrigger(caster)) return;
+		if (!isCancelStateOk(event.isCancelled())) return;
+
+		LivingEntity caster = event.getCaster();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
+		if (spell.equals(passiveSpell)) return;
 		if (filter != null && !filter.check(spell)) return;
 
-		if (!isCancelStateOk(event.isCancelled())) return;
-		if (spell.equals(passiveSpell)) return;
 		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellCastedListener.java
@@ -55,20 +55,20 @@ public class SpellCastedListener extends PassiveListener {
 
 		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSpellCast(SpellCastedEvent event) {
-		LivingEntity caster = event.getCaster();
 		if (event.getSpellCastState() != SpellCastState.NORMAL) return;
 		if (event.getPostCastAction() == PostCastAction.ALREADY_HANDLED) return;
-		if (!hasSpell(caster)) return;
-		if (!canTrigger(caster)) return;
+
+		LivingEntity caster = event.getCaster();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		Spell spell = event.getSpell();
+		if (spell.equals(passiveSpell)) return;
 		if (filter != null && !filter.check(spell)) return;
 
-		if (spell.equals(passiveSpell)) return;
 		passiveSpell.activate(caster);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
@@ -56,11 +56,12 @@ public class SpellSelectListener extends PassiveListener {
 	@EventHandler
 	public void onSpellSelect(SpellSelectionChangedEvent event) {
 		if (!(event.getCaster() instanceof Player)) return;
-		Player player = (Player) event.getCaster();
-		if (!hasSpell(player)) return;
-		if (filter != null && !filter.check(event.getSpell())) return;
 
-		passiveSpell.activate(player);
+		Player caster = (Player) event.getCaster();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		if (filter != null && !filter.check(event.getSpell())) return;
+		passiveSpell.activate(caster);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetListener.java
@@ -52,16 +52,17 @@ public class SpellTargetListener extends PassiveListener {
 
 		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSpellTarget(SpellTargetEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
+
 		LivingEntity caster = event.getCaster();
-		if (!hasSpell(caster)) return;
-		if (!canTrigger(caster)) return;
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
 		if (filter != null && !filter.check(event.getSpell())) return;
 
-		if (!isCancelStateOk(event.isCancelled())) return;
 		boolean casted = passiveSpell.activate(caster, event.getTarget());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellTargetedListener.java
@@ -52,16 +52,17 @@ public class SpellTargetedListener extends PassiveListener {
 
 		filter = new SpellFilter(spells, deniedSpells, tagList, deniedTagList);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSpellTarget(SpellTargetEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
+
 		LivingEntity target = event.getTarget();
-		if (!hasSpell(target)) return;
-		if (!canTrigger(target)) return;
+		if (!hasSpell(target) || !canTrigger(target)) return;
+
 		if (filter != null && !filter.check(event.getSpell())) return;
 
-		if (!isCancelStateOk(event.isCancelled())) return;
 		boolean casted = passiveSpell.activate(target, event.getCaster());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartFlyListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartFlyListener.java
@@ -9,23 +9,23 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 // No trigger variable is currently used
 public class StartFlyListener extends PassiveListener {
-	
+
 	@Override
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onFly(PlayerToggleFlightEvent event) {
-		Player player = event.getPlayer();
-		if (!event.isFlying()) return;
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (!event.isFlying()) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartGlideListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartGlideListener.java
@@ -19,16 +19,14 @@ public class StartGlideListener extends PassiveListener {
 	@EventHandler
 	public void onGlide(EntityToggleGlideEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-
-		if (!event.isGliding()) return;
-		if (!hasSpell(entity)) return;
-		if (!canTrigger(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (!event.isGliding()) return;
+
+		LivingEntity caster = (LivingEntity) event.getEntity();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSneakListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSneakListener.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spells.passive;
 
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerToggleSneakEvent;
 
@@ -8,7 +9,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 // No trigger variable is currently used
 public class StartSneakListener extends PassiveListener {
-		
+
 	@Override
 	public void initialize(String var) {
 
@@ -17,10 +18,12 @@ public class StartSneakListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSneak(PlayerToggleSneakEvent event) {
-		if (!event.isSneaking()) return;
-		if (!hasSpell(event.getPlayer())) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
+		if (!event.isSneaking()) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(event.getPlayer()) || !canTrigger(caster)) return;
+
 		boolean casted = passiveSpell.activate(event.getPlayer());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSprintListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSprintListener.java
@@ -9,23 +9,22 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 // No trigger variable is used here
 public class StartSprintListener extends PassiveListener {
-	
+
 	@Override
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSprint(PlayerToggleSprintEvent event) {
-		Player player = event.getPlayer();
-		if (!event.isSprinting()) return;
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+
+		Player caster = event.getPlayer();
+		if (!event.isSprinting() || !hasSpell(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSwimListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSwimListener.java
@@ -9,25 +9,24 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 // No trigger variable is currently used
 public class StartSwimListener extends PassiveListener {
-	
+
 	@Override
 	public void initialize(String var) {
 
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onSwim(EntityToggleSwimEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-		if (!event.isSwimming()) return;
-		if (!hasSpell(entity)) return;
-		if (!canTrigger(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (!event.isSwimming()) return;
+
+		LivingEntity caster = (LivingEntity) event.getEntity();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopFlyListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopFlyListener.java
@@ -18,14 +18,14 @@ public class StopFlyListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onFly(PlayerToggleFlightEvent event) {
-		Player player = event.getPlayer();
-		if (event.isFlying()) return;
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (event.isFlying()) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopGlideListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopGlideListener.java
@@ -19,15 +19,14 @@ public class StopGlideListener extends PassiveListener {
 	@EventHandler
 	public void onGlide(EntityToggleGlideEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-		if (event.isGliding()) return;
-		if (!hasSpell(entity)) return;
-		if (!canTrigger(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (event.isGliding()) return;
+
+		LivingEntity caster = (LivingEntity) event.getEntity();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSneakListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSneakListener.java
@@ -17,12 +17,13 @@ public class StopSneakListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSneak(PlayerToggleSneakEvent event) {
-		Player player = event.getPlayer();
-		if (event.isSneaking()) return;
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
+		if (event.isSneaking()) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSprintListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSprintListener.java
@@ -18,14 +18,14 @@ public class StopSprintListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSprint(PlayerToggleSprintEvent event) {
-		Player player = event.getPlayer();
-		if (event.isSprinting()) return;
-		if (!hasSpell(player)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(player);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (event.isSprinting()) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSwimListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSwimListener.java
@@ -19,15 +19,14 @@ public class StopSwimListener extends PassiveListener {
 	@EventHandler
 	public void onSwim(EntityToggleSwimEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
-		if (event.isSwimming()) return;
-		if (!hasSpell(entity)) return;
-		if (!canTrigger(entity)) return;
-
 		if (!isCancelStateOk(event.isCancelled())) return;
-		boolean casted = passiveSpell.activate(entity);
-		if (!cancelDefaultAction(casted)) return;
-		event.setCancelled(true);
+		if (event.isSwimming()) return;
+
+		LivingEntity caster = (LivingEntity) event.getEntity();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
+		boolean casted = passiveSpell.activate(caster);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -65,15 +65,18 @@ public class TakeDamageListener extends PassiveListener {
 
 		if (!damageCauses.isEmpty() && !damageCauses.contains(event.getCause())) return;
 
+		LivingEntity attacker = getAttacker(event);
+
 		if (!items.isEmpty()) {
-			EntityEquipment eq = caster.getEquipment();
+			if (attacker == null) return;
+
+			EntityEquipment eq = attacker.getEquipment();
 			if (eq == null) return;
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(eq.getItemInMainHand());
 			if (itemData == null || !contains(itemData)) return;
 		}
 
-		LivingEntity attacker = getAttacker(event);
 		boolean casted = passiveSpell.activate(caster, attacker);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -77,7 +77,7 @@ public class TakeDamageListener extends PassiveListener {
 		boolean casted = passiveSpell.activate(caster, attacker);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
-	
+
 	private LivingEntity getAttacker(EntityDamageEvent event) {
 		if (!(event instanceof EntityDamageByEntityEvent)) return null;
 		Entity e = ((EntityDamageByEntityEvent) event).getDamager();

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
@@ -53,7 +53,7 @@ public class TicksListener extends PassiveListener {
 			}
 		}
 	}
-	
+
 	@Override
 	public void turnOff() {
 		ticker.turnOff();
@@ -88,7 +88,7 @@ public class TicksListener extends PassiveListener {
 		if (!canTrigger((LivingEntity) entity)) return;
 		ticker.add((LivingEntity) entity);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
@@ -97,7 +97,7 @@ public class TicksListener extends PassiveListener {
 		if (!canTrigger(player)) return;
 		ticker.add(player);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
@@ -105,7 +105,7 @@ public class TicksListener extends PassiveListener {
 		if (!canTrigger(player)) return;
 		ticker.remove(player);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onDeath(PlayerDeathEvent event) {
@@ -113,7 +113,7 @@ public class TicksListener extends PassiveListener {
 		if (!canTrigger(player)) return;
 		ticker.remove(player);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onRespawn(PlayerRespawnEvent event) {
@@ -122,7 +122,7 @@ public class TicksListener extends PassiveListener {
 		if (!canTrigger(player)) return;
 		ticker.add(player);
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onLearn(SpellLearnEvent event) {
@@ -131,7 +131,7 @@ public class TicksListener extends PassiveListener {
 		if (!spell.getInternalName().equals(passiveSpell.getInternalName())) return;
 		ticker.add(event.getLearner());
 	}
-	
+
 	@OverridePriority
 	@EventHandler
 	public void onForget(SpellForgetEvent event) {
@@ -140,7 +140,7 @@ public class TicksListener extends PassiveListener {
 		if (!spell.getInternalName().equals(passiveSpell.getInternalName())) return;
 		ticker.remove(event.getForgetter());
 	}
-	
+
 	private static class Ticker implements Runnable {
 
 		private final Collection<LivingEntity> entities;
@@ -149,14 +149,14 @@ public class TicksListener extends PassiveListener {
 
 		private final int taskId;
 		private final String profilingKey;
-		
+
 		public Ticker(PassiveSpell passiveSpell, int interval) {
 			this.passiveSpell = passiveSpell;
 			taskId = MagicSpells.scheduleRepeatingTask(this, interval, interval);
 			profilingKey = MagicSpells.profilingEnabled() ? "PassiveTick:" + interval : null;
 			entities = new ArrayList<>();
 		}
-		
+
 		public void add(LivingEntity livingEntity) {
 			entities.add(livingEntity);
 		}
@@ -179,11 +179,11 @@ public class TicksListener extends PassiveListener {
 
 			if (profilingKey != null) MagicSpells.addProfile(profilingKey, System.nanoTime() - start);
 		}
-		
+
 		public void turnOff() {
 			MagicSpells.cancelTask(taskId);
 		}
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/WorldChangeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/WorldChangeListener.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -22,7 +23,10 @@ public class WorldChangeListener extends PassiveListener {
 
 		for (String worldName : var.split(",")) {
 			World world = Bukkit.getWorld(worldName);
-			if (world == null) continue;
+			if (world == null) {
+				MagicSpells.error("Invalid world '" + worldName + "' in worldchange trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
 
 			worldNames.add(worldName);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/WorldChangeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/WorldChangeListener.java
@@ -5,7 +5,7 @@ import java.util.HashSet;
 
 import org.bukkit.World;
 import org.bukkit.Bukkit;
-import org.bukkit.Location;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerTeleportEvent;
 
@@ -31,19 +31,19 @@ public class WorldChangeListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onWorldChange(PlayerTeleportEvent event) {
+		if (!isCancelStateOk(event.isCancelled())) return;
+
 		World worldFrom = event.getFrom().getWorld();
 		if (worldFrom == null) return;
 
-		Location locTo = event.getTo();
-		if (locTo == null) return;
-
-		World worldTo = locTo.getWorld();
-		if (worldTo == null) return;
-		if (worldFrom.equals(worldTo)) return;
+		World worldTo = event.getTo().getWorld();
+		if (worldTo == null || worldFrom.equals(worldTo)) return;
 
 		if (!worldNames.isEmpty() && !worldNames.contains(worldTo.getName())) return;
-		if (!hasSpell(event.getPlayer())) return;
-		if (!isCancelStateOk(event.isCancelled())) return;
+
+		Player caster = event.getPlayer();
+		if (!hasSpell(caster) || !canTrigger(caster)) return;
+
 		boolean casted = passiveSpell.activate(event.getPlayer());
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/BossBarManager.java
@@ -36,22 +36,28 @@ public class BossBarManager {
 	}
 
 	public Bar getBar(Player player, String namespaceKey) {
+		return getBar(player, namespaceKey, true);
+	}
+
+	public Bar getBar(Player player, String namespaceKey, boolean create) {
 		if (namespaceKey == null || namespaceKey.isEmpty()) namespaceKey = NAMESPACE_KEY_DEFAULT;
-		// Check if the bar exists.
-		Bar finalBar = null;
+
+		// Return bar if it already exists.
 		for (Bar bar : bars) {
 			if (bar.player.equals(player.getUniqueId()) && bar.namespaceKey.equals(namespaceKey)) {
-				finalBar = bar;
-				break;
+				return bar;
 			}
 		}
-		// If it doesn't, create it.
-		if (finalBar == null) {
+
+		// Create bar if specified.
+		Bar bar = null;
+		if (create) {
 			BossBar bossBar = Bukkit.createBossBar(createNamespaceKey(namespaceKey), "", BarColor.WHITE, BarStyle.SOLID);
-			finalBar = new Bar(bossBar, player, namespaceKey);
-			bars.add(finalBar);
+			bar = new Bar(bossBar, player, namespaceKey);
+			bars.add(bar);
 		}
-		return finalBar;
+
+		return bar;
 	}
 
 	public void turnOff() {
@@ -78,6 +84,11 @@ public class BossBarManager {
 			bossbar.setStyle(style);
 			bossbar.setColor(color);
 			bossbar.setProgress(progress);
+		}
+
+		public void set(String title, double progress, BarStyle style, BarColor color, boolean visible) {
+			set(title, progress, style, color);
+			bossbar.setVisible(visible);
 		}
 
 		public void addFlag(BarFlag flag) {


### PR DESCRIPTION
Fixes:
- `craft` trigger now properly supports magic items.
- `takedamage` passive trigger now properly checks for the attacker's, not the caster's, main hand item.
- `leftclickblockcoord` and `rightclickblockcoord` now properly accept multiple locations.

Additions:
- `visible` option for `BossBarEffect`. When false, applied boss bar is not visible.
- `remove` option for `BossBarEffect`. When true, removes specified boss bar.
- `foodlevelchange` passive trigger now supports a pipe separated filter for magic items.
- `gamemodechange` passive trigger now supports specifying multiple game modes.
- `inventoryopen`, `kill`, and `leavebed` passive triggers now support cancellation.
- `resourcepack` passive trigger now supports specifying multiple resource pack statuses.
- `sheepshear` passive trigger now supports specifying multiple dye colors.
- `sheapshear` passive trigger now targets the sheared sheep.