### PR TITLE
BowSpell bugfix, add equip and unequip passive triggers

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -236,8 +236,7 @@ public class BowSpell extends Spell {
 				if (!MagicSpells.plugin.equals(meta.getOwningPlugin())) continue;
 
 				ProjectileSource shooter = proj.getShooter();
-				if (!(shooter instanceof LivingEntity)) break;
-				LivingEntity caster = (LivingEntity) shooter;
+				if (!(shooter instanceof LivingEntity caster)) break;
 
 				List<ArrowData> arrowDataList = (List<ArrowData>) meta.value();
 				if (arrowDataList == null || arrowDataList.isEmpty()) break;
@@ -248,9 +247,7 @@ public class BowSpell extends Spell {
 
 					SpellTargetLocationEvent targetLocationEvent = new SpellTargetLocationEvent(data.bowSpell, caster, proj.getLocation(), data.power);
 					EventUtil.call(targetLocationEvent);
-					if (targetLocationEvent.isCancelled()) {
-						break;
-					}
+					if (targetLocationEvent.isCancelled()) continue;
 
 					if (groundSpell.isTargetedLocationSpell())
 						groundSpell.castAtLocation(caster, targetLocationEvent.getTargetLocation(), targetLocationEvent.getPower());
@@ -278,12 +275,10 @@ public class BowSpell extends Spell {
 				if (!MagicSpells.plugin.equals(meta.getOwningPlugin())) continue;
 
 				Entity damaged = event.getEntity();
-				if (!(damaged instanceof LivingEntity)) break;
-				LivingEntity target = (LivingEntity) damaged;
+				if (!(damaged instanceof LivingEntity target)) break;
 
 				ProjectileSource shooter = ((Arrow) damager).getShooter();
-				if (!(shooter instanceof LivingEntity)) break;
-				LivingEntity caster = (LivingEntity) shooter;
+				if (!(shooter instanceof LivingEntity caster)) break;
 
 				List<ArrowData> arrowDataList = (List<ArrowData>) meta.value();
 				if (arrowDataList == null || arrowDataList.isEmpty()) break;
@@ -294,9 +289,8 @@ public class BowSpell extends Spell {
 
 					SpellTargetEvent targetEvent = new SpellTargetEvent(data.bowSpell, caster, target, data.power);
 					EventUtil.call(targetEvent);
-					if (targetEvent.isCancelled()) {
-						continue;
-					}
+					if (targetEvent.isCancelled()) continue;
+
 					target = targetEvent.getTarget();
 
 					if (entitySpell.isTargetedEntityFromLocationSpell())

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/EquipListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/EquipListener.java
@@ -1,0 +1,70 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.ItemStack;
+
+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+
+public class EquipListener extends PassiveListener {
+
+	private final Set<MagicItemData> items = new HashSet<>();
+
+	@Override
+	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
+
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in equip trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
+
+			items.add(itemData);
+		}
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onEquip(PlayerArmorChangeEvent event) {
+		Player caster = event.getPlayer();
+		if (!canTrigger(caster) || !hasSpell(caster)) return;
+
+		if (!items.isEmpty()) {
+			ItemStack newItem = event.getNewItem();
+			if (newItem == null) return;
+
+			MagicItemData newData = MagicItems.getMagicItemDataFromItemStack(newItem);
+			if (newData == null) return;
+
+			ItemStack oldItem = event.getOldItem();
+			MagicItemData oldData = MagicItems.getMagicItemDataFromItemStack(oldItem);
+
+			if (!contains(oldData, newData)) return;
+		}
+
+		passiveSpell.activate(caster);
+	}
+
+	private boolean contains(MagicItemData oldData, MagicItemData newData) {
+		for (MagicItemData data : items)
+			if ((oldData == null || !data.matches(oldData)) && data.matches(newData))
+				return true;
+
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/UnequipListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/UnequipListener.java
@@ -1,0 +1,70 @@
+package com.nisovin.magicspells.spells.passive;
+
+import java.util.Set;
+import java.util.HashSet;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.ItemStack;
+
+import com.destroystokyo.paper.event.player.PlayerArmorChangeEvent;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+
+public class UnequipListener extends PassiveListener {
+
+	private final Set<MagicItemData> items = new HashSet<>();
+
+	@Override
+	public void initialize(String var) {
+		if (var == null || var.isEmpty()) return;
+
+		String[] split = var.split("\\|");
+		for (String s : split) {
+			s = s.trim();
+
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + s + "' in unequip trigger on passive spell '" + passiveSpell.getInternalName() + "'");
+				continue;
+			}
+
+			items.add(itemData);
+		}
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onUnequip(PlayerArmorChangeEvent event) {
+		Player caster = event.getPlayer();
+		if (!canTrigger(caster) || !hasSpell(caster)) return;
+
+		if (!items.isEmpty()) {
+			ItemStack oldItem = event.getOldItem();
+			if (oldItem == null) return;
+
+			MagicItemData oldData = MagicItems.getMagicItemDataFromItemStack(oldItem);
+			if (oldData == null) return;
+
+			ItemStack newItem = event.getNewItem();
+			MagicItemData newData = MagicItems.getMagicItemDataFromItemStack(newItem);
+
+			if (!contains(oldData, newData)) return;
+		}
+
+		passiveSpell.activate(caster);
+	}
+
+	private boolean contains(MagicItemData oldData, MagicItemData newData) {
+		for (MagicItemData data : items)
+			if (data.matches(oldData) && (newData == null || !data.matches(newData)))
+				return true;
+
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -63,7 +63,7 @@ public class PassiveManager {
 		}
 		return null;
 	}
-	
+
 	private void initialize() {
 		// initialize priorities
 		for (EventPriority priority : EventPriority.values()) {
@@ -77,6 +77,7 @@ public class PassiveManager {
 		addListener("death", DeathListener.class);
 		addListener("dropitem", DropItemListener.class);
 		addListener("enterbed", EnterBedListener.class);
+		addListener("equip", EquipListener.class);
 		addListener("fataldamage", FatalDamageListener.class);
 		addListener("fish", FishListener.class);
 		addListener("foodlevelchange", FoodLevelChangeListener.class);
@@ -133,7 +134,8 @@ public class PassiveManager {
 		addListener("takedamage", TakeDamageListener.class);
 		addListener("teleport", TeleportListener.class);
 		addListener("ticks", TicksListener.class);
+		addListener("unequip", UnequipListener.class);
 		addListener("worldchange", WorldChangeListener.class);
 	}
-	
+
 }


### PR DESCRIPTION
- `BowSpell` currently stops processing all `spell-on-hit-ground` if one of the spells associated with the arrow has their `SpellTargetLocationEvent` cancelled.
- Added `equip` and `unequip` passive triggers.