### PR TITLE
Add meta variables for attribute value, fix issue with RewindSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -14,6 +14,7 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.mana.ManaHandler;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.events.SpellCastEvent;
@@ -135,8 +136,12 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 			this.caster = caster;
 			this.power = power;
 			this.entity = entity;
-			if (entity instanceof Player) this.startMana = MagicSpells.getManaHandler().getMana((Player) entity);
+
 			this.startHealth = entity.getHealth();
+			if (MagicSpells.isManaSystemEnabled() && entity instanceof Player player) {
+				ManaHandler handler = MagicSpells.getManaHandler();
+				if (handler != null) this.startMana = handler.getMana(player);
+			}
 
 			entities.put(entity, this);
 			this.taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
@@ -209,7 +214,10 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		private void stop() {
 			MagicSpells.cancelTask(taskId);
 			if (rewindHealth) entity.setHealth(startHealth);
-			if (entity instanceof Player && rewindMana) MagicSpells.getManaHandler().setMana((Player) entity, startMana, ManaChangeReason.OTHER);
+			if (rewindMana && MagicSpells.isManaSystemEnabled() && entity instanceof Player player) {
+				ManaHandler handler = MagicSpells.getManaHandler();
+				if (handler != null) handler.setMana(player, startMana, ManaChangeReason.OTHER);
+			}
 		}
 
 		private void cancel() {

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -9,6 +9,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
+import org.bukkit.attribute.Attribute;
 import org.bukkit.scoreboard.Objective;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.configuration.ConfigurationSection;
@@ -143,6 +144,18 @@ public class VariableManager {
 		addMetaVariableType("attribute_generic_armor_base", new AttributeBaseValueVariable("GENERIC_ARMOR"));
 		addMetaVariableType("attribute_generic_armor_toughness_base", new AttributeBaseValueVariable("GENERIC_ARMOR_TOUGHNESS"));
 		addMetaVariableType("attribute_generic_luck_base", new AttributeBaseValueVariable("GENERIC_LUCK"));
+
+		addMetaVariableType("attribute_generic_max_health", new AttributeVariable(Attribute.GENERIC_MAX_HEALTH));
+		addMetaVariableType("attribute_generic_follow_range", new AttributeVariable(Attribute.GENERIC_FOLLOW_RANGE));
+		addMetaVariableType("attribute_generic_knockback_resistance", new AttributeVariable(Attribute.GENERIC_KNOCKBACK_RESISTANCE));
+		addMetaVariableType("attribute_generic_movement_speed", new AttributeVariable(Attribute.GENERIC_MOVEMENT_SPEED));
+		addMetaVariableType("attribute_generic_flying_speed", new AttributeVariable(Attribute.GENERIC_FLYING_SPEED));
+		addMetaVariableType("attribute_generic_attack_damage", new AttributeVariable(Attribute.GENERIC_ATTACK_DAMAGE));
+		addMetaVariableType("attribute_generic_attack_knockback", new AttributeVariable(Attribute.GENERIC_ATTACK_KNOCKBACK));
+		addMetaVariableType("attribute_generic_attack_speed", new AttributeVariable(Attribute.GENERIC_ATTACK_SPEED));
+		addMetaVariableType("attribute_generic_armor", new AttributeVariable(Attribute.GENERIC_ARMOR));
+		addMetaVariableType("attribute_generic_armor_toughness", new AttributeVariable(Attribute.GENERIC_ARMOR_TOUGHNESS));
+		addMetaVariableType("attribute_generic_luck", new AttributeVariable(Attribute.GENERIC_LUCK));
 	}
 
 	// DEBUG INFO: level 2, loaded variable (name)

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/AttributeVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/AttributeVariable.java
@@ -1,0 +1,31 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class AttributeVariable extends MetaVariable {
+
+	private final Attribute attribute;
+
+	public AttributeVariable(Attribute attribute) {
+		super();
+
+		this.attribute = attribute;
+	}
+
+	@Override
+	public double getValue(String player) {
+		Player p = PlayerNameUtils.getPlayerExact(player);
+		if (p == null) return 0D;
+
+		AttributeInstance inst = p.getAttribute(attribute);
+		if (inst == null) return 0D;
+
+		return inst.getValue();
+	}
+
+}


### PR DESCRIPTION
- `RewindSpell` attempts to use the mana handler even when the internal mana system is disabled, causing a `NullPointerException`.
- Added meta variables such as `meta_attribute_generic_armor` for the value of attributes. Current meta variables only allow you to check/modify their base value.