### PR TITLE
Fix MagicSpellsEntityDamageByEntityEvent for FlamewalkSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
@@ -142,7 +142,7 @@ public class FlamewalkSpell extends BuffSpell {
 					if (validTargetList != null && !validTargetList.canTarget(target)) continue;
 					if (livingEntity.equals(target)) continue;
 					if (checkPlugins) {
-						MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(livingEntity, entity, DamageCause.ENTITY_ATTACK, 1, FlamewalkSpell.this);
+						MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(livingEntity, target, DamageCause.ENTITY_ATTACK, 1, FlamewalkSpell.this);
 						EventUtil.call(event);
 						if (event.isCancelled()) continue;
 					}


### PR DESCRIPTION
Currently the compatibility event fired for `check-plugins: true` lists the caster as the targeted entity.