### PR TITLE
Don't fail TargetedMultiSpell if hard casted spell returns NO_MESSAGES

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -187,7 +187,8 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			if (locTarget != null) return spell.castAtLocation(caster, locTarget, power);
 		}
 
-		return spell.cast(caster, power) == PostCastAction.HANDLE_NORMALLY;
+		PostCastAction action = spell.cast(caster, power);
+		return action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
 	}
 	
 	private static class Action {


### PR DESCRIPTION
Causes issues if attempting to hard cast targeted spells in a TargetedMultiSpell (such as when you want to target self).