### PR TITLE
Adventure support

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 
     implementation group: "com.comphenix.protocol", name: "ProtocolLib", version: "4.7.0"
 
+    implementation "net.kyori:adventure-text-minimessage:4.1.0-SNAPSHOT"
     implementation "io.papermc.paper:paper-api:1.17.1-R0.1-SNAPSHOT"
     implementation "org.spigotmc:spigot:1.17.1-R0.1-SNAPSHOT"
 

--- a/core/src/main/java/com/nisovin/magicspells/MagicLogger.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicLogger.java
@@ -126,9 +126,9 @@ public class MagicLogger implements Listener {
 	
 	private String getTeacherName(Object o) {
 		if (o == null) return "none";
-		if (o instanceof Player) return "player-" + ((Player)o).getName();
-		if (o instanceof Spell) return "spell-" + ((Spell)o).getInternalName();
-		if (o instanceof Block) return "block-" + formatLoc(((Block)o).getLocation());
+		if (o instanceof Player player) return "player-" + player.getName();
+		if (o instanceof Spell spell) return "spell-" + spell.getInternalName();
+		if (o instanceof Block block) return "block-" + formatLoc(block.getLocation());
 		return o.toString();
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -166,6 +166,7 @@ public class MagicSpells extends JavaPlugin {
 	private boolean cooldownsPersistThroughReload;
 	private boolean allowAnticheatIntegrations;
 
+	private int debugLevelOriginal;
 	private int debugLevel;
 	private int spellIconSlot;
 	private int globalRadius;
@@ -249,7 +250,8 @@ public class MagicSpells extends JavaPlugin {
 		debug = config.getBoolean(path + "debug", false);
 		debugNull = config.getBoolean(path + "debug-null", true);
 		debugNumberFormat = config.getBoolean(path + "debug-number-format", true);
-		debugLevel = config.getInt(path + "debug-level", 3);
+		debugLevelOriginal = config.getInt(path + "debug-level", 3);
+		debugLevel = debugLevelOriginal;
 
 		tabCompleteInternalNames = config.getBoolean(path + "tab-complete-internal-names", false);
 		terminateEffectlibInstances = config.getBoolean(path + "terminate-effectlib-instances", true);
@@ -1059,8 +1061,16 @@ public class MagicSpells extends JavaPlugin {
 		return plugin.globalCooldown;
 	}
 
+	public static int getDebugLevelOriginal() {
+		return plugin.debugLevelOriginal;
+	}
+
 	public static void setDebug(boolean debug) {
 		plugin.debug = debug;
+	}
+
+	public static void setDebugLevel(int level) {
+		plugin.debugLevel = level;
 	}
 
 	public static boolean hasProfilingEnabled() {

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -15,6 +15,10 @@ import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.MalformedURLException;
 
+import de.slikey.effectlib.EffectManager;
+
+import org.jetbrains.annotations.NotNull;
+
 import co.aikar.commands.PaperCommandManager;
 
 import org.bukkit.Bukkit;
@@ -62,8 +66,6 @@ import com.nisovin.magicspells.spelleffects.trackers.AsyncEffectTracker;
 import com.nisovin.magicspells.spelleffects.effecttypes.EffectLibEffect;
 import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
-
-import de.slikey.effectlib.EffectManager;
 
 public class MagicSpells extends JavaPlugin {
 
@@ -545,7 +547,7 @@ public class MagicSpells extends JavaPlugin {
 		registerEvents(new MagicPlayerListener(this));
 		registerEvents(new MagicSpellListener(this));
 		registerEvents(new CastListener(this));
-		if (!incantations.isEmpty()) registerEvents(new MagicChatListener(this));
+		if (!incantations.isEmpty()) registerEvents(new MagicChatListener());
 
 		LeftClickListener leftClickListener = new LeftClickListener();
 		if (leftClickListener.hasLeftClickCastItems()) registerEvents(leftClickListener);
@@ -553,7 +555,7 @@ public class MagicSpells extends JavaPlugin {
 		RightClickListener rightClickListener = new RightClickListener();
 		if (rightClickListener.hasRightClickCastItems()) registerEvents(rightClickListener);
 
-		ConsumeListener consumeListener = new ConsumeListener(this);
+		ConsumeListener consumeListener = new ConsumeListener();
 		if (consumeListener.hasConsumeCastItems()) registerEvents(consumeListener);
 		if (config.getBoolean(path + "enable-dance-casting", true)) new DanceCastListener(this, config);
 
@@ -1535,7 +1537,7 @@ public class MagicSpells extends JavaPlugin {
 				final String eventKey = plugin.enableProfiling ? "Event:" + listener.getClass().getName().replace("com.nisovin.magicspells.", "") + '.' + method.getName() + '(' + eventClass.getSimpleName() + ')' : null;
 
 				@Override
-				public void execute(Listener listener, Event event) {
+				public void execute(@NotNull Listener listener, @NotNull Event event) {
 					try {
 						if (!eventClass.isAssignableFrom(event.getClass())) return;
 						long start = System.nanoTime();
@@ -1709,7 +1711,7 @@ public class MagicSpells extends JavaPlugin {
 
 		Spellbook spellbook = getSpellbook(player);
 
-		if (spellbook == null || spellbook.hasSpell(spell) || !spellbook.canLearn(spell)) return false;
+		if (spellbook.hasSpell(spell) || !spellbook.canLearn(spell)) return false;
 
 		// Call event
 		SpellLearnEvent event = new SpellLearnEvent(spell, player, LearnSource.OTHER, null);

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1360,7 +1360,7 @@ public class MagicSpells extends JavaPlugin {
 		//Send messages
 		for (String msg : message.split("\n")) {
 			if (msg.isEmpty()) continue;
-			livingEntity.sendMessage(Util.colorize(getTextColor() + msg));
+			livingEntity.sendMessage(Util.getMiniMessage(getTextColor() + msg));
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -361,9 +361,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 					minCooldown = min;
 					maxCooldown = max;
 				}
-			} catch (NumberFormatException ex) {
-
-			}
+			} catch (NumberFormatException ignored) {}
 		}
 
 		serverCooldown = (float) config.getDouble(path + "server-cooldown", 0);
@@ -469,48 +467,44 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 					float money = 1;
 
 					switch (data[0].toLowerCase()) {
-						case "health":
+						case "health" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setHealth(amt);
-							break;
-						case "mana":
+						}
+						case "mana" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setMana(amt);
-							break;
-						case "hunger":
+						}
+						case "hunger" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setHunger(amt);
-							break;
-						case "experience":
+						}
+						case "experience" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setExperience(amt);
-							break;
-						case "levels":
+						}
+						case "levels" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setLevels(amt);
-							break;
-						case "durability":
+						}
+						case "durability" -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
 							reagents.setDurability(amt);
-							break;
-						case "money":
+						}
+						case "money" -> {
 							if (data.length > 1) money = Float.parseFloat(data[1]);
 							reagents.setMoney(money);
-							break;
-						case "variable":
-							reagents.addVariable(data[1], Double.parseDouble(data[2]));
-							break;
-						default:
+						}
+						case "variable" -> reagents.addVariable(data[1], Double.parseDouble(data[2]));
+						default -> {
 							if (data.length > 1) amt = Integer.parseInt(data[1]);
-
 							MagicItemData itemData = MagicItems.getMagicItemDataFromString(data[0]);
 							if (itemData == null) {
 								MagicSpells.error("Failed to process cost value for " + internalName + " spell: " + costVal);
 								continue;
 							}
-
 							reagents.addItem(new SpellReagents.ReagentItem(itemData, amt));
-							break;
+						}
 					}
 				} catch (Exception e) {
 					// FIXME this should not be a means of breaking
@@ -590,7 +584,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			}
 
 			String positionName = section.getString("position", "");
-			if (positionName == null || positionName.isEmpty()) {
+			if (positionName.isEmpty()) {
 				MagicSpells.error("Spell effect '" + key + "' on spell '" + internalName + "' does not contain a 'position' value.");
 				continue;
 			}
@@ -602,7 +596,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			}
 
 			String effectType = section.getString("effect", "");
-			if (effectType == null || effectType.isEmpty()) {
+			if (effectType.isEmpty()) {
 				MagicSpells.error("Spell effect '" + key + "' on spell '" + internalName + "' does not contain an 'effect' value.");
 				continue;
 			}
@@ -896,17 +890,17 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 				if (action.setCooldown()) setCooldown(caster, spellCast.getCooldown());
 				if (action.chargeReagents()) removeReagents(caster, spellCast.getReagents());
 				if (action.sendMessages()) sendMessages(caster, spellCast.getSpellArgs());
-				if (experience > 0 && caster instanceof Player) ((Player) caster).giveExp(experience);
+				if (experience > 0 && caster instanceof Player player) player.giveExp(experience);
 			} else if (state == SpellCastState.ON_COOLDOWN) {
 				MagicSpells.sendMessageAndFormat(strOnCooldown, caster, spellCast.getSpellArgs(),
 					"%c", Math.round(getCooldown(caster)) + "", "%s", spellCast.getSpell().getName());
 				playSpellEffects(EffectPosition.COOLDOWN, caster);
-				if (soundOnCooldown != null && caster instanceof Player) ((Player) caster).playSound(caster.getLocation(), soundOnCooldown, 1F, 1F);
+				if (soundOnCooldown != null && caster instanceof Player player) player.playSound(caster.getLocation(), soundOnCooldown, 1F, 1F);
 			} else if (state == SpellCastState.MISSING_REAGENTS) {
 				MagicSpells.sendMessage(strMissingReagents, caster, spellCast.getSpellArgs());
 				playSpellEffects(EffectPosition.MISSING_REAGENTS, caster);
 				if (MagicSpells.showStrCostOnMissingReagents() && strCost != null && !strCost.isEmpty()) MagicSpells.sendMessage("    (" + strCost + ')', caster, spellCast.getSpellArgs());
-				if (soundMissingReagents != null && caster instanceof Player) ((Player) caster).playSound(caster.getLocation(), soundMissingReagents, 1F, 1F);
+				if (soundMissingReagents != null && caster instanceof Player player) player.playSound(caster.getLocation(), soundMissingReagents, 1F, 1F);
 			} else if (state == SpellCastState.CANT_CAST) {
 				MagicSpells.sendMessage(strCantCast, caster, spellCast.getSpellArgs());
 			} else if (state == SpellCastState.NO_MAGIC_ZONE) {
@@ -952,7 +946,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		for (Player p : Bukkit.getOnlinePlayers()) {
 			String name = p.getName();
 			if (!name.toLowerCase().startsWith(partial)) continue;
-			if (sender.isOp() || !(sender instanceof Player) || ((Player) sender).canSee(p)) matches.add(name);
+			if (sender.isOp() || !(sender instanceof Player player) || player.canSee(p)) matches.add(name);
 		}
 		if (!matches.isEmpty()) return matches;
 		return null;
@@ -1094,7 +1088,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 					playSpellEffects(EffectPosition.CHARGE_USE, livingEntity);
 					if (rechargeSound == null) return;
 					if (rechargeSound.isEmpty()) return;
-					if (livingEntity instanceof Player) ((Player) livingEntity).playSound(livingEntity.getLocation(), rechargeSound, 1.0F, 1.0F);
+					if (livingEntity instanceof Player player) player.playSound(livingEntity.getLocation(), rechargeSound, 1.0F, 1.0F);
 				}, Math.round(TimeUtil.TICKS_PER_SECOND * cd));
 			}
 
@@ -1144,23 +1138,23 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		if (Perm.NO_REAGENTS.has(livingEntity)) return true;
 
 		// player reagents
-		if (livingEntity instanceof Player) {
+		if (livingEntity instanceof Player player) {
 			// Mana costs
-			if (manaCost > 0 && (MagicSpells.getManaHandler() == null || !MagicSpells.getManaHandler().hasMana((Player) livingEntity, manaCost))) return false;
+			if (manaCost > 0 && (MagicSpells.getManaHandler() == null || !MagicSpells.getManaHandler().hasMana(player, manaCost))) return false;
 
 			// Hunger costs
-			if (hungerCost > 0 && ((Player) livingEntity).getFoodLevel() < hungerCost) return false;
+			if (hungerCost > 0 && player.getFoodLevel() < hungerCost) return false;
 
 			// Experience costs
-			if (experienceCost > 0 && !ExperienceUtils.hasExp((Player) livingEntity, experienceCost)) return false;
+			if (experienceCost > 0 && !ExperienceUtils.hasExp(player, experienceCost)) return false;
 
 			// Level costs
-			if (levelsCost > 0 && ((Player) livingEntity).getLevel() < levelsCost) return false;
+			if (levelsCost > 0 && player.getLevel() < levelsCost) return false;
 
 			// Money costs
 			if (moneyCost > 0) {
 				MoneyHandler moneyHandler = MagicSpells.getMoneyHandler();
-				if (moneyHandler == null || !moneyHandler.hasMoney((Player) livingEntity, moneyCost)) {
+				if (moneyHandler == null || !moneyHandler.hasMoney(player, moneyCost)) {
 					return false;
 				}
 			}
@@ -1171,7 +1165,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 				if (varMan == null) return false;
 				for (Map.Entry<String, Double> var : variables.entrySet()) {
 					double val = var.getValue();
-					if (val > 0 && varMan.getValue(var.getKey(), (Player) livingEntity) < val) return false;
+					if (val > 0 && varMan.getValue(var.getKey(), player) < val) return false;
 				}
 			}
 		}
@@ -1182,19 +1176,20 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		// Durabilty costs
 		if (durabilityCost > 0) {
 			// Durability cost is charged from the main hand item
-			ItemStack inHand = livingEntity.getEquipment().getItemInMainHand();
-			if (inHand == null) return false;
-			if (!(inHand.getItemMeta() instanceof Damageable)) return false;
-			if (((Damageable) inHand.getItemMeta()).getDamage() >= inHand.getType().getMaxDurability()) return false;
+			EntityEquipment equipment = livingEntity.getEquipment();
+			if (equipment == null) return false;
+			ItemStack inHand = equipment.getItemInMainHand();
+			if (!(inHand.getItemMeta() instanceof Damageable damageable)) return false;
+			if (damageable.getDamage() >= inHand.getType().getMaxDurability()) return false;
 		}
 
 		// Item costs
 		if (reagents != null) {
-			if (livingEntity instanceof Player) {
-				Inventory playerInventory = ((Player) livingEntity).getInventory();
+			if (livingEntity instanceof Player player) {
+				Inventory inventory = player.getInventory();
 				for (SpellReagents.ReagentItem item : reagents) {
 					if (item == null) continue;
-					if (InventoryUtil.inventoryContains(playerInventory, item)) continue;
+					if (InventoryUtil.inventoryContains(inventory, item)) continue;
 					return false;
 				}
 			} else {
@@ -1248,42 +1243,42 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		if (reagents != null) {
 			for (SpellReagents.ReagentItem item : reagents) {
 				if (item == null) continue;
-				if (livingEntity instanceof Player) Util.removeFromInventory(((Player) livingEntity).getInventory(), item);
+				if (livingEntity instanceof Player player) Util.removeFromInventory(player.getInventory(), item);
 				else if (livingEntity.getEquipment() != null) Util.removeFromInventory(livingEntity.getEquipment(), item);
 			}
 		}
 
-		if (livingEntity instanceof Player) {
-			if (manaCost != 0) MagicSpells.getManaHandler().addMana((Player) livingEntity, -manaCost, ManaChangeReason.SPELL_COST);
+		if (livingEntity instanceof Player player) {
+			if (manaCost != 0) MagicSpells.getManaHandler().addMana(player, -manaCost, ManaChangeReason.SPELL_COST);
 
 			if (hungerCost != 0) {
-				int f = ((Player) livingEntity).getFoodLevel() - hungerCost;
+				int f = player.getFoodLevel() - hungerCost;
 				if (f < 0) f = 0;
 				if (f > 20) f = 20;
-				((Player) livingEntity).setFoodLevel(f);
+				player.setFoodLevel(f);
 			}
 
-			if (experienceCost != 0) ExperienceUtils.changeExp((Player) livingEntity, -experienceCost);
+			if (experienceCost != 0) ExperienceUtils.changeExp(player, -experienceCost);
 
 			if (moneyCost != 0) {
 				MoneyHandler moneyHandler = MagicSpells.getMoneyHandler();
 				if (moneyHandler != null) {
-					if (moneyCost > 0) moneyHandler.removeMoney((Player) livingEntity, moneyCost);
-					else moneyHandler.addMoney((Player) livingEntity, moneyCost);
+					if (moneyCost > 0) moneyHandler.removeMoney(player, moneyCost);
+					else moneyHandler.addMoney(player, moneyCost);
 				}
 			}
 
 			if (levelsCost != 0) {
-				int lvl = ((Player) livingEntity).getLevel() - levelsCost;
+				int lvl = player.getLevel() - levelsCost;
 				if (lvl < 0) lvl = 0;
-				((Player) livingEntity).setLevel(lvl);
+				player.setLevel(lvl);
 			}
 
 			if (variables != null) {
 				VariableManager varMan = MagicSpells.getVariableManager();
 				if (varMan != null) {
 					for (Map.Entry<String, Double> var : variables.entrySet()) {
-						varMan.set(var.getKey(), (Player) livingEntity, varMan.getValue(var.getKey(), (Player) livingEntity) - var.getValue());
+						varMan.set(var.getKey(), player, varMan.getValue(var.getKey(), player) - var.getValue());
 					}
 				}
 			}
@@ -1296,16 +1291,17 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			livingEntity.setHealth(h);
 		}
 
-		if (durabilityCost != 0) {
-			ItemStack inHand = livingEntity.getEquipment().getItemInMainHand();
-			if (inHand != null && inHand.getItemMeta() instanceof Damageable && inHand.getType().getMaxDurability() > 0) {
-				short newDura = (short) (((Damageable) inHand.getItemMeta()).getDamage() + durabilityCost);
+		EntityEquipment equipment = livingEntity.getEquipment();
+		if (durabilityCost != 0 && equipment != null) {
+			ItemStack inHand = equipment.getItemInMainHand();
+			if (inHand.getItemMeta() instanceof Damageable damageable && inHand.getType().getMaxDurability() > 0) {
+				short newDura = (short) (damageable.getDamage() + durabilityCost);
 				if (newDura < 0) newDura = 0;
 				if (newDura >= inHand.getType().getMaxDurability()) {
 					livingEntity.getEquipment().setItemInMainHand(null);
 				} else {
 					ItemMeta meta = inHand.getItemMeta();
-					((Damageable) meta).setDamage(newDura);
+					damageable.setDamage(newDura);
 					inHand.setItemMeta(meta);
 				}
 			}
@@ -1516,9 +1512,8 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		for (SpellEffect effect : effectsList) {
 			Runnable canceler = effect.playEffect(entity);
 			if (canceler == null) continue;
-			if (!(entity instanceof Player)) continue;
-			Player p = (Player) entity;
-			Map<EffectPosition, List<Runnable>> runnablesMap = callbacks.get(p.getUniqueId().toString());
+			if (!(entity instanceof Player player)) continue;
+			Map<EffectPosition, List<Runnable>> runnablesMap = callbacks.get(player.getUniqueId().toString());
 			if (runnablesMap == null) continue;
 			List<Runnable> runnables = runnablesMap.get(pos);
 			if (runnables == null) continue;
@@ -1622,12 +1617,8 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		List<Runnable> cancelers = callbacks.get(uuid).get(pos);
 		while (!cancelers.isEmpty()) {
 			Runnable c = cancelers.iterator().next();
-			if (c instanceof Effect) {
-				Effect eff = (Effect)c;
-				eff.cancel();
-			} else {
-				c.run();
-			}
+			if (c instanceof Effect eff) eff.cancel();
+			else c.run();
 			cancelers.remove(c);
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1,5 +1,7 @@
 package com.nisovin.magicspells;
 
+import net.kyori.adventure.text.Component;
+
 import java.util.*;
 import java.util.concurrent.ThreadLocalRandom;
 
@@ -293,7 +295,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 					spellIcon.setAmount(0);
 					if (!iconStr.contains("|")) {
 						ItemMeta iconMeta = spellIcon.getItemMeta();
-						iconMeta.setDisplayName(MagicSpells.getTextColor() + name);
+						iconMeta.displayName(Component.text(MagicSpells.getTextColor() + name));
 						spellIcon.setItemMeta(iconMeta);
 					}
 				}

--- a/core/src/main/java/com/nisovin/magicspells/Spellbook.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spellbook.java
@@ -1,9 +1,5 @@
 package com.nisovin.magicspells;
 
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.OutputStreamWriter;
-
 import java.util.Set;
 import java.util.Map;
 import java.util.List;
@@ -14,11 +10,17 @@ import java.util.Scanner;
 import java.util.ArrayList;
 import java.util.Collections;
 
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.OutputStreamWriter;
+
 import org.bukkit.World;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.Plugin;
 import org.bukkit.inventory.ItemStack;
+
+import java.nio.charset.StandardCharsets;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.CastItem;
@@ -37,17 +39,14 @@ public class Spellbook {
 	private String playerName;
 	private String uniqueId;
 
-	private TreeSet<Spell> allSpells = new TreeSet<Spell>() {
+	private TreeSet<Spell> allSpells = new TreeSet<>() {
 
 		private static final long serialVersionUID = 1L;
 
 		@Override
 		public boolean remove(Object o) {
 			boolean ret = super.remove(o);
-			if (o instanceof Spell) {
-				Spell s = (Spell) o;
-				s.unloadPlayerEffectTracker(player);
-			}
+			if (o instanceof Spell spell) spell.unloadPlayerEffectTracker(player);
 			return ret;
 		}
 
@@ -149,7 +148,7 @@ public class Spellbook {
 
 			if (!file.exists()) return;
 
-			Scanner scanner = new Scanner(file, "UTF-8");
+			Scanner scanner = new Scanner(file, StandardCharsets.UTF_8);
 			while (scanner.hasNext()) {
 				String line = scanner.nextLine();
 				if (line.isEmpty()) continue;
@@ -172,7 +171,7 @@ public class Spellbook {
 						e.printStackTrace();
 					}
 				}
-				addSpell(spell, items.toArray(new CastItem[items.size()]));
+				addSpell(spell, items.toArray(new CastItem[0]));
 			}
 			scanner.close();
 
@@ -446,7 +445,7 @@ public class Spellbook {
 	}
 
 	public void removeSpell(Spell spell) {
-		if (spell instanceof BuffSpell) ((BuffSpell) spell).turnOff(player);
+		if (spell instanceof BuffSpell buffSpell) buffSpell.turnOff(player);
 		CastItem[] items = spell.getCastItems();
 		if (customBindings.containsKey(spell)) items = customBindings.remove(spell).toArray(new CastItem[]{});
 		for (CastItem item : items) {
@@ -534,8 +533,8 @@ public class Spellbook {
 
 	public void removeAllSpells() {
 		for (Spell spell : allSpells) {
-			if (!(spell instanceof BuffSpell)) continue;
-			((BuffSpell) spell).turnOff(player);
+			if (!(spell instanceof BuffSpell buffSpell)) continue;
+			buffSpell.turnOff(player);
 		}
 		allSpells.clear();
 		itemSpells.clear();
@@ -566,7 +565,7 @@ public class Spellbook {
 				file = new File(plugin.getDataFolder(), "spellbooks" + File.separator + uniqueId + ".txt");
 			}
 
-			OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file, false), "UTF-8");
+			OutputStreamWriter writer = new OutputStreamWriter(new FileOutputStream(file, false), StandardCharsets.UTF_8);
 			for (Spell spell : allSpells) {
 				if (isTemporary(spell)) continue;
 				writer.append(spell.getInternalName());

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -175,9 +175,9 @@ public class Subspell {
 				}
 
 				if (success) {
-					if (spell instanceof TargetedSpell) {
+					if (spell instanceof TargetedSpell targetedSpell) {
 						action = PostCastAction.NO_MESSAGES;
-						((TargetedSpell) spell).sendMessages(caster, target, null);
+						targetedSpell.sendMessages(caster, target, null);
 					}
 				} else action = PostCastAction.ALREADY_HANDLED;
 			}
@@ -317,9 +317,9 @@ public class Subspell {
 					else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, spellCast.getPower());
 				}
 				if (success) {
-					if (spell instanceof TargetedSpell) {
+					if (spell instanceof TargetedSpell targetedSpell) {
 						action = PostCastAction.NO_MESSAGES;
-						((TargetedSpell) spell).sendMessages(caster, target, null);
+						targetedSpell.sendMessages(caster, target, null);
 					}
 				} else action = PostCastAction.ALREADY_HANDLED;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -518,7 +518,7 @@ public enum ModifierType {
 
 			@Override
 			public boolean isValid() {
-				return variable != null && variableOwner != VariableOwner.TARGET && (mod.getVariableOwner() != VariableOwner.TARGET || mod.isConstantValue());
+				return variable != null;
 			}
 
 			@Override
@@ -528,10 +528,12 @@ public enum ModifierType {
 
 		}
 
-		private void modifyVariable(VariableModData data, Player caster, Player targetPlayer) {
-			if (data.isValid()) return;
-			Player owner = data.variableOwner == VariableOwner.CASTER ? caster : targetPlayer;
-			double amount = data.mod.getValue(caster, targetPlayer);
+		private void modifyVariable(VariableModData data, Player caster, Player target) {
+			if (!data.isValid()) return;
+			boolean needsTarget = data.variableOwner == VariableOwner.TARGET || (data.mod.getVariableOwner() == VariableOwner.TARGET && !data.mod.isConstantValue());
+			if (needsTarget && target == null) return;
+			Player owner = data.variableOwner == VariableOwner.CASTER ? caster : target;
+			double amount = data.mod.getValue(caster, target);
 			Variable variable = data.variable;
 			double newAmount = data.mod.getOperation().applyTo(variable.getValue(owner), amount);
 			MagicSpells.getVariableManager().set(variable, owner.getName(), newAmount);
@@ -571,7 +573,7 @@ public enum ModifierType {
 			if (check) modifyVariable((VariableModData) customData, event.getPlayer(), null);
 			return true;
 		}
-		
+
 		@Override
 		public CustomData buildCustomActionData(String text) {
 			//input format

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AdvancementCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AdvancementCondition.java
@@ -65,13 +65,10 @@ public class AdvancementCondition extends Condition {
 	}
 
 	private boolean hasAdvancement(LivingEntity livingEntity) {
-		if (!(livingEntity instanceof Player)) return false;
-		Player player = (Player) livingEntity;
-
+		if (!(livingEntity instanceof Player player)) return false;
 		for (Advancement advancement : advancements) {
 			if (!player.getAdvancementProgress(advancement).isDone()) return false;
 		}
-
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DisplayNameCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DisplayNameCondition.java
@@ -25,8 +25,8 @@ public class DisplayNameCondition extends Condition {
 
     @Override
     public boolean check(LivingEntity livingEntity, LivingEntity target) {
-        if (!(target instanceof Player)) return false;
-        return ((Player) target).getDisplayName().equalsIgnoreCase(displayName);
+        if (!(target instanceof Player player)) return false;
+        return Util.getStringFromComponent(player.displayName()).equalsIgnoreCase(displayName);
     }
 
     @Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DurabilityCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DurabilityCondition.java
@@ -76,27 +76,15 @@ public class DurabilityCondition extends Condition {
 	private boolean checkDurability(LivingEntity livingEntity) {
 		EntityEquipment equipment = livingEntity.getEquipment();
 		for (DurabilityChecker d : durabilitySet) {
-			ItemStack item = null;
-			switch (d.slot) {
-				case 0:
-					item = equipment.getHelmet();
-					break;
-				case 1:
-					item = equipment.getChestplate();
-					break;
-				case 2:
-					item = equipment.getLeggings();
-					break;
-				case 3:
-					item = equipment.getBoots();
-					break;
-				case 4:
-					item = equipment.getItemInOffHand();
-					break;
-				case 5:
-					item = equipment.getItemInMainHand();
-					break;
-			}
+			ItemStack item = switch (d.slot) {
+				case 0 -> equipment.getHelmet();
+				case 1 -> equipment.getChestplate();
+				case 2 -> equipment.getLeggings();
+				case 3 -> equipment.getBoots();
+				case 4 -> equipment.getItemInOffHand();
+				case 5 -> equipment.getItemInMainHand();
+				default -> null;
+			};
 
 			if (item == null) return false;
 			ItemMeta meta = item.getItemMeta();

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/EntityTypeCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/EntityTypeCondition.java
@@ -25,19 +25,13 @@ public class EntityTypeCondition extends Condition {
 		String[] vars = var.replace(" ", "").split(",");
 		for (String v : vars) {
 			switch (v.toLowerCase()) {
-				case "player":
-					player = true;
-					break;
-				case "monster":
-					monster = true;
-					break;
-				case "animal":
-					animal = true;
-					break;
-				default:
+				case "player" -> player = true;
+				case "monster" -> monster = true;
+				case "animal" -> animal = true;
+				default -> {
 					EntityType type = MobUtil.getEntityType(v);
 					if (type != null) types.add(type);
-					break;
+				}
 			}
 		}
 		return player || monster || animal || !types.isEmpty();

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasSpellCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasSpellCondition.java
@@ -14,11 +14,8 @@ public class HasSpellCondition extends Condition {
 
     @Override
     public boolean initialize(String var) {
-        Spell s = MagicSpells.getSpellByInternalName(var);
-        if (s == null) return false;
-        if (!(s instanceof Spell)) return false;
-        spell = s;
-        return true;
+        spell = MagicSpells.getSpellByInternalName(var);
+        return spell != null;
     }
 
     @Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HoveringWithCondition.java
@@ -23,9 +23,8 @@ public class HoveringWithCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity) {
-		if (!(livingEntity instanceof Player)) return false;
+		if (!(livingEntity instanceof Player player)) return false;
 
-		Player player = (Player) livingEntity;
 		ItemStack itemCursor = player.getOpenInventory().getCursor();
 		if (itemCursor == null) return false;
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LastDamageTypeCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LastDamageTypeCondition.java
@@ -1,16 +1,17 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
-import org.bukkit.Location;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.castmodifiers.Condition;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 public class LastDamageTypeCondition extends Condition {
 
 	private DamageCause cause;
-	
+
 	@Override
 	public boolean initialize(String var) {
 		for (DamageCause dc : DamageCause.values()) {
@@ -30,7 +31,8 @@ public class LastDamageTypeCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		return target.getLastDamageCause().getCause() == cause;
+		EntityDamageEvent event = target.getLastDamageCause();
+		return event != null && event.getCause() == cause;
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NamePatternCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NamePatternCondition.java
@@ -6,6 +6,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.castmodifiers.Condition;
 
@@ -31,8 +32,8 @@ public class NamePatternCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		if (!(target instanceof Player)) return false;
-		return RegexUtil.matches(compiledPattern, target.getName()) || RegexUtil.matches(compiledPattern, ((Player) target).getDisplayName());
+		if (!(target instanceof Player player)) return false;
+		return RegexUtil.matches(compiledPattern, target.getName()) || RegexUtil.matches(compiledPattern, Util.getStringFromComponent(player.displayName()));
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnSameTeamCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnSameTeamCondition.java
@@ -25,7 +25,6 @@ public class OnSameTeamCondition extends Condition {
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
 		if (target instanceof Player && livingEntity instanceof Player) {
 			ScoreboardManager scoreboardManager = Bukkit.getScoreboardManager();
-			if (scoreboardManager == null) return false;
 			Team team1 = scoreboardManager.getMainScoreboard().getEntryTeam(livingEntity.getName());
 			Team team2 = scoreboardManager.getMainScoreboard().getEntryTeam(target.getName());
 			return team1 != null && team1.equals(team2);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SignTextCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SignTextCondition.java
@@ -1,12 +1,16 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
-import com.nisovin.magicspells.util.Util;
+import java.util.List;
+import java.util.ArrayList;
+
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
 import org.bukkit.block.Block;
 import org.bukkit.entity.LivingEntity;
 
-import com.nisovin.magicspells.MagicSpells;
+import net.kyori.adventure.text.Component;
+
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.MagicLocation;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.castmodifiers.Condition;
@@ -16,7 +20,7 @@ public class SignTextCondition extends Condition {
 	//world,x,y,z,text
 
 	private MagicLocation location;
-	private String[] text;
+	private List<Component> text;
 
 	@Override
 	public boolean initialize(String var) {
@@ -24,14 +28,10 @@ public class SignTextCondition extends Condition {
 			String[] vars = var.split(",");
 			location = new MagicLocation(vars[0], Integer.parseInt(vars[1]), Integer.parseInt(vars[2]), Integer.parseInt(vars[3]));
 
-			String[] sign = vars[4].split("\\\\n");
-			text = new String[sign.length];
-
-			for (int i = 0; i < sign.length; i++) {
-				String replaced = sign[i].replaceAll("__", " ");
-				text[i] = Util.colorize(replaced);
+			text = new ArrayList<>();
+			for (String line : vars[4].split("\\\\n")) {
+				text.add(Util.getMiniMessage(line.replaceAll("__", " ")));
 			}
-
 			return true;
 		} catch (Exception e) {
 			DebugHandler.debugGeneral(e);
@@ -59,8 +59,10 @@ public class SignTextCondition extends Condition {
 		if (!block.getType().name().contains("SIGN")) return false;
 
 		Sign sign = (Sign) block.getState();
-		for (int i = 0; i < sign.getLines().length; i++) {
-			if (text.length > i && !sign.getLine(i).contains(text[i])) return false;
+		List<Component> lines = sign.lines();
+		for (int i = 0; i < lines.size(); i++) {
+			if (lines.get(i).equals(text.get(i))) continue;
+			return false;
 		}
 
 		return true;

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SpellSelectedCondition.java
@@ -57,9 +57,7 @@ public class SpellSelectedCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity) {
-		if (!(livingEntity instanceof Player)) return false;
-
-		Player player = (Player) livingEntity;
+		if (!(livingEntity instanceof Player player)) return false;
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		ItemStack item = player.getInventory().getItemInMainHand();
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -59,9 +59,14 @@ public class MagicCommand extends BaseCommand {
 			return spells;
 		});
 		commandManager.getCommandCompletions().registerAsyncCompletion("owned_spells", context -> {
+			Set<Spell> spells = new HashSet<>();
 			Player player = context.getPlayer();
-			if (player == null) return Collections.emptyList();
-			return getSpellNames(MagicSpells.getSpellbook(player).getSpells());
+			Spellbook spellbook = MagicSpells.getSpellbook(player);
+			for (Spell spell : MagicSpells.getSpellsOrdered()) {
+				if (!spellbook.hasSpell(spell)) continue;
+				spells.add(spell);
+			}
+			return getSpellNames(spells);
 		});
 		commandManager.getCommandCompletions().registerAsyncCompletion("players+", context -> {
 			Set<String> players = new HashSet<>();

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -92,21 +92,11 @@ public class MagicCommand extends BaseCommand {
 			Location location = block.getLocation();
 			String num = "";
 			switch (config.toLowerCase()) {
-				case "x":
-					num += location.getX();
-					break;
-				case "y":
-					num += location.getY();
-					break;
-				case "z":
-					num += location.getZ();
-					break;
-				case "pitch":
-					num += player.getLocation().getPitch();
-					break;
-				case "yaw":
-					num += player.getLocation().getYaw();
-					break;
+				case "x" -> num += location.getX();
+				case "y" -> num += location.getY();
+				case "z" -> num += location.getZ();
+				case "pitch" -> num += player.getLocation().getPitch();
+				case "yaw" -> num += player.getLocation().getYaw();
 			}
 			if (!num.isEmpty()) completions.add(num);
 			return completions;
@@ -634,13 +624,18 @@ public class MagicCommand extends BaseCommand {
 	}
 
 	@Subcommand("debug")
+	@Syntax("[level]")
 	@Description("Toggle MagicSpells debug mode.")
 	@HelpPermission(permission = Perm.COMMAND_DEBUG)
-	public static void onDebug(CommandIssuer issuer) {
+	public static void onDebug(CommandIssuer issuer, @Optional Integer level) {
 		if (!MagicSpells.isLoaded()) return;
 		if (noPermission(issuer.getIssuer(), Perm.COMMAND_DEBUG)) return;
+
+		int levelFinal = MagicSpells.isDebug() || level == null ? MagicSpells.getDebugLevelOriginal() : level;
+		MagicSpells.setDebugLevel(levelFinal);
 		MagicSpells.setDebug(!MagicSpells.isDebug());
-		issuer.sendMessage(MagicSpells.getTextColor() + "MagicSpells debug mode " + (MagicSpells.isDebug() ? "enabled" : "disabled") + ".");
+
+		issuer.sendMessage(MagicSpells.getTextColor() + "MagicSpells debug mode " + (MagicSpells.isDebug() ? "enabled (level: " + levelFinal + ")" : "disabled") + ".");
 	}
 
 	@Subcommand("magicxp")
@@ -717,8 +712,7 @@ public class MagicCommand extends BaseCommand {
 				return;
 			}
 			// LivingEntity
-			if (sender instanceof LivingEntity) {
-				LivingEntity livingEntity = (LivingEntity) sender;
+			if (sender instanceof LivingEntity livingEntity) {
 				if (!spell.canCastByCommand()) return;
 				EntityEquipment equipment = livingEntity.getEquipment();
 				if (equipment == null) return;
@@ -766,11 +760,10 @@ public class MagicCommand extends BaseCommand {
 			if (target == null) throw new ConditionFailedException("Entity not found.");
 			Spell spell = getSpell(issuer, args[1]);
 			if (spell == null) return;
-			if (!(spell instanceof TargetedEntitySpell)) {
+			if (!(spell instanceof TargetedEntitySpell newSpell)) {
 				throw new ConditionFailedException("Spell is not a targeted entity spell.");
 			}
 
-			TargetedEntitySpell newSpell = ((TargetedEntitySpell) spell);
 			boolean casted;
 			// Handle with or without caster.
 			if (issuer.getIssuer() instanceof LivingEntity) casted = newSpell.castAtEntity(issuer.getIssuer(), target, 1F);
@@ -790,7 +783,7 @@ public class MagicCommand extends BaseCommand {
 			if (args.length < 4) throw new InvalidCommandArgument();
 			Spell spell = getSpell(issuer, args[0]);
 			if (spell == null) return;
-			if (!(spell instanceof TargetedLocationSpell)) {
+			if (!(spell instanceof TargetedLocationSpell newSpell)) {
 				throw new ConditionFailedException("Spell is not a targeted location spell.");
 			}
 
@@ -833,7 +826,6 @@ public class MagicCommand extends BaseCommand {
 			}
 			Location location = new Location(world, x, y, z, pitch, yaw);
 
-			TargetedLocationSpell newSpell = ((TargetedLocationSpell) spell);
 			boolean casted;
 			// Handle with or without caster.
 			if (issuer.getIssuer() instanceof LivingEntity) casted = newSpell.castAtLocation(issuer.getIssuer(), location, 1F);

--- a/core/src/main/java/com/nisovin/magicspells/handlers/MagicXpHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/MagicXpHandler.java
@@ -117,9 +117,8 @@ public class MagicXpHandler implements Listener {
 
 		if (!autoLearn) return;
 		final LivingEntity caster = event.getCaster();
-		if (!(caster instanceof Player)) return;
+		if (!(caster instanceof Player player)) return;
 
-		Player player = (Player) caster;
 		final Spell castedSpell = event.getSpell();
 		MagicSpells.scheduleDelayedTask(() -> {
 
@@ -222,7 +221,6 @@ public class MagicXpHandler implements Listener {
 		File folder = new File(plugin.getDataFolder(), "xp");
 		if (!folder.exists()) folder.mkdirs();
 		if (MagicSpells.arePlayerSpellsSeparatedPerWorld()) {
-			if (world == null) return;
 			folder = new File(folder, world);
 			if (!folder.exists()) folder.mkdirs();
 		}

--- a/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/RecipeHandler.java
@@ -18,12 +18,7 @@ public class RecipeHandler implements Listener {
     private static final Map<String, Recipe> recipes = new HashMap<>();
 
     public static void create(ConfigurationSection config) {
-        String type = config.getString("type", "shaped");
-        if (type == null) {
-            MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'type' defined.");
-            return;
-        }
-        type = type.toLowerCase();
+        String type = config.getString("type", "shaped").toLowerCase();
 
         String itemString = config.getString("result");
         if (itemString == null || itemString.isEmpty()) {
@@ -60,32 +55,12 @@ public class RecipeHandler implements Listener {
 
         Recipe recipe = null;
         switch (type) {
-            case "shaped":
-                recipe = createShapedRecipe(config, namespaceKey, result, group);
-                break;
-
-            case "shapeless":
-                recipe = createShapelessRecipe(config, namespaceKey, result, group);
-                break;
-
-            case "smoking":
-            case "campfire":
-            case "blasting":
-            case "furnace":
-                recipe = createCookingRecipe(config, type, namespaceKey, result, group);
-                break;
-
-            case "stonecutting":
-                recipe = createStoneCuttingRecipe(config, namespaceKey, result, group);
-                break;
-
-            case "smithing":
-                recipe = createSmithingRecipe(config, namespaceKey, result);
-                break;
-
-            default:
-                MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'type' defined.");
-                break;
+            case "shaped" -> recipe = createShapedRecipe(config, namespaceKey, result, group);
+            case "shapeless" -> recipe = createShapelessRecipe(config, namespaceKey, result, group);
+            case "smoking", "campfire", "blasting", "furnace" -> recipe = createCookingRecipe(config, type, namespaceKey, result, group);
+            case "stonecutting" -> recipe = createStoneCuttingRecipe(config, namespaceKey, result, group);
+            case "smithing" -> recipe = createSmithingRecipe(config, namespaceKey, result);
+            default -> MagicSpells.error("Recipe '" + config.getName() + "' has an invalid 'type' defined.");
         }
         if (recipe == null) return;
 
@@ -173,9 +148,7 @@ public class RecipeHandler implements Listener {
     private static Recipe createStoneCuttingRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result, String group) {
         Material ingredient = getMaterial(config.getString("ingredient"), "Recipe '" + config.getName() + "' has an invalid 'ingredient' defined.");
         if (ingredient == null) return null;
-        Recipe recipe = ItemUtil.createStonecutterRecipe(namespaceKey, group, result, ingredient);
-        if (recipe == null) MagicSpells.error("Recipe type 'stonecutting' on recipe '" + config.getName() + "' is unsupported on this version of spigot.");
-        return recipe;
+        return ItemUtil.createStonecutterRecipe(namespaceKey, group, result, ingredient);
     }
 
     private static Recipe createSmithingRecipe(ConfigurationSection config, NamespacedKey namespaceKey, ItemStack result) {
@@ -183,9 +156,7 @@ public class RecipeHandler implements Listener {
         if (base == null) return null;
         Material addition = getMaterial(config.getString("base"), "Recipe '" + config.getName() + "' has an invalid 'addition' defined.");
         if (addition == null) return null;
-        Recipe recipe = new SmithingRecipe(namespaceKey, result, new RecipeChoice.MaterialChoice(base), new RecipeChoice.MaterialChoice(addition));
-        if (recipe == null) MagicSpells.error("Recipe type 'stonecutting' on recipe '" + config.getName() + "' is unsupported on this version of spigot.");
-        return recipe;
+        return new SmithingRecipe(namespaceKey, result, new RecipeChoice.MaterialChoice(base), new RecipeChoice.MaterialChoice(addition));
     }
 
     public static void clearRecipes() {

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -166,19 +166,16 @@ public class CastListener implements Listener {
 	
 	@EventHandler
 	public void onPlayerShootBow(EntityShootBowEvent event) {
-		if (!(event.getEntity() instanceof Player)) return;
+		if (!(event.getEntity() instanceof Player player)) return;
 		if (event.getHand() == EquipmentSlot.OFF_HAND && !MagicSpells.castBoundBowSpellsFromOffhand()) return;
 
-		Player player = (Player) event.getEntity();
 		ItemStack bow = event.getBow();
 		if (bow == null) return;
 
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		Spell spell = spellbook.getActiveSpell(bow);
 
-		if (spell instanceof BowSpell) {
-			BowSpell bowSpell = (BowSpell) spell;
-
+		if (spell instanceof BowSpell bowSpell) {
 			if (bowSpell.canCastWithItem() && bowSpell.isBindRequired() && checkGlobalCooldown(player, spell)) bowSpell.handleBowCast(event);
 		} else castSpell(player, spell);
 

--- a/core/src/main/java/com/nisovin/magicspells/listeners/ConsumeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/ConsumeListener.java
@@ -16,13 +16,10 @@ import com.nisovin.magicspells.Spell.SpellCastResult;
 
 public class ConsumeListener implements Listener {
 
-	private MagicSpells plugin;
-
 	private Map<CastItem, Spell> consumeCastItems = new HashMap<>();
 	private Map<String, Long> lastCast = new HashMap<>();
 	
-	public ConsumeListener(MagicSpells plugin) {
-		this.plugin = plugin;
+	public ConsumeListener() {
 		for (Spell spell : MagicSpells.getSpells().values()) {
 			CastItem[] items = spell.getConsumeCastItems();
 			if (items.length <= 0) continue;

--- a/core/src/main/java/com/nisovin/magicspells/listeners/MagicChatListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/MagicChatListener.java
@@ -1,26 +1,23 @@
 package com.nisovin.magicspells.listeners;
 
-import org.bukkit.entity.Player;
-import org.bukkit.event.Listener;
-import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
-import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 
-public class MagicChatListener implements Listener {
+import io.papermc.paper.event.player.AsyncChatEvent;
 
-	private MagicSpells plugin;
-	
-	public MagicChatListener(MagicSpells plugin) {
-		this.plugin = plugin;
-	}
+import org.bukkit.entity.Player;
+import org.bukkit.event.Listener;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.player.PlayerCommandPreprocessEvent;
+
+public class MagicChatListener implements Listener {
 	
 	@EventHandler(ignoreCancelled = true)
-	public void onPlayerChat(final AsyncPlayerChatEvent event) {
-		MagicSpells.scheduleDelayedTask(() -> handleIncantation(event.getPlayer(), event.getMessage()), 0);
+	public void onPlayerChat(final AsyncChatEvent event) {
+		handleIncantation(event.getPlayer(), Util.getStringFromComponent(event.message()));
 	}
 	
 	@EventHandler(ignoreCancelled = true)

--- a/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
@@ -62,7 +62,6 @@ public class MagicSpellListener implements Listener {
 	@EventHandler
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
-		if (entity == null) return;
 		if (!isMSEntity(entity)) return;
 		event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/listeners/VariableListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/VariableListener.java
@@ -51,8 +51,7 @@ public class VariableListener implements Listener {
 		Multimap<String, VariableMod> varMods = event.getSpell().getVariableModsCast();
 		if (varMods == null || varMods.isEmpty()) return;
 		LivingEntity caster = event.getCaster();
-		if (!(caster instanceof Player)) return;
-		Player player = (Player) caster;
+		if (!(caster instanceof Player player)) return;
 		for (Map.Entry<String, VariableMod> entry : varMods.entries()) {
 			VariableMod mod = entry.getValue();
 			if (mod == null) continue;
@@ -69,8 +68,7 @@ public class VariableListener implements Listener {
 		Multimap<String, VariableMod> varMods = event.getSpell().getVariableModsCasted();
 		if (varMods == null || varMods.isEmpty()) return;
 		LivingEntity caster = event.getCaster();
-		if (!(caster instanceof Player)) return;
-		Player player = (Player) caster;
+		if (!(caster instanceof Player player)) return;
 		for (Map.Entry<String, VariableMod> entry : varMods.entries()) {
 			VariableMod mod = entry.getValue();
 			if (mod == null) continue;

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ActionBarTextEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ActionBarTextEffect.java
@@ -5,7 +5,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Util;
-import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 
 public class ActionBarTextEffect extends SpellEffect {
@@ -28,7 +27,7 @@ public class ActionBarTextEffect extends SpellEffect {
 	}
 	
 	private void send(Player player) {
-		player.sendActionBar(Util.doVarReplacementAndColorize(player, message));
+		player.sendActionBar(Util.getMiniMessageWithVars(player, message));
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -163,7 +163,7 @@ public class BowSpell extends Spell {
 		ItemStack inHand = event.getBow();
 		if (inHand == null || (inHand.getType() != Material.BOW && inHand.getType() != Material.CROSSBOW)) return;
 
-		String name = inHand.getItemMeta().getDisplayName();
+		String name = Util.getStringFromComponent(inHand.displayName());
 		if (bowNames != null && !bowNames.contains(name)) return;
 		if (disallowedBowNames != null && disallowedBowNames.contains(name)) return;
 		if (bowName != null && !bowName.isEmpty() && !bowName.equals(name)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -474,8 +474,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 			if (!entry.getValue().getUniqueId().equals(livingEntity.getUniqueId())) continue;
 
 			Entity entity = Bukkit.getEntity(entry.getKey());
-			if (!(entity instanceof LivingEntity)) return null;
-			LivingEntity target = (LivingEntity) entity;
+			if (!(entity instanceof LivingEntity target)) return null;
 			return isActiveAndNotExpired(target) ? target : null;
 		}
 
@@ -488,28 +487,26 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		public void onEntityDamage(EntityDamageEvent e) {
 			if (cancelOnTakeDamage) {
 				Entity entity = e.getEntity();
-				if (!(entity instanceof LivingEntity)) return;
-				LivingEntity target = getWhoToCancel((LivingEntity) entity);
+				if (!(entity instanceof LivingEntity livingEntity)) return;
+				LivingEntity target = getWhoToCancel(livingEntity);
 				if (target == null) return;
 				turnOff(target);
 				return;
 			}
 
 			if (cancelOnGiveDamage) {
-				if (!(e instanceof EntityDamageByEntityEvent)) return;
-				EntityDamageByEntityEvent evt = (EntityDamageByEntityEvent) e;
+				if (!(e instanceof EntityDamageByEntityEvent evt)) return;
 
 				Entity damager = evt.getDamager();
-				if (!(damager instanceof LivingEntity)) return;
-
-				LivingEntity target = getWhoToCancel((LivingEntity) damager);
+				if (!(damager instanceof LivingEntity livingEntity)) return;
+				LivingEntity target = getWhoToCancel(livingEntity);
 				if (target != null) {
 					turnOff(target);
 					return;
 				}
 
-				if (damager instanceof Projectile && ((Projectile) damager).getShooter() instanceof LivingEntity) {
-					LivingEntity newTarget = getWhoToCancel((LivingEntity) ((Projectile) damager).getShooter());
+				if (damager instanceof Projectile projectile && projectile.getShooter() instanceof LivingEntity shooter) {
+					LivingEntity newTarget = getWhoToCancel(shooter);
 					if (newTarget == null) return;
 					turnOff(newTarget);
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
@@ -149,18 +149,18 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			if (commandToExecute != null && !commandToExecute.isEmpty()) {
 
 				Conversation convo = null;
-				if (sender instanceof Player) {
+				if (sender instanceof Player player) {
 					if (blockChatOutput && messageBlocker != null) {
-						messageBlocker.addPlayer((Player) sender);
+						messageBlocker.addPlayer(player);
 					} else if (convoFac != null) {
-						convo = convoFac.buildConversation((Player) sender);
+						convo = convoFac.buildConversation(player);
 						convo.begin();
 					}
 				}
 				
 				int delay = 0;
 				Player varOwner;
-				if (!useTargetVariablesInstead) varOwner = sender instanceof Player ? (Player) sender : null;
+				if (!useTargetVariablesInstead) varOwner = sender instanceof Player player ? player : null;
 				else varOwner = target;
 
 				for (String comm : commandToExecute) {
@@ -184,7 +184,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 						Bukkit.dispatchCommand(actualSender, comm);
 					}
 				}
-				if (blockChatOutput && messageBlocker != null && sender instanceof Player) messageBlocker.removePlayer((Player) sender);
+				if (blockChatOutput && messageBlocker != null && sender instanceof Player player) messageBlocker.removePlayer(player);
 				else if (convo != null) convo.abandon();
 			}
 		} catch (Exception e) {
@@ -196,11 +196,11 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 		if (opped) actualSender.setOp(false);
 		
 		// Effects
-		if (sender instanceof Player) {
-			if (target != null) playSpellEffects((Player) sender, target);
-			else playSpellEffects(EffectPosition.CASTER, (Player) sender);
-		} else if (sender instanceof BlockCommandSender) {
-			playSpellEffects(EffectPosition.CASTER, ((BlockCommandSender) sender).getBlock().getLocation());
+		if (sender instanceof Player player) {
+			if (target != null) playSpellEffects(player, target);
+			else playSpellEffects(EffectPosition.CASTER, player);
+		} else if (sender instanceof BlockCommandSender commandBlock) {
+			playSpellEffects(EffectPosition.CASTER, commandBlock.getBlock().getLocation());
 		}
 		// Add delayed command
 		if (commandToExecuteLater != null && !commandToExecuteLater.isEmpty() && !commandToExecuteLater.get(0).isEmpty()) {
@@ -210,8 +210,8 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (requirePlayerTarget && target instanceof Player) {
-			process(caster, (Player) target, MagicSpells.NULL_ARGS);
+		if (requirePlayerTarget && target instanceof Player player) {
+			process(caster, player, MagicSpells.NULL_ARGS);
 			return true;
 		}
 		return false;
@@ -219,8 +219,8 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (requirePlayerTarget && target instanceof Player) {
-			process(null, (Player) target, MagicSpells.NULL_ARGS);
+		if (requirePlayerTarget && target instanceof Player player) {
+			process(null, player, MagicSpells.NULL_ARGS);
 			return true;
 		}
 		return false;
@@ -293,11 +293,11 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			// Run commands
 			try {
 				Conversation convo = null;
-				if (sender instanceof Player) {
+				if (sender instanceof Player player) {
 					if (blockChatOutput && messageBlocker != null) {
-						messageBlocker.addPlayer((Player) sender);
+						messageBlocker.addPlayer(player);
 					} else if (convoFac != null) {
-						convo = convoFac.buildConversation((Player) sender);
+						convo = convoFac.buildConversation(player);
 						convo.begin();
 					}
 				}
@@ -308,7 +308,7 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 					if (target != null) comm = comm.replace("%t", target.getName());
 					Bukkit.dispatchCommand(actualSender, comm);
 				}
-				if (blockChatOutput && messageBlocker != null && sender instanceof Player) messageBlocker.removePlayer((Player) sender);
+				if (blockChatOutput && messageBlocker != null && sender instanceof Player player) messageBlocker.removePlayer(player);
 				else if (convo != null) convo.abandon();
 			} catch (Exception e) {
 				// Catch exceptions to make sure we don't leave someone opped
@@ -320,8 +320,8 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			
 			// Graphical effect
 			if (sender == null) return;
-			if (sender instanceof Player) playSpellEffects(EffectPosition.DISABLED, (Player) sender);
-			else if (sender instanceof BlockCommandSender) playSpellEffects(EffectPosition.DISABLED, ((BlockCommandSender) sender).getBlock().getLocation());
+			if (sender instanceof Player player) playSpellEffects(EffectPosition.DISABLED, player);
+			else if (sender instanceof BlockCommandSender commandBlock) playSpellEffects(EffectPosition.DISABLED, commandBlock.getBlock().getLocation());
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -125,8 +125,8 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			option.spellName = getConfigString(path + "spell", "");
 			option.spellRightName = getConfigString(path + "spell-right", "");
 			option.spellMiddleName = getConfigString(path + "spell-middle", "");
-			option.spellSneakRightName = getConfigString(path + "spell-sneak-left", "");
-			option.spellSneakLeftName = getConfigString(path + "spell-sneak-right", "");
+			option.spellSneakLeftName = getConfigString(path + "spell-sneak-left", "");
+			option.spellSneakRightName = getConfigString(path + "spell-sneak-right", "");
 			option.power = getConfigFloat(path + "power", 1);
 			option.modifierList = getConfigStringList(path + "modifiers", null);
 			option.stayOpen = getConfigBoolean(path + "stay-open", false);

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -4,7 +4,6 @@ import java.util.*;
 
 import co.aikar.commands.ACFUtil;
 
-import com.nisovin.magicspells.util.ItemUtil;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -22,6 +21,7 @@ import org.bukkit.event.inventory.InventoryClickEvent;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.BlockUtils;
 import com.nisovin.magicspells.util.MagicConfig;
@@ -289,7 +289,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 			// Select and finalise item to display.
 			ItemStack item = (option.item != null ? option.item : option.items.get(Util.getRandomInt(option.items.size()))).clone();
-			item = ItemUtil.setPersistentString(item, "menuOption", option.menuOptionName);
+			ItemUtil.setPersistentString(item, "menuOption", option.menuOptionName);
 			item = translateItem(opener, args, item);
 
 			int quantity;

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -18,15 +18,10 @@ import org.bukkit.event.inventory.ClickType;
 import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
-import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.ItemUtil;
-import com.nisovin.magicspells.util.TargetInfo;
-import com.nisovin.magicspells.util.BlockUtils;
-import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.variables.Variable;
-import com.nisovin.magicspells.util.PlayerNameUtils;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
@@ -289,7 +284,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 			// Select and finalise item to display.
 			ItemStack item = (option.item != null ? option.item : option.items.get(Util.getRandomInt(option.items.size()))).clone();
-			ItemUtil.setPersistentString(item, "menuOption", option.menuOptionName);
+			DataUtil.setString(item, "menuOption", option.menuOptionName);
 			item = translateItem(opener, args, item);
 
 			int quantity;
@@ -356,7 +351,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	private String castSpells(Player player, ItemStack item, ClickType click) {
 		// Outside inventory.
 		if (item == null) return stayOpenNonOption ? "ignore" : "close";
-		String key = ItemUtil.getPersistentString(item, "menuOption");
+		String key = DataUtil.getString(item, "menuOption");
 		// Probably a filler or air.
 		if (key == null || key.isEmpty() || !options.containsKey(key)) return stayOpenNonOption ? "ignore" : "close";
 		MenuOption option = options.get(key);

--- a/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
@@ -239,7 +239,8 @@ public final class MultiSpell extends InstantSpell {
 		@Override
 		public void run() {
 			Entity entity = Bukkit.getEntity(casterUUID);
-			if (entity != null && entity.isValid() && entity instanceof LivingEntity) spell.cast((LivingEntity) entity, power);
+			if (entity == null || !entity.isValid() || !(entity instanceof LivingEntity livingEntity)) return;
+			spell.cast(livingEntity, power);
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/OffhandCooldownSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/OffhandCooldownSpell.java
@@ -75,8 +75,8 @@ public class OffhandCooldownSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			players.add((Player) caster);
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
+			players.add(player);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -10,7 +10,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.EventPriority;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Subspell;
@@ -320,8 +319,6 @@ public class PassiveSpell extends Spell {
 				Location loc = null;
 				if (location != null) loc = location;
 				else if (target != null) loc = target.getLocation();
-
-				if (loc == null) continue;
 
 				SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(this, caster, loc, basePower);
 				EventUtil.call(targetEvent);

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -83,22 +83,22 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	public void initializeModifiers() {
 		super.initializeModifiers();
 
-		if (playerModifiersStrings != null && !playerModifiersStrings.isEmpty()) {
-			playerModifiers = new ModifierSet(playerModifiersStrings, this);
-		}
+		if (playerModifiersStrings == null || playerModifiersStrings.isEmpty()) return;
+		playerModifiers = new ModifierSet(playerModifiersStrings, this);
 	}
 
 	@Override
 	public void initialize() {
 		super.initialize();
 
-		spellOffline = initSubspell(spellOfflineName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-offline defined!");
-		spellRange = initSubspell(spellRangeName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-range defined!");
-		spellOnLeft = initSubspell(spellOnLeftName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-on-left defined!");
-		spellOnRight = initSubspell(spellOnRightName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-on-right defined!");
-		spellOnMiddle = initSubspell(spellOnMiddleName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-on-middle defined!");
-		spellOnSneakLeft = initSubspell(spellOnSneakLeftName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-on-sneak-left defined!");
-		spellOnSneakRight = initSubspell(spellOnSneakRightName, "PlayerMenuSpell '" + internalName + "' has an invalid spell-on-sneak-right defined!");
+		String error = "PlayerMenuSpell '" + internalName + "' has an invalid ";
+		spellOffline = initSubspell(spellOfflineName, error + "spell-offline defined!");
+		spellRange = initSubspell(spellRangeName, error + "spell-range defined!");
+		spellOnLeft = initSubspell(spellOnLeftName, error + "spell-on-left defined!");
+		spellOnRight = initSubspell(spellOnRightName, error + "spell-on-right defined!");
+		spellOnMiddle = initSubspell(spellOnMiddleName, error + "spell-on-middle defined!");
+		spellOnSneakLeft = initSubspell(spellOnSneakLeftName, error + "spell-on-sneak-left defined!");
+		spellOnSneakRight = initSubspell(spellOnSneakRightName, error + "spell-on-sneak-right defined!");
 
 		spellPower = new HashMap<>();
 	}
@@ -117,15 +117,15 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!(target instanceof Player)) return false;
-		openDelay((Player) target, power);
+		if (!(target instanceof Player player)) return false;
+		openDelay(player, power);
 		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!(target instanceof Player)) return false;
-		openDelay((Player) target, power);
+		if (!(target instanceof Player player)) return false;
+		openDelay(player, power);
 		return true;
 	}
 
@@ -231,11 +231,11 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 			return;
 		}
 		switch (event.getClick()) {
-			case LEFT: processClickSpell(spellOnLeft, player, targetPlayer, power); break;
-			case RIGHT: processClickSpell(spellOnRight, player, targetPlayer, power); break;
-			case MIDDLE: processClickSpell(spellOnMiddle, player, targetPlayer, power); break;
-			case SHIFT_LEFT: processClickSpell(spellOnSneakLeft, player, targetPlayer, power); break;
-			case SHIFT_RIGHT: processClickSpell(spellOnSneakRight, player, targetPlayer, power); break;
+			case LEFT -> processClickSpell(spellOnLeft, player, targetPlayer, power);
+			case RIGHT -> processClickSpell(spellOnRight, player, targetPlayer, power);
+			case MIDDLE -> processClickSpell(spellOnMiddle, player, targetPlayer, power);
+			case SHIFT_LEFT -> processClickSpell(spellOnSneakLeft, player, targetPlayer, power);
+			case SHIFT_RIGHT -> processClickSpell(spellOnSneakRight, player, targetPlayer, power);
 		}
 		if (variableTarget != null && !variableTarget.isEmpty() && MagicSpells.getVariableManager().getVariable(variableTarget) != null) {
 			MagicSpells.getVariableManager().set(variableTarget, player, target.getName());

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -2,6 +2,8 @@ package com.nisovin.magicspells.spells;
 
 import java.util.*;
 
+import net.kyori.adventure.text.Component;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.OfflinePlayer;
@@ -144,10 +146,10 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		else open(opener);
 	}
 
-	private String translate(Player player, Player target, String string) {
+	private Component translate(Player player, Player target, String string) {
 		if (target != null) string = string.replaceAll("%t", target.getName());
 		string = string.replaceAll("%a", player.getName());
-		return Util.doVarReplacementAndColorize(player, string);
+		return Util.getMiniMessageWithVars(player, string);
 	}
 
 	private void processClickSpell(Subspell subspell, Player caster, Player target, float power) {
@@ -166,7 +168,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		if (radius > 0) players.removeIf(player -> opener.getLocation().distance(player.getLocation()) > radius);
 
 		int size = (int) Math.ceil((players.size()+1) / 9.0) * 9;
-		Inventory inv = Bukkit.createInventory(opener, size, internalName);
+		Inventory inv = Bukkit.createInventory(opener, size, Component.text(internalName));
 
 		for (int i = 0; i < players.size(); i++) {
 			ItemStack head = new ItemStack(Material.PLAYER_HEAD);
@@ -174,13 +176,13 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 			SkullMeta skullMeta = (SkullMeta) itemMeta;
 			if (skullMeta == null) continue;
 			skullMeta.setOwningPlayer(players.get(i));
-			itemMeta.setDisplayName(translate(opener, players.get(i), skullName));
+			itemMeta.displayName(translate(opener, players.get(i), skullName));
 			if (skullLore != null) {
-				List<String> lore = new ArrayList<>();
+				List<Component> lore = new ArrayList<>();
 				for (String loreLine : skullLore) {
 					lore.add(translate(opener, players.get(i), loreLine));
 				}
-				itemMeta.setLore(lore);
+				itemMeta.lore(lore);
 			}
 			head.setItemMeta(skullMeta);
 			inv.setItem(i, head);
@@ -197,7 +199,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	@EventHandler
 	public void onItemClick(InventoryClickEvent event) {
 		Player player = (Player) event.getWhoClicked();
-		if (!event.getView().getTitle().equals(internalName)) return;
+		if (!Util.getStringFromComponent(event.getView().title()).equals(internalName)) return;
 		event.setCancelled(true);
 		ItemStack item = event.getCurrentItem();
 		if (item == null) return;
@@ -207,7 +209,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		OfflinePlayer target = skullMeta.getOwningPlayer();
 		float power = spellPower.containsKey(player.getUniqueId()) ?  spellPower.get(player.getUniqueId()) : 1;
 		if (target == null || !target.isOnline()) {
-			itemMeta.setDisplayName(translate(player, null, skullNameOffline));
+			itemMeta.displayName(translate(player, null, skullNameOffline));
 			if (spellOffline != null) spellOffline.cast(player, power);
 			if (stayOpen) item.setItemMeta(itemMeta);
 			else {
@@ -216,12 +218,12 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 			}
 			return;
 		} else {
-			itemMeta.setDisplayName(translate(player, (Player) target, skullName));
+			itemMeta.displayName(translate(player, (Player) target, skullName));
 			item.setItemMeta(itemMeta);
 		}
 		Player targetPlayer = (Player) target;
 		if (radius > 0  && targetPlayer.getLocation().distance(player.getLocation()) > radius) {
-			itemMeta.setDisplayName(translate(player, targetPlayer, skullNameRadius));
+			itemMeta.displayName(translate(player, targetPlayer, skullNameRadius));
 			if (spellRange != null) spellRange.cast(player, power);
 			if (stayOpen) item.setItemMeta(itemMeta);
 			else {

--- a/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
@@ -68,7 +68,7 @@ public class RandomSpell extends InstantSpell {
 					if (checkIndividualCooldowns && o.spell.getSpell().onCooldown(caster)) continue;
 					if (checkIndividualModifiers) {
 						ModifierSet modifiers = o.spell.getSpell().getModifiers();
-						if (modifiers != null && caster instanceof Player && !modifiers.check((Player) caster)) continue;
+						if (modifiers != null && caster instanceof Player && !modifiers.check(caster)) continue;
 					}
 					set.add(o);
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -62,11 +62,11 @@ public abstract class TargetedSpell extends InstantSpell {
 	public void sendMessages(LivingEntity caster, LivingEntity target, String[] args) {
 		String casterName = getTargetName(caster);
 		Player playerCaster = null;
-		if (caster instanceof Player) playerCaster = (Player) caster;
+		if (caster instanceof Player player) playerCaster = player;
 
 		String targetName = getTargetName(target);
 		Player playerTarget = null;
-		if (target instanceof Player) playerTarget = (Player) target;
+		if (target instanceof Player player) playerTarget = player;
 
 		if (playerCaster != null)
 			sendMessage(prepareMessage(strCastSelf, playerCaster, playerTarget), caster, args,
@@ -110,7 +110,8 @@ public abstract class TargetedSpell extends InstantSpell {
 	 * Plays the fizzle sound if it is enabled for this spell.
 	 */
 	protected void fizzle(LivingEntity livingEntity) {
-		if (playFizzleSound && livingEntity instanceof Player) ((Player) livingEntity).playEffect(livingEntity.getLocation(), Effect.EXTINGUISH, null);
+		if (!playFizzleSound || !(livingEntity instanceof Player player)) return;
+		player.playEffect(livingEntity.getLocation(), Effect.EXTINGUISH, null);
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
@@ -27,6 +27,9 @@ import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 import org.bukkit.event.inventory.InventoryType.SlotType;
 
+import net.kyori.adventure.text.Component;
+
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.MagicConfig;
@@ -48,7 +51,7 @@ public class ArmorSpell extends BuffSpell {
 
 	private String strHasArmor;
 
-	private String hiddenLore;
+	private Component hiddenLore;
 
 	public ArmorSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -74,10 +77,10 @@ public class ArmorSpell extends BuffSpell {
 		if (!permanent) registerEvents(new ArmorListener());
 	}
 
-	public static String getInvisibleLore(String s) {
+	public static Component getInvisibleLore(String s) {
 		String lore = "";
 		for (char c : s.toCharArray()) lore += ChatColor.COLOR_CHAR + "" + c;
-		return lore;
+		return Util.getMiniMessage(lore);
 	}
 
 	private ItemStack getItem(String s) {
@@ -100,14 +103,10 @@ public class ArmorSpell extends BuffSpell {
 
 		if (!permanent) {
 			ItemMeta meta = item.getItemMeta();
-
-			List<String> lore;
-			if (meta.hasLore()) lore = meta.getLore();
-			else lore = new ArrayList<>();
-
+			List<Component> lore = meta.lore();
+			if (lore == null) lore = new ArrayList<>();
 			lore.add(hiddenLore);
-
-			meta.setLore(lore);
+			meta.lore(lore);
 			item.setItemMeta(meta);
 		}
 
@@ -230,16 +229,9 @@ public class ArmorSpell extends BuffSpell {
 			while (drops.hasNext()) {
 				ItemStack drop = drops.next();
 				if (drop == null) continue;
-				if (!drop.hasItemMeta()) continue;
-
-				ItemMeta dropMeta = drop.getItemMeta();
-				if (dropMeta == null) continue;
-
-				List<String> lore = dropMeta.getLore();
+				List<Component> lore = drop.lore();
 				if (lore == null) continue;
-				if (lore.isEmpty()) continue;
 				if (!lore.get(lore.size() - 1).equals(hiddenLore)) continue;
-
 				drops.remove();
 			}
 		}
@@ -334,11 +326,11 @@ public class ArmorSpell extends BuffSpell {
 		this.strHasArmor = strHasArmor;
 	}
 
-	public String getHiddenLore() {
+	public Component getHiddenLore() {
 		return hiddenLore;
 	}
 
-	public void setHiddenLore(String hiddenLore) {
+	public void setHiddenLore(Component hiddenLore) {
 		this.hiddenLore = hiddenLore;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
@@ -208,11 +208,8 @@ public class ArmorSpell extends BuffSpell {
 		@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled=true)
 		public void onEntityDamage(EntityDamageEvent event) {
 			Entity entity = event.getEntity();
-			if (!(entity instanceof LivingEntity)) return;
-
-			LivingEntity livingEntity = (LivingEntity) entity;
+			if (!(entity instanceof LivingEntity livingEntity)) return;
 			if (!isActive(livingEntity)) return;
-
 			if (livingEntity.getNoDamageTicks() >= 10) return;
 			addUseAndChargeCost(livingEntity);
 		}
@@ -220,14 +217,9 @@ public class ArmorSpell extends BuffSpell {
 		@EventHandler(ignoreCancelled=true)
 		public void onInventoryClick(InventoryClickEvent event) {
 			if (event.getSlotType() != SlotType.ARMOR) return;
-
 			HumanEntity entity = event.getWhoClicked();
-
-			if (!(entity instanceof Player)) return;
-
-			Player p = (Player)entity;
+			if (!(entity instanceof Player p)) return;
 			if (!isActive(p)) return;
-
 			event.setCancelled(true);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
@@ -125,9 +125,7 @@ public class FlamewalkSpell extends BuffSpell {
 		public void run() {
 			for (UUID id : entities.keySet()) {
 				Entity entity = Bukkit.getEntity(id);
-				if (!(entity instanceof LivingEntity)) continue;
-				LivingEntity livingEntity = (LivingEntity) entity;
-
+				if (!(entity instanceof LivingEntity livingEntity)) continue;
 				if (isExpired(livingEntity)) {
 					turnOff(livingEntity);
 					continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/GillsSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/GillsSpell.java
@@ -79,12 +79,10 @@ public class GillsSpell extends BuffSpell {
 		if (headEffect && headMaterial != null) {
 			for (UUID id : entities.keySet()) {
 				Entity entity = Bukkit.getEntity(id);
-				if (!(entity instanceof LivingEntity)) continue;
-				LivingEntity livingEntity = (LivingEntity) entity;
+				if (!(entity instanceof LivingEntity livingEntity)) continue;
 				if (!livingEntity.isValid()) continue;
-
 				EntityEquipment equipment = livingEntity.getEquipment();
-
+				if (equipment == null) continue;
 				equipment.setHelmet(entities.get(id));
 			}
 		}
@@ -95,10 +93,8 @@ public class GillsSpell extends BuffSpell {
 	@EventHandler(ignoreCancelled = true)
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
-		if (!(entity instanceof LivingEntity)) return;
+		if (!(entity instanceof LivingEntity livingEntity)) return;
 		if (event.getCause() != DamageCause.DROWNING) return;
-		
-		LivingEntity livingEntity = (LivingEntity) entity;
 		if (!isActive(livingEntity)) return;
 		if (isExpired(livingEntity)) {
 			turnOff(livingEntity);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
@@ -77,8 +77,7 @@ public class HasteSpell extends BuffSpell {
 	protected void turnOff() {
 		for (UUID id : entities.keySet()) {
 			Entity e = Bukkit.getEntity(id);
-			if (!(e instanceof LivingEntity)) continue;
-			LivingEntity livingEntity = (LivingEntity) e;
+			if (!(e instanceof LivingEntity livingEntity)) continue;
 			livingEntity.removePotionEffect(PotionEffectType.SPEED);
 			HasteData data = entities.get(id);
 			if (data != null) MagicSpells.cancelTask(data.task);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ImpactRecordSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ImpactRecordSpell.java
@@ -74,9 +74,7 @@ public class ImpactRecordSpell extends BuffSpell {
 		if (event.isCancelled() && !recordCancelled) return;
 		
 		LivingEntity target = event.getTarget();
-		if (!(target instanceof Player)) return;
-
-		Player playerTarget = (Player) target;
+		if (!(target instanceof Player playerTarget)) return;
 		if (!isActive(playerTarget)) return;
 		
 		Spell spell = event.getSpell();

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvisibilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvisibilitySpell.java
@@ -47,16 +47,16 @@ public class InvisibilitySpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return false;
-		makeInvisible(entity);
+		if (!(entity instanceof Player player)) return false;
+		makeInvisible(player);
 		entities.add(entity.getUniqueId());
 		return true;
 	}
 	
 	@Override
 	public boolean recastBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return false;
-		makeInvisible(entity);
+		if (!(entity instanceof Player player)) return false;
+		makeInvisible(player);
 		if (entities.contains(entity.getUniqueId())) entities.add(entity.getUniqueId());
 		return true;
 	}
@@ -69,7 +69,8 @@ public class InvisibilitySpell extends BuffSpell {
 	@Override
 	public void turnOffBuff(LivingEntity entity) {
 		entities.remove(entity.getUniqueId());
-		if (entity instanceof Player) Util.forEachPlayerOnline(p -> p.showPlayer(MagicSpells.getInstance(), (Player) entity));
+		if (!(entity instanceof Player player)) return;
+		Util.forEachPlayerOnline(p -> p.showPlayer(MagicSpells.getInstance(), player));
 	}
 
 	@Override
@@ -77,18 +78,14 @@ public class InvisibilitySpell extends BuffSpell {
 		entities.clear();
 	}
 
-	private void makeInvisible(LivingEntity entity) {
-		Util.forEachPlayerOnline(p -> p.hidePlayer(MagicSpells.getInstance(), (Player) entity));
-		
-		Creature creature;
-		for (Entity e : entity.getNearbyEntities(mobRadius, mobRadius, mobRadius)) {
-			if (!(e instanceof Creature)) continue;
-			
-			creature = (Creature) e;
+	private void makeInvisible(Player player) {
+		Util.forEachPlayerOnline(p -> p.hidePlayer(MagicSpells.getInstance(), player));
+
+		for (Entity entity : player.getNearbyEntities(mobRadius, mobRadius, mobRadius)) {
+			if (!(entity instanceof Creature creature)) continue;
 			LivingEntity target = creature.getTarget();
 			if (target == null) continue;
-			if (!target.equals(entity)) continue;
-			
+			if (!target.equals(player)) continue;
 			creature.setTarget(null);
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -77,8 +77,7 @@ public class InvulnerabilitySpell extends BuffSpell {
 			return;
 		}
 
-		if (!(event.getSpell() instanceof DamageSpell)) return;
-		DamageSpell spell = (DamageSpell) event.getSpell();
+		if (!(event.getSpell() instanceof DamageSpell spell)) return;
 		String spellDamageType = spell.getSpellDamageType();
 		if (spellDamageType == null) return;
 		if (!spellDamageTypes.contains(spellDamageType)) return;
@@ -92,10 +91,8 @@ public class InvulnerabilitySpell extends BuffSpell {
 	@EventHandler(ignoreCancelled = true)
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
-		if (!(entity instanceof LivingEntity)) return;
+		if (!(entity instanceof LivingEntity livingEntity)) return;
 		if (!damageCauses.isEmpty() && !damageCauses.contains(event.getCause())) return;
-
-		LivingEntity livingEntity = (LivingEntity) entity;
 		if (!isActive(livingEntity)) return;
 		if (isExpired(livingEntity)) {
 			turnOff(livingEntity);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
@@ -135,9 +135,7 @@ public class LifewalkSpell extends BuffSpell {
 				Entity entity = Bukkit.getEntity(id);
 				if (entity == null) continue;
 				if (!entity.isValid()) continue;
-				if (!(entity instanceof LivingEntity)) continue;
-
-				LivingEntity livingEntity = (LivingEntity) entity;
+				if (!(entity instanceof LivingEntity livingEntity)) continue;
 				if (isExpired(livingEntity)) {
 					turnOff(livingEntity);
 					continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -124,8 +124,7 @@ public class MinionSpell extends BuffSpell {
 					if (split.length > 1) duration = Integer.parseInt(split[1]);
 					int strength = 0;
 					if (split.length > 2) strength = Integer.parseInt(split[2]);
-					boolean ambient = false;
-					if (split.length > 3 && split[3].equalsIgnoreCase("ambient")) ambient = true;
+					boolean ambient = split.length > 3 && split[3].equalsIgnoreCase("ambient");
 					potionEffects.add(new PotionEffect(type, duration, strength, ambient));
 				} catch (Exception e) {
 					MagicSpells.error("MinionSpell '" + internalName + "' has an invalid potion effect string " + potion);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
@@ -78,10 +78,9 @@ public class ResistSpell extends BuffSpell {
 	@EventHandler
 	public void onSpellDamage(SpellApplyDamageEvent event) {
 		if (spellDamageTypes.isEmpty()) return;
-		if (!(event.getSpell() instanceof DamageSpell)) return;
+		if (!(event.getSpell() instanceof DamageSpell spell)) return;
 		if (!isActive(event.getTarget())) return;
 
-		DamageSpell spell = (DamageSpell) event.getSpell();
 		String spellDamageType = spell.getSpellDamageType();
 		if (spellDamageType == null) return;
 		if (!spellDamageTypes.contains(spellDamageType)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
@@ -105,7 +105,7 @@ public class SeeHealthSpell extends BuffSpell {
 			sb.append(symbol.repeat(barSize - remain));
 		}
 
-		player.sendActionBar(sb.toString());
+		player.sendActionBar(Util.getMiniMessage(sb.toString()));
 	}
 
 	public static String getColors() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
@@ -97,13 +97,12 @@ public class SeeHealthSpell extends BuffSpell {
 		StringBuilder sb = new StringBuilder(barSize);
 		sb.append(getRandomColor().toString());
 		int remain = (int) Math.round(barSize * pct);
-		sb.append(color.toString());
-
-		for (int i = 0; i < remain; i++) sb.append(symbol);
+		sb.append(color);
+		sb.append(symbol.repeat(remain));
 
 		if (remain < barSize) {
-			sb.append(ChatColor.DARK_GRAY.toString());
-			for (int i = 0; i < barSize - remain; i++) sb.append(symbol);
+			sb.append(ChatColor.DARK_GRAY);
+			sb.append(symbol.repeat(barSize - remain));
 		}
 
 		player.sendActionBar(sb.toString());

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/StealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/StealthSpell.java
@@ -44,8 +44,7 @@ public class StealthSpell extends BuffSpell {
 
 	@EventHandler(ignoreCancelled = true)
 	public void onEntityTarget(EntityTargetEvent event) {
-		if (!(event.getTarget() instanceof LivingEntity)) return;
-		LivingEntity target = (LivingEntity) event.getTarget();
+		if (!(event.getTarget() instanceof LivingEntity target)) return;
 		if (!isActive(target)) return;
 		if (isExpired(target)) {
 			turnOff(target);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
@@ -115,8 +115,7 @@ public class WindglideSpell extends BuffSpell {
 	@EventHandler
 	public void onEntityGlide(EntityToggleGlideEvent e) {
 		Entity entity = e.getEntity();
-		if (!(entity instanceof LivingEntity)) return;
-		LivingEntity livingEntity = (LivingEntity) entity;
+		if (!(entity instanceof LivingEntity livingEntity)) return;
 		if (!isActive(livingEntity)) return;
 		if (livingEntity.isGliding()) e.setCancelled(true);
 	}
@@ -124,10 +123,8 @@ public class WindglideSpell extends BuffSpell {
 	@EventHandler
 	public void onEntityCollision(EntityDamageEvent e) {
 		if (e.getCause() != EntityDamageEvent.DamageCause.FLY_INTO_WALL) return;
-		if (!(e.getEntity() instanceof LivingEntity)) return;
-		LivingEntity livingEntity = (LivingEntity) e.getEntity();
+		if (!(e.getEntity() instanceof LivingEntity livingEntity)) return;
 		if (!isActive(livingEntity)) return;
-
 		if (blockCollisionDmg) e.setCancelled(true);
 		if (cancelOnCollision) turnOff(livingEntity);
 		if (collisionSpell != null) collisionSpell.castAtLocation(livingEntity, livingEntity.getLocation(), 1F);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/AdminTeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/AdminTeachSpell.java
@@ -43,7 +43,6 @@ public class AdminTeachSpell extends CommandSpell {
 		if (targetPlayer == null) return false;
 		
 		Spellbook spellbook = MagicSpells.getSpellbook(targetPlayer);
-		if (spellbook == null) return false;
 		// No target, TODO add messages
 
 		String[] nodes = Arrays.copyOfRange(args, 1, args.length);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
@@ -67,8 +67,7 @@ public class BindSpell extends CommandSpell {
 	// DEBUG INFO: level 3, bind successful
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length == 0) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -77,7 +76,7 @@ public class BindSpell extends CommandSpell {
 			Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(args, ' '));
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 
-			if (spell == null || spellbook == null) {
+			if (spell == null) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -98,7 +97,7 @@ public class BindSpell extends CommandSpell {
 			}
 
 			CastItem castItem = new CastItem(player.getEquipment().getItemInMainHand());
-			MagicSpells.debug(3, "Trying to bind spell '" + spell.getInternalName() + "' to cast item " + castItem.toString() + "...");
+			MagicSpells.debug(3, "Trying to bind spell '" + spell.getInternalName() + "' to cast item " + castItem + "...");
 
 			if (BlockUtils.isAir(castItem.getType()) && !allowBindToFist) {
 				sendMessage(strCantBindItem, player, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
@@ -93,15 +93,18 @@ public class ForgetSpell extends CommandSpell {
 			if (!all && !targetSpellbook.hasSpell(spell)) {
 				sendMessage(strDoesntKnow, player, args);
 				return PostCastAction.ALREADY_HANDLED;
-			} 
-			
+			}
+
+
+			String playerDisplayName = Util.getStringFromComponent(player.displayName());
+			String targetDisplayName = Util.getStringFromComponent(target.displayName());
 			// Remove spell(s)
 			if (!all) {
 				targetSpellbook.removeSpell(spell);
 				targetSpellbook.save();
 				if (!player.equals(target)) {
-					sendMessage(strCastTarget, target, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
-					sendMessage(strCastSelf, player, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
+					sendMessage(strCastTarget, target, args, "%a", playerDisplayName, "%s", spell.getName(), "%t", targetDisplayName);
+					sendMessage(strCastSelf, player, args, "%a", playerDisplayName, "%s", spell.getName(), "%t", targetDisplayName);
 					playSpellEffects(player, target);
 				} else {
 					sendMessage(strCastSelfTarget, player, args, "%s", spell.getName());
@@ -114,7 +117,7 @@ public class ForgetSpell extends CommandSpell {
 			targetSpellbook.save();
 
 			if (!player.equals(target)) {
-				sendMessage(strResetTarget, player, args, "%t", target.getDisplayName());
+				sendMessage(strResetTarget, player, args, "%t", targetDisplayName);
 				playSpellEffects(player, target);
 			} else {
 				sendMessage(strResetSelf, player, args);
@@ -155,15 +158,16 @@ public class ForgetSpell extends CommandSpell {
 		SpellForgetEvent forgetEvent = new SpellForgetEvent(spell, target);
 		EventUtil.call(forgetEvent);
 		if (forgetEvent.isCancelled()) return false;
+		String targetDisplayName = Util.getStringFromComponent(target.displayName());
 		if (!all) {
 			targetSpellbook.removeSpell(spell);
 			targetSpellbook.save();
-			sendMessage(strCastTarget, target, args, "%a", getConsoleName(), "%s", spell.getName(), "%t", target.getDisplayName());
-			sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", target.getDisplayName()));
+			sendMessage(strCastTarget, target, args, "%a", getConsoleName(), "%s", spell.getName(), "%t", targetDisplayName);
+			sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", targetDisplayName));
 		} else {
 			targetSpellbook.removeAllSpells();
 			targetSpellbook.save();
-			sender.sendMessage(formatMessage(strResetTarget, "%t", target.getDisplayName()));
+			sender.sendMessage(formatMessage(strResetTarget, "%t", targetDisplayName));
 		}
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
@@ -51,8 +51,7 @@ public class ForgetSpell extends CommandSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length == 0 || args.length > 2) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -91,7 +90,7 @@ public class ForgetSpell extends CommandSpell {
 			}
 			
 			Spellbook targetSpellbook = MagicSpells.getSpellbook(target);
-			if (targetSpellbook == null || (!all && !targetSpellbook.hasSpell(spell))) {
+			if (!all && !targetSpellbook.hasSpell(spell)) {
 				sendMessage(strDoesntKnow, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			} 
@@ -148,7 +147,7 @@ public class ForgetSpell extends CommandSpell {
 		}
 
 		Spellbook targetSpellbook = MagicSpells.getSpellbook(target);
-		if (targetSpellbook == null || (!all && !targetSpellbook.hasSpell(spell))) {
+		if (!all && !targetSpellbook.hasSpell(spell)) {
 			sender.sendMessage(strDoesntKnow);
 			return false;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
@@ -35,8 +35,7 @@ public class HelpSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length == 0) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -45,7 +44,7 @@ public class HelpSpell extends CommandSpell {
 			Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(args, ' '));
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 
-			if (spell == null || (requireKnownSpell && (spellbook == null || !spellbook.hasSpell(spell)))) {
+			if (spell == null || requireKnownSpell && !spellbook.hasSpell(spell)) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -212,8 +212,14 @@ public class ImbueSpell extends CommandSpell {
 	
 	private void setItemNameAndLore(ItemStack item, Spell spell, int uses) {
 		ItemMeta meta = item.getItemMeta();
-		if (!strItemName.isEmpty()) meta.setDisplayName(strItemName.replace("%s", spell.getName()).replace("%u", uses+""));
-		if (!strItemLore.isEmpty()) meta.setLore(Collections.singletonList(strItemLore.replace("%s", spell.getName()).replace("%u", uses + "")));
+		if (!strItemName.isEmpty()) {
+			String displayName = strItemName.replace("%s", spell.getName()).replace("%u", uses+"");
+			meta.displayName(Util.getMiniMessage(displayName));
+		}
+		if (!strItemLore.isEmpty()) {
+			String lore = strItemLore.replace("%s", spell.getName()).replace("%u", uses + "");
+			meta.lore(Collections.singletonList(Util.getMiniMessage(lore)));
+		}
 		item.setItemMeta(meta);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -110,7 +110,7 @@ public class ImbueSpell extends CommandSpell {
 			}
 			
 			// Check for already imbued
-			if (ItemUtil.getPersistentString(inHand, key) != null) {
+			if (DataUtil.getString(inHand, key) != null) {
 				sendMessage(strCantImbueItem, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -147,7 +147,7 @@ public class ImbueSpell extends CommandSpell {
 			}
 			
 			setItemNameAndLore(inHand, spell, uses);
-			ItemUtil.setPersistentString(inHand, key, spell.getInternalName() + ',' + uses);
+			DataUtil.setString(inHand, key, spell.getInternalName() + ',' + uses);
 			player.getInventory().setItemInMainHand(inHand);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
@@ -177,14 +177,14 @@ public class ImbueSpell extends CommandSpell {
 		}
 		if (!allowed) return;
 		
-		String imbueData = ItemUtil.getPersistentString(item, key);
+		String imbueData = DataUtil.getString(item, key);
 		if (imbueData == null || imbueData.isEmpty()) return;
 		String[] data = imbueData.split(",");
 		Spell spell = MagicSpells.getSpellByInternalName(data[0]);
 		int uses = Integer.parseInt(data[1]);
 
 		if (spell == null || uses <= 0) {
-			ItemUtil.removePersistentString(item, key);
+			DataUtil.remove(item, key);
 			return;
 		}
 
@@ -193,12 +193,12 @@ public class ImbueSpell extends CommandSpell {
 		if (uses <= 0) {
 			if (consumeItem) event.getPlayer().getInventory().setItemInMainHand(null);
 			else {
-				ItemUtil.removePersistentString(item, key);
+				DataUtil.remove(item, key);
 				if (nameAndLoreHaveUses) setItemNameAndLore(item, spell, 0);
 			}
 		} else {
 			if (nameAndLoreHaveUses) setItemNameAndLore(item, spell, uses);
-			ItemUtil.setPersistentString(item, key, spell.getInternalName() + ',' + uses);
+			DataUtil.setString(item, key, spell.getInternalName() + ',' + uses);
 		}
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -17,17 +17,15 @@ import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.Perm;
 import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.RegexUtil;
-import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.SpellReagents;
 import com.nisovin.magicspells.spells.CommandSpell;
 
 // Advanced perm is for specifying the number of uses if it isn't normally allowed
 
 public class ImbueSpell extends CommandSpell {
 
+	private static final String key = "imbue_data";
 	private static final Pattern CAST_ARG_USES_PATTERN = Pattern.compile("[0-9]+");
 
 	private final Set<Material> allowedItemTypes;
@@ -36,7 +34,6 @@ public class ImbueSpell extends CommandSpell {
 	private int maxUses;
 	private int defaultUses;
 
-	private String key;
 	private String strUsage;
 	private String strItemName;
 	private String strItemLore;
@@ -69,8 +66,6 @@ public class ImbueSpell extends CommandSpell {
 
 		maxUses = getConfigInt("max-uses", 10);
 		defaultUses = getConfigInt("default-uses", 5);
-
-		key = "Imb" + internalName;
 		strUsage = getConfigString("str-usage", "Usage: /cast imbue <spell> [uses]");
 		strItemName = getConfigString("str-item-name", "");
 		strItemLore = getConfigString("str-item-lore", "Imbued: %s");
@@ -89,15 +84,14 @@ public class ImbueSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length == 0) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
 			
 			// Get item
-			ItemStack inHand = player.getEquipment().getItemInMainHand();
+			ItemStack inHand = player.getInventory().getItemInMainHand();
 			if (!allowedItemTypes.contains(inHand.getType())) {
 				sendMessage(strCantImbueItem, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -116,7 +110,7 @@ public class ImbueSpell extends CommandSpell {
 			}
 			
 			// Check for already imbued
-			if (getImbueData(inHand) != null) {
+			if (ItemUtil.getPersistentString(inHand, key) != null) {
 				sendMessage(strCantImbueItem, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -153,8 +147,8 @@ public class ImbueSpell extends CommandSpell {
 			}
 			
 			setItemNameAndLore(inHand, spell, uses);
-			setImbueData(inHand, spell.getInternalName() + ',' + uses);
-			player.getEquipment().setItemInMainHand(inHand);
+			ItemUtil.setPersistentString(inHand, key, spell.getInternalName() + ',' + uses);
+			player.getInventory().setItemInMainHand(inHand);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
@@ -171,6 +165,7 @@ public class ImbueSpell extends CommandSpell {
 		Action action = event.getAction();
 		if (!actionAllowedForCast(action)) return;
 		ItemStack item = event.getItem();
+		if (item == null) return;
 		if (!allowedItemTypes.contains(item.getType())) return;
 		
 		boolean allowed = false;
@@ -182,42 +177,37 @@ public class ImbueSpell extends CommandSpell {
 		}
 		if (!allowed) return;
 		
-		String imbueData = getImbueData(item);
+		String imbueData = ItemUtil.getPersistentString(item, key);
 		if (imbueData == null || imbueData.isEmpty()) return;
 		String[] data = imbueData.split(",");
 		Spell spell = MagicSpells.getSpellByInternalName(data[0]);
 		int uses = Integer.parseInt(data[1]);
 
 		if (spell == null || uses <= 0) {
-			Util.removeLoreData(item);
+			ItemUtil.removePersistentString(item, key);
 			return;
 		}
 
 		spell.castSpell(event.getPlayer(), SpellCastState.NORMAL, 1.0F, MagicSpells.NULL_ARGS);
 		uses--;
 		if (uses <= 0) {
-			if (consumeItem) event.getPlayer().getEquipment().setItemInMainHand(null);
+			if (consumeItem) event.getPlayer().getInventory().setItemInMainHand(null);
 			else {
-				Util.removeLoreData(item);
+				ItemUtil.removePersistentString(item, key);
 				if (nameAndLoreHaveUses) setItemNameAndLore(item, spell, 0);
 			}
 		} else {
 			if (nameAndLoreHaveUses) setItemNameAndLore(item, spell, uses);
-			setImbueData(item, spell.getInternalName() + ',' + uses);
+			ItemUtil.setPersistentString(item, key, spell.getInternalName() + ',' + uses);
 		}
 	}
 	
 	private boolean actionAllowedForCast(Action action) {
-		switch (action) {
-			case RIGHT_CLICK_AIR:
-			case RIGHT_CLICK_BLOCK:
-				return rightClickCast;
-			case LEFT_CLICK_AIR:
-			case LEFT_CLICK_BLOCK:
-				return leftClickCast;
-			default:
-				return false;
-		}
+		return switch (action) {
+			case RIGHT_CLICK_AIR, RIGHT_CLICK_BLOCK -> rightClickCast;
+			case LEFT_CLICK_AIR, LEFT_CLICK_BLOCK -> leftClickCast;
+			default -> false;
+		};
 	}
 	
 	private void setItemNameAndLore(ItemStack item, Spell spell, int uses) {
@@ -225,16 +215,6 @@ public class ImbueSpell extends CommandSpell {
 		if (!strItemName.isEmpty()) meta.setDisplayName(strItemName.replace("%s", spell.getName()).replace("%u", uses+""));
 		if (!strItemLore.isEmpty()) meta.setLore(Collections.singletonList(strItemLore.replace("%s", spell.getName()).replace("%u", uses + "")));
 		item.setItemMeta(meta);
-	}
-	
-	private void setImbueData(ItemStack item, String data) {
-		Util.setLoreData(item, key + ':' + data);
-	}
-	
-	private String getImbueData(ItemStack item) {
-		String s = Util.getLoreData(item);
-		if (s != null && s.startsWith(key + ':')) return s.replace(key + ':', "");
-		return null;
 	}
 
 	@Override
@@ -268,14 +248,6 @@ public class ImbueSpell extends CommandSpell {
 
 	public void setDefaultUses(int defaultUses) {
 		this.defaultUses = defaultUses;
-	}
-
-	public String getKey() {
-		return key;
-	}
-
-	public void setKey(String key) {
-		this.key = key;
 	}
 
 	public String getStrUsage() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
@@ -57,19 +57,12 @@ public class ItemSerializeSpell extends CommandSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
-			if (player == null) {
-				// TODO send error message
-				return PostCastAction.ALREADY_HANDLED;
-			}
-			
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			ItemStack heldItem = player.getInventory().getItemInMainHand();
 			if (InventoryUtil.isNothing(heldItem)) {
 				player.sendMessage("You must be holding an item in your hand");
 				return PostCastAction.ALREADY_HANDLED;
 			}
-			
 			processItem(heldItem);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
@@ -62,7 +62,7 @@ public class KeybindSpell extends CommandSpell {
 			conf.load(file);
 			for (String key : conf.getKeys(false)) {
 				int slot = Integer.parseInt(key);
-				String spellName = conf.getString(key);
+				String spellName = conf.getString(key, "");
 				Spell spell = MagicSpells.getSpellByInternalName(spellName);
 				if (spell != null) keybinds.setKeybind(slot, spell);
 			}
@@ -92,8 +92,7 @@ public class KeybindSpell extends CommandSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args.length != 1) {
 				player.sendMessage("Invalid args.");
 				return PostCastAction.ALREADY_HANDLED;
@@ -114,7 +113,7 @@ public class KeybindSpell extends CommandSpell {
 				saveKeybinds(keybinds);
 				return PostCastAction.HANDLE_NORMALLY;
 			}
-			if (item != null && !BlockUtils.isAir(item.getType())) {
+			if (!BlockUtils.isAir(item.getType())) {
 				player.sendMessage("Not empty.");
 				return PostCastAction.ALREADY_HANDLED;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
@@ -10,6 +10,7 @@ import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.SpellFilter;
@@ -56,7 +57,7 @@ public class ListSpell extends CommandSpell {
 				Player p = PlayerNameUtils.getPlayer(args[0]);
 				if (p != null) {
 					spellbook = MagicSpells.getSpellbook(p);
-					extra = '(' + p.getDisplayName() + ") ";
+					extra = '(' + Util.getStringFromComponent(p.displayName()) + ") ";
 				}
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
@@ -49,8 +49,7 @@ public class ListSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 			String extra = "";
 			if (args != null && args.length > 0 && spellbook.hasAdvancedPerm("list")) {
@@ -61,9 +60,9 @@ public class ListSpell extends CommandSpell {
 				}
 			}
 
-			if (spellbook != null && reloadGrantedSpells) spellbook.addGrantedSpells();
+			if (reloadGrantedSpells) spellbook.addGrantedSpells();
 
-			if (spellbook == null || spellbook.getSpells().isEmpty()) {
+			if (spellbook.getSpells().isEmpty()) {
 				sendMessage(strNoSpells, player, args);
 				return PostCastAction.HANDLE_NORMALLY;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -1,10 +1,9 @@
 package com.nisovin.magicspells.spells.command;
 
-import java.util.Map;
-import java.util.List;
-import java.util.HashMap;
-import java.util.ArrayList;
+import java.util.*;
 import java.util.regex.Pattern;
+
+import net.kyori.adventure.text.Component;
 
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
@@ -211,11 +210,11 @@ public class ScrollSpell extends CommandSpell {
 		ItemMeta meta = item.getItemMeta();
 		if (meta instanceof Damageable) ((Damageable) meta).setDamage(0);
 
-		meta.setDisplayName(Util.colorize(strScrollName.replace("%s", spell.getName()).replace("%u", (uses >= 0 ? uses + "" : "many"))));
+		String displayName = strScrollName.replace("%s", spell.getName()).replace("%u", (uses >= 0 ? uses + "" : "many"));
+		meta.displayName(Util.getMiniMessage(displayName));
 		if (strScrollSubtext != null && !strScrollSubtext.isEmpty()) {
-			List<String> lore = new ArrayList<>();
-			lore.add(Util.colorize(strScrollSubtext.replace("%s", spell.getName()).replace("%u", (uses >= 0 ? uses + "" : "many"))));
-			meta.setLore(lore);
+			Component lore = Util.getMiniMessage(strScrollSubtext.replace("%s", spell.getName()).replace("%u", (uses >= 0 ? uses + "" : "many")));
+			meta.lore(Collections.singletonList(lore));
 		}
 
 		ItemUtil.addFakeEnchantment(meta);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -21,13 +21,9 @@ import org.bukkit.event.player.PlayerItemHeldEvent;
 
 import com.nisovin.magicspells.Perm;
 import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.ItemUtil;
-import com.nisovin.magicspells.util.RegexUtil;
-import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.SpellReagents;
 import com.nisovin.magicspells.spells.CommandSpell;
 
 public class ScrollSpell extends CommandSpell {
@@ -224,7 +220,7 @@ public class ScrollSpell extends CommandSpell {
 
 		ItemUtil.addFakeEnchantment(meta);
 		item.setItemMeta(meta);
-		ItemUtil.setPersistentString(item, key, spell.getInternalName() + (uses > 0 ? "," + uses : ""));
+		DataUtil.setString(item, key, spell.getInternalName() + (uses > 0 ? "," + uses : ""));
 		return item;
 	}
 	
@@ -253,7 +249,7 @@ public class ScrollSpell extends CommandSpell {
 		}
 		
 		// Get scroll data (spell and uses)
-		String scrollDataString = ItemUtil.getPersistentString(inHand, key);
+		String scrollDataString = DataUtil.getString(inHand, key);
 		if (scrollDataString == null || scrollDataString.isEmpty()) return;
 		String[] scrollData = scrollDataString.split(",");
 		Spell spell = MagicSpells.getSpellByInternalName(scrollData[0]);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
@@ -97,8 +97,7 @@ public class SpellbookSpell extends CommandSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length < 1 || args.length > 2 || (args.length == 2 && !RegexUtil.matches(PATTERN_CAST_ARG_USAGE, args[1]))) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.HANDLE_NORMALLY;
@@ -114,7 +113,7 @@ public class SpellbookSpell extends CommandSpell {
 
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 			Spell spell = MagicSpells.getSpellByInGameName(args[0]);
-			if (spellbook == null || spell == null || !spellbook.hasSpell(spell)) {
+			if (spell == null || !spellbook.hasSpell(spell)) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -168,8 +167,12 @@ public class SpellbookSpell extends CommandSpell {
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onPlayerInteract(PlayerInteractEvent event) {
 		if (spellbookBlock == null) return;
-		if (!event.hasBlock() || !spellbookBlock.equals(event.getClickedBlock().getType()) || event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
-		if (event.getHand().equals(EquipmentSlot.OFF_HAND)) return;
+		Block clickedBlock = event.getClickedBlock();
+		if (clickedBlock == null) return;
+		EquipmentSlot slot = event.getHand();
+		if (slot == null) return;
+		if (!event.hasBlock() || !spellbookBlock.equals(clickedBlock.getType()) || event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
+		if (slot == EquipmentSlot.OFF_HAND) return;
 		MagicLocation loc = new MagicLocation(event.getClickedBlock().getLocation());
 		if (!bookLocations.contains(loc)) return;
 
@@ -178,7 +181,7 @@ public class SpellbookSpell extends CommandSpell {
 		int i = bookLocations.indexOf(loc);
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		Spell spell = MagicSpells.getSpellByInternalName(bookSpells.get(i));
-		if (spellbook == null || spell == null) {
+		if (spell == null) {
 			sendMessage(strLearnError, player, MagicSpells.NULL_ARGS);
 			return;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
@@ -45,8 +45,7 @@ public class SublistSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 			String extra = "";
 			if (args != null && args.length > 0 && spellbook.hasAdvancedPerm("list")) {
@@ -56,8 +55,8 @@ public class SublistSpell extends CommandSpell {
 					extra = '(' + p.getDisplayName() + ") ";
 				}
 			}
-			if (spellbook != null && reloadGrantedSpells) spellbook.addGrantedSpells();
-			if (spellbook == null || spellbook.getSpells().isEmpty()) {
+			if (reloadGrantedSpells) spellbook.addGrantedSpells();
+			if (spellbook.getSpells().isEmpty()) {
 				sendMessage(strNoSpells, player, args);
 				return PostCastAction.HANDLE_NORMALLY;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
@@ -10,6 +10,7 @@ import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.CommandSpell;
@@ -52,7 +53,7 @@ public class SublistSpell extends CommandSpell {
 				Player p = PlayerNameUtils.getPlayer(args[0]);
 				if (p != null) {
 					spellbook = MagicSpells.getSpellbook(p);
-					extra = '(' + p.getDisplayName() + ") ";
+					extra = '(' + Util.getStringFromComponent(p.displayName()) + ") ";
 				}
 			}
 			if (reloadGrantedSpells) spellbook.addGrantedSpells();

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
@@ -127,8 +127,9 @@ public class TeachSpell extends CommandSpell {
 		}
 		targetSpellbook.addSpell(spell);
 		targetSpellbook.save();
-		sendMessage(strCastTarget, players.get(0), args, "%a", getConsoleName(), "%s", spell.getName(), "%t", players.get(0).getDisplayName());
-		sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", players.get(0).getDisplayName()));
+		String displayName = Util.getStringFromComponent(players.get(0).displayName());
+		sendMessage(strCastTarget, players.get(0), args, "%a", getConsoleName(), "%s", spell.getName(), "%t", displayName);
+		sender.sendMessage(formatMessage(strCastSelf, "%a", getConsoleName(), "%s", spell.getName(), "%t", displayName));
 		return true;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
@@ -44,8 +44,7 @@ public class TeachSpell extends CommandSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length != 2) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -62,7 +61,7 @@ public class TeachSpell extends CommandSpell {
 				return PostCastAction.ALREADY_HANDLED;
 			}
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
-			if (spellbook == null || (!spellbook.hasSpell(spell) && requireKnownSpell)) {
+			if (!spellbook.hasSpell(spell) && requireKnownSpell) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -71,7 +70,7 @@ public class TeachSpell extends CommandSpell {
 				return PostCastAction.ALREADY_HANDLED;
 			}
 			Spellbook targetSpellbook = MagicSpells.getSpellbook(target);
-			if (targetSpellbook == null || !targetSpellbook.canLearn(spell)) {
+			if (!targetSpellbook.canLearn(spell)) {
 				sendMessage(strCantLearn, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -86,8 +85,10 @@ public class TeachSpell extends CommandSpell {
 			}
 			targetSpellbook.addSpell(spell);
 			targetSpellbook.save();
-			sendMessage(strCastTarget, target, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
-			sendMessage(strCastSelf, player, args, "%a", player.getDisplayName(), "%s", spell.getName(), "%t", target.getDisplayName());
+			String playerDisplayName = Util.getStringFromComponent(player.displayName());
+			String targetDisplayName = Util.getStringFromComponent(target.displayName());
+			sendMessage(strCastTarget, target, args, "%a", playerDisplayName, "%s", spell.getName(), "%t", targetDisplayName);
+			sendMessage(strCastSelf, player, args, "%a", playerDisplayName, "%s", spell.getName(), "%t", targetDisplayName);
 			playSpellEffects(player, target);
 			return PostCastAction.NO_MESSAGES;
 		}
@@ -111,7 +112,7 @@ public class TeachSpell extends CommandSpell {
 			return true;
 		}
 		Spellbook targetSpellbook = MagicSpells.getSpellbook(players.get(0));
-		if (targetSpellbook == null || !targetSpellbook.canLearn(spell)) {
+		if (!targetSpellbook.canLearn(spell)) {
 			sender.sendMessage(strCantLearn);
 			return true;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -17,7 +17,6 @@ import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.DataUtil;
-import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.CommandSpell;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -16,6 +16,7 @@ import org.bukkit.event.player.PlayerInteractEvent;
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.DataUtil;
 import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.util.MagicConfig;
@@ -94,7 +95,7 @@ public class TomeSpell extends CommandSpell {
 				sendMessage(strNoBook, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
-			if (!allowOverwrite && ItemUtil.getPersistentString(item, key) != null) {
+			if (!allowOverwrite && DataUtil.getString(item, key) != null) {
 				sendMessage(strAlreadyHasSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -126,7 +127,7 @@ public class TomeSpell extends CommandSpell {
 			bookMeta.setTitle(getName() + ": " + spell.getName());
 			item.setItemMeta(bookMeta);
 		}
-		ItemUtil.setPersistentString(item, key, spell.getInternalName() + (uses > 0 ? "," + uses : ""));
+		DataUtil.setString(item, key, spell.getInternalName() + (uses > 0 ? "," + uses : ""));
 		return item;
 	}
 	
@@ -138,7 +139,7 @@ public class TomeSpell extends CommandSpell {
 		if (item == null) return;
 		if (item.getType() != Material.WRITTEN_BOOK) return;
 		
-		String spellData = ItemUtil.getPersistentString(item, key);
+		String spellData = DataUtil.getString(item, key);
 		if (spellData == null || spellData.isEmpty()) return;
 		
 		String[] data = spellData.split(",");
@@ -169,8 +170,8 @@ public class TomeSpell extends CommandSpell {
 
 		if (uses > 0) {
 			uses--;
-			if (uses > 0) ItemUtil.setPersistentString(item, key, data[0] + "," + uses);
-			else ItemUtil.removePersistentString(item, key);
+			if (uses > 0) DataUtil.setString(item, key, data[0] + "," + uses);
+			else DataUtil.remove(item, key);
 
 		}
 		if (uses <= 0 && consumeBook) event.getPlayer().getInventory().setItemInMainHand(null);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -14,9 +14,9 @@ import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.Spell;
-import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.Spellbook;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.ItemUtil;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.CommandSpell;
@@ -28,6 +28,7 @@ import com.nisovin.magicspells.events.SpellLearnEvent.LearnSource;
 // TODO this should not be hardcoded to use a book
 public class TomeSpell extends CommandSpell {
 
+	private static final String key = "tome_data";
 	private static final Pattern INT_PATTERN = Pattern.compile("^[0-9]+$");
 	
 	private boolean consumeBook;
@@ -70,8 +71,7 @@ public class TomeSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			Spell spell;
 			if (args == null || args.length == 0) {
 				sendMessage(strUsage, player, args);
@@ -80,7 +80,7 @@ public class TomeSpell extends CommandSpell {
 
 			Spellbook spellbook = MagicSpells.getSpellbook(player);
 			spell = MagicSpells.getSpellByInGameName(args[0]);
-			if (spell == null || spellbook == null || !spellbook.hasSpell(spell)) {
+			if (spell == null || !spellbook.hasSpell(spell)) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -89,12 +89,12 @@ public class TomeSpell extends CommandSpell {
 				return PostCastAction.ALREADY_HANDLED;
 			}
 
-			ItemStack item = player.getEquipment().getItemInMainHand();
+			ItemStack item = player.getInventory().getItemInMainHand();
 			if (item.getType() != Material.WRITTEN_BOOK) {
 				sendMessage(strNoBook, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
-			if (!allowOverwrite && getSpellDataFromTome(item) != null) {
+			if (!allowOverwrite && ItemUtil.getPersistentString(item, key) != null) {
 				sendMessage(strAlreadyHasSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -102,7 +102,7 @@ public class TomeSpell extends CommandSpell {
 			int uses = defaultUses;
 			if (args.length > 1 && RegexUtil.matches(INT_PATTERN, args[1])) uses = Integer.parseInt(args[1]);
 			item = createTome(spell, uses, item);
-			player.getEquipment().setItemInMainHand(item);
+			player.getInventory().setItemInMainHand(item);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
@@ -116,12 +116,6 @@ public class TomeSpell extends CommandSpell {
 	public List<String> tabComplete(CommandSender sender, String partial) {
 		return null;
 	}
-	
-	private String getSpellDataFromTome(ItemStack item) {
-		String loreData = Util.getLoreData(item);
-		if (loreData != null && loreData.startsWith(internalName + ':')) return loreData.replace(internalName + ':', "");
-		return null;
-	}
 
 	public ItemStack createTome(Spell spell, int uses, ItemStack item) {
 		if (maxUses > 0 && uses > maxUses) uses = maxUses;
@@ -132,7 +126,7 @@ public class TomeSpell extends CommandSpell {
 			bookMeta.setTitle(getName() + ": " + spell.getName());
 			item.setItemMeta(bookMeta);
 		}
-		Util.setLoreData(item, internalName + ':' + spell.getInternalName() + (uses > 0 ? "," + uses : ""));
+		ItemUtil.setPersistentString(item, key, spell.getInternalName() + (uses > 0 ? "," + uses : ""));
 		return item;
 	}
 	
@@ -141,9 +135,10 @@ public class TomeSpell extends CommandSpell {
 		if (event.getAction() != Action.RIGHT_CLICK_AIR && event.getAction() != Action.RIGHT_CLICK_BLOCK) return;
 		if (!event.hasItem()) return;
 		ItemStack item = event.getItem();
+		if (item == null) return;
 		if (item.getType() != Material.WRITTEN_BOOK) return;
 		
-		String spellData = getSpellDataFromTome(item);
+		String spellData = ItemUtil.getPersistentString(item, key);
 		if (spellData == null || spellData.isEmpty()) return;
 		
 		String[] data = spellData.split(",");
@@ -152,8 +147,7 @@ public class TomeSpell extends CommandSpell {
 		if (data.length > 1) uses = Integer.parseInt(data[1]);
 		Spellbook spellbook = MagicSpells.getSpellbook(event.getPlayer());
 		if (spell == null) return;
-		if (spellbook == null) return;
-		
+
 		if (spellbook.hasSpell(spell)) {
 			sendMessage(strAlreadyKnown, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
@@ -162,7 +156,7 @@ public class TomeSpell extends CommandSpell {
 			sendMessage(strCantLearn, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
 			return;
 		}
-		SpellLearnEvent learnEvent = new SpellLearnEvent(spell, event.getPlayer(), LearnSource.TOME, event.getPlayer().getEquipment().getItemInMainHand());
+		SpellLearnEvent learnEvent = new SpellLearnEvent(spell, event.getPlayer(), LearnSource.TOME, event.getPlayer().getInventory().getItemInMainHand());
 		EventUtil.call(learnEvent);
 		if (learnEvent.isCancelled()) {
 			sendMessage(strCantLearn, event.getPlayer(), MagicSpells.NULL_ARGS, "%s", spell.getName());
@@ -175,11 +169,11 @@ public class TomeSpell extends CommandSpell {
 
 		if (uses > 0) {
 			uses--;
-			if (uses > 0) Util.setLoreData(item, internalName + ':' + data[0] + ',' + uses);
-			else Util.removeLoreData(item);
+			if (uses > 0) ItemUtil.setPersistentString(item, key, data[0] + "," + uses);
+			else ItemUtil.removePersistentString(item, key);
 
 		}
-		if (uses <= 0 && consumeBook) event.getPlayer().getEquipment().setItemInMainHand(null);
+		if (uses <= 0 && consumeBook) event.getPlayer().getInventory().setItemInMainHand(null);
 		playSpellEffects(EffectPosition.DELAYED, event.getPlayer());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
@@ -52,8 +52,7 @@ public class UnbindSpell extends CommandSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args == null || args.length == 0) {
 				sendMessage(strUsage, player, args);
 				return PostCastAction.ALREADY_HANDLED;
@@ -82,7 +81,7 @@ public class UnbindSpell extends CommandSpell {
 			}
 
 			Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(args, ' '));
-			if (spell == null || spellbook == null) {
+			if (spell == null) {
 				sendMessage(strNoSpell, player, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
@@ -36,7 +36,7 @@ public class CastAtMarkSpell extends InstantSpell {
 		if (initialized) return;
 
 		Spell spell = MagicSpells.getSpellByInternalName(markSpellName);
-		if (spell == null || !(spell instanceof MarkSpell)) {
+		if (!(spell instanceof MarkSpell)) {
 			MagicSpells.error("CastAtMarkSpell '" + internalName + "' has an invalid mark-spell defined!");
 			return;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ConfusionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ConfusionSpell.java
@@ -51,9 +51,9 @@ public class ConfusionSpell extends InstantSpell implements TargetedLocationSpel
 		List<LivingEntity> monsters = new ArrayList<>();
 
 		for (Entity e : entities) {
-			if (!(e instanceof LivingEntity)) continue;
+			if (!(e instanceof LivingEntity livingEntity)) continue;
 			if (!validTargetList.canTarget(caster, e)) continue;
-			monsters.add((LivingEntity) e);
+			monsters.add(livingEntity);
 		}
 
 		for (int i = 0; i < monsters.size(); i++) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureFireworkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureFireworkSpell.java
@@ -53,7 +53,7 @@ public class ConjureFireworkSpell extends InstantSpell implements TargetedLocati
 		FireworkMeta meta = (FireworkMeta) firework.getItemMeta();
 		
 		meta.setPower(flight);
-		if (!fireworkName.isEmpty()) meta.setDisplayName(Util.colorize(fireworkName));
+		if (!fireworkName.isEmpty()) meta.displayName(Util.getMiniMessage(fireworkName));
 		
 		List<String> fireworkEffects = getConfigStringList("firework-effects", null);
 		if (fireworkEffects != null && !fireworkEffects.isEmpty()) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureFireworkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureFireworkSpell.java
@@ -115,8 +115,7 @@ public class ConjureFireworkSpell extends InstantSpell implements TargetedLocati
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			boolean added = false;
 			ItemStack item = firework.clone();
 			if (addToInventory) added = Util.addToInventory(player.getInventory(), item, true, false);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
@@ -72,8 +72,7 @@ public class DowseSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			int distance = -1;
 			if (material != null) {
 				Block foundBlock = null;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/EnderchestSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/EnderchestSpell.java
@@ -16,8 +16,7 @@ public class EnderchestSpell extends InstantSpell implements TargetedEntitySpell
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (args != null && args.length == 1 && player.hasPermission("magicspells.advanced." + internalName)) {
 				Player target = PlayerNameUtils.getPlayer(args[0]);
 				if (target == null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/FoodSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/FoodSpell.java
@@ -24,8 +24,7 @@ public class FoodSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			int f = player.getFoodLevel() + food;
 			if (f > 20) f = 20;
 			player.setFoodLevel(f);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
@@ -50,10 +50,9 @@ public class ForcepushSpell extends InstantSpell {
 		Vector v;
 		Vector p = livingEntity.getLocation().toVector();
 		for (Entity entity : entities) {
-			if (!(entity instanceof LivingEntity)) continue;
+			if (!(entity instanceof LivingEntity target)) continue;
 			if (!validTargetList.canTarget(livingEntity, entity)) continue;
 
-			LivingEntity target = (LivingEntity) entity;
 			float power = basePower;
 			SpellTargetEvent event = new SpellTargetEvent(this, livingEntity, target, power);
 			EventUtil.call(event);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/GateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/GateSpell.java
@@ -68,27 +68,26 @@ public class GateSpell extends InstantSpell {
 			
 			if (location == null) {
 				switch (coordinates.toUpperCase()) {
-					case "SPAWN":
+					case "SPAWN" -> {
 						location = effectiveWorld.getSpawnLocation();
 						location = new Location(effectiveWorld, location.getX(), effectiveWorld.getHighestBlockYAt(location) + 1, location.getZ());
-						break;
-					case "EXACTSPAWN":
-						location = effectiveWorld.getSpawnLocation();
-						break;
-					case "CURRENT":
+					}
+					case "EXACTSPAWN" -> location = effectiveWorld.getSpawnLocation();
+					case "CURRENT" -> {
 						Location l = caster.getLocation();
 						location = new Location(effectiveWorld, l.getBlockX(), l.getBlockY(), l.getBlockZ(), l.getYaw(), l.getPitch());
-						break;
-					default:
+					}
+					default -> {
 						MagicSpells.error("GateSpell '" + internalName + "' has invalid coordinates defined!");
 						sendMessage(strGateFailed, caster, args);
 						return PostCastAction.ALREADY_HANDLED;
+					}
 				}
 			}
 
 			location.setX(location.getX() + .5);
 			location.setZ(location.getZ() + .5);
-			MagicSpells.debug(3, "Gate location: " + location.toString());
+			MagicSpells.debug(3, "Gate location: " + location);
 			
 			Block b = location.getBlock();
 			if (!BlockUtils.isPathable(b) || !BlockUtils.isPathable(b.getRelative(0, 1, 0))) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
@@ -65,8 +65,7 @@ public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
 		Collection<Entity> entities = center.getWorld().getNearbyEntities(center, radius, radius, radius);
 		List<Item> ret = new ArrayList<>();
 		for (Entity e: entities) {
-			if (!(e instanceof Item)) continue;
-			Item i = (Item) e;
+			if (!(e instanceof Item i)) continue;
 			ItemStack stack = i.getItemStack();
 			if (InventoryUtil.isNothing(stack)) continue;
 			if (i.isDead()) continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ManaSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ManaSpell.java
@@ -21,8 +21,7 @@ public class ManaSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			int amount = Math.round(mana * power);
 			boolean added = MagicSpells.getManaHandler().addMana(player, amount, ManaChangeReason.OTHER);
 			if (!added) return PostCastAction.ALREADY_HANDLED;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -320,7 +320,6 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 					continue;
 				}
 
-				if (params.length <= 1) continue;
 				if (params[1] == null) continue;
 				Subspell collisionSpell = new Subspell(params[1]);
 				if (!collisionSpell.process() || !collisionSpell.isTargetedLocationSpell()) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -259,13 +259,10 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 	@EventHandler
 	public void onProjectileHit(EntityDamageByEntityEvent event) {
 		if (event.getCause() != EntityDamageEvent.DamageCause.PROJECTILE) return;
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity entity)) return;
 
-		LivingEntity entity = (LivingEntity) event.getEntity();
 		Entity damagerEntity = event.getDamager();
-		if (!(damagerEntity instanceof Projectile)) return;
-
-		Projectile projectile = (Projectile) damagerEntity;
+		if (!(damagerEntity instanceof Projectile projectile)) return;
 
 		Iterator<ProjectileTracker> iterator = trackerSet.iterator();
 		while (iterator.hasNext()) {
@@ -291,7 +288,6 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 	public void onEnderTeleport(PlayerTeleportEvent event) {
 		if (event.getCause() != PlayerTeleportEvent.TeleportCause.ENDER_PEARL) return;
 		for (ProjectileTracker tracker : trackerSet) {
-			if (event.getTo() == null) continue;
 			if (tracker.getProjectile() == null) continue;
 			if (!locationsEqual(tracker.getProjectile().getLocation(), event.getTo())) continue;
 			event.setCancelled(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/PurgeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/PurgeSpell.java
@@ -69,12 +69,12 @@ public class PurgeSpell extends InstantSpell implements TargetedLocationSpell {
 		Collection<Entity> entitiesNearby = loc.getWorld().getNearbyEntities(loc, castingRange, castingRange, castingRange);
 		boolean killed = false;
 		for (Entity entity : entitiesNearby) {
-			if (!(entity instanceof LivingEntity)) continue;
+			if (!(entity instanceof LivingEntity livingEntity)) continue;
 			if (entity instanceof Player) continue;
 			if (entities != null && !entities.contains(entity.getType())) continue;
 			playSpellEffectsTrail(loc, entity.getLocation());
 			playSpellEffects(EffectPosition.TARGET, entity);
-			((LivingEntity) entity).setHealth(0);
+			livingEntity.setHealth(0);
 			killed = true;
 		}
 		return killed;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RepairSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RepairSpell.java
@@ -90,8 +90,7 @@ public class RepairSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			boolean repaired = false;
 			for (String s : toRepair) {
 				if (s.equals(REPAIR_SELECTOR_KEY_HELD)) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
@@ -81,8 +81,7 @@ public class RitualSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (spellToCast == null || !(caster instanceof Player)) return PostCastAction.ALREADY_HANDLED;
-		Player player = (Player) caster;
+		if (spellToCast == null || !(caster instanceof Player player)) return PostCastAction.ALREADY_HANDLED;
 		if (activeRituals.containsKey(player)) {
 			ActiveRitual channel = activeRituals.remove(player);
 			channel.stop(strRitualInterrupted);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RoarSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RoarSpell.java
@@ -40,10 +40,10 @@ public class RoarSpell extends InstantSpell {
 			List<Entity> entities = caster.getNearbyEntities(radius, radius, radius);
 
 			for (Entity entity : entities) {
-				if (!(entity instanceof LivingEntity)) continue;
+				if (!(entity instanceof LivingEntity livingEntity)) continue;
 				if (entity instanceof Player) continue;
 				if (!validTargetList.canTarget(caster, entity)) continue;
-				MobUtil.setTarget((LivingEntity) entity, caster);
+				MobUtil.setTarget(livingEntity, caster);
 				playSpellEffectsTrail(caster.getLocation(), entity.getLocation());
 				playSpellEffects(EffectPosition.TARGET, entity);
 				count++;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
@@ -120,21 +120,21 @@ public class SteedSpell extends InstantSpell {
 			Entity entity = caster.getWorld().spawnEntity(caster.getLocation(), type);
 			entity.setGravity(gravity);
 
-			if (entity instanceof AbstractHorse) {
-				((AbstractHorse) entity).setAdult();
-				((AbstractHorse) entity).setTamed(true);
-				if (caster instanceof AnimalTamer) ((AbstractHorse) entity).setOwner((AnimalTamer) caster);
-				((AbstractHorse) entity).setJumpStrength(jumpStrength);
-				((AbstractHorse) entity).getInventory().setSaddle(new ItemStack(Material.SADDLE));
+			if (entity instanceof AbstractHorse abstractHorse) {
+				abstractHorse.setAdult();
+				abstractHorse.setTamed(true);
+				if (caster instanceof AnimalTamer tamer) abstractHorse.setOwner(tamer);
+				abstractHorse.setJumpStrength(jumpStrength);
+				abstractHorse.getInventory().setSaddle(new ItemStack(Material.SADDLE));
 
-				if (entity instanceof Horse) {
-					if (color != null) ((Horse) entity).setColor(color);
-					else ((Horse) entity).setColor(Horse.Color.values()[random.nextInt(Horse.Color.values().length)]);
-					if (style != null) ((Horse) entity).setStyle(style);
-					else ((Horse) entity).setStyle(Horse.Style.values()[random.nextInt(Horse.Style.values().length)]);
-					if (armor != null) ((Horse) entity).getInventory().setArmor(armor);
-				} else if (entity instanceof ChestedHorse) {
-					((ChestedHorse) entity).setCarryingChest(hasChest);
+				if (entity instanceof Horse horse) {
+					if (color != null) horse.setColor(color);
+					else horse.setColor(Horse.Color.values()[random.nextInt(Horse.Color.values().length)]);
+					if (style != null) horse.setStyle(style);
+					else horse.setStyle(Horse.Style.values()[random.nextInt(Horse.Style.values().length)]);
+					if (armor != null) horse.getInventory().setArmor(armor);
+				} else if (entity instanceof ChestedHorse chestedHorse) {
+					chestedHorse.setCarryingChest(hasChest);
 				}
 			}
 
@@ -161,8 +161,7 @@ public class SteedSpell extends InstantSpell {
 	
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
 	private void onDismount(EntityDismountEvent event) {
-		if (!(event.getEntity() instanceof Player)) return;
-		Player player = (Player) event.getEntity();
+		if (!(event.getEntity() instanceof Player player)) return;
 		if (!mounted.containsKey(player.getUniqueId())) return;
 		mounted.remove(player.getUniqueId());
 		event.getDismounted().remove();

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -192,8 +192,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			Iterator<Entity> iter = fallingBlocks.keySet().iterator();
 			while (iter.hasNext()) {
 				Entity entity = iter.next();
-				if (entity instanceof FallingBlock) {
-					FallingBlock block = (FallingBlock) entity;
+				if (entity instanceof FallingBlock block) {
 					if (block.isValid()) continue;
 					iter.remove();
 					if (!removeBlocks) continue;
@@ -202,8 +201,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 						playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation());
 						b.setType(Material.AIR);
 					}
-				} else if (entity instanceof TNTPrimed) {
-					TNTPrimed tnt = (TNTPrimed) entity;
+				} else if (entity instanceof TNTPrimed tnt) {
 					if (!tnt.isValid() || tnt.isDead()) iter.remove();
 				}
 			}
@@ -267,8 +265,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			FallingBlockInfo info;
 			if (removeBlocks || preventBlocks) info = fallingBlocks.get(event.getDamager());
 			else info = fallingBlocks.remove(event.getDamager());
-			if (info == null || !(event.getEntity() instanceof LivingEntity)) return;
-			LivingEntity entity = (LivingEntity) event.getEntity();
+			if (info == null || !(event.getEntity() instanceof LivingEntity entity)) return;
 			float power = info.power;
 			if (callTargetEvent && info.caster != null) {
 				SpellTargetEvent evt = new SpellTargetEvent(thisSpell, info.caster, entity, power);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/UnconjureSpell.java
@@ -48,8 +48,7 @@ public class UnconjureSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			PlayerInventory inventory = player.getInventory();
 
 			ItemStack[] contents = new ItemStack[1];

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VariableCastSpell.java
@@ -31,9 +31,7 @@ public class VariableCastSpell extends InstantSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
-
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			if (variableName == null) return PostCastAction.HANDLE_NORMALLY;
 			String value = MagicSpells.getVariableManager().getVariable(variableName).getStringValue(player);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -36,8 +36,7 @@ public class BuffListener extends PassiveListener {
 	@Override
 	public void initialize(String var) {
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
-			if (!(s.getSpell() instanceof BuffSpell)) continue;
-			BuffSpell buff = (BuffSpell) s.getSpell();
+			if (!(s.getSpell() instanceof BuffSpell buff)) continue;
 			buff.setAsEverlasting();
 		}
 
@@ -134,8 +133,7 @@ public class BuffListener extends PassiveListener {
 		if (!hasSpell(entity)) return;
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
-			if (!(s.getSpell() instanceof BuffSpell)) continue;
-			BuffSpell buff = (BuffSpell) s.getSpell();
+			if (!(s.getSpell() instanceof BuffSpell buff)) continue;
 			if (buff.isActive(entity)) continue;
 			buff.castAtEntity(entity, entity, 1F);
 		}
@@ -146,8 +144,7 @@ public class BuffListener extends PassiveListener {
 		if (!hasSpell(entity)) return;
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
-			if (!(s.getSpell() instanceof BuffSpell)) continue;
-			BuffSpell buff = (BuffSpell) s.getSpell();
+			if (!(s.getSpell() instanceof BuffSpell buff)) continue;
 			if (!buff.isActive(entity)) continue;
 			buff.turnOff(entity);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/DismountListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/DismountListener.java
@@ -1,17 +1,17 @@
 package com.nisovin.magicspells.spells.passive;
 
-import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.spells.passive.util.PassiveListener;
-import com.nisovin.magicspells.util.MobUtil;
-import com.nisovin.magicspells.util.OverridePriority;
+import java.util.EnumSet;
+
 import org.bukkit.entity.EntityType;
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.event.player.PlayerSwapHandItemsEvent;
+import org.bukkit.entity.LivingEntity;
+
 import org.spigotmc.event.entity.EntityDismountEvent;
 
-import java.util.EnumSet;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.MobUtil;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class DismountListener extends PassiveListener {
 
@@ -36,11 +36,9 @@ public class DismountListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDismount(EntityDismountEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (!types.isEmpty() && !types.contains(event.getDismounted().getType())) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
@@ -18,11 +18,8 @@ public class FatalDamageListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	void onDamage(EntityDamageEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
-
 		if (event.getFinalDamage() < caster.getHealth()) return;
 		if (!canTrigger(caster) || !hasSpell(caster)) return;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
@@ -57,7 +57,7 @@ public class GiveDamageListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDamage(EntityDamageByEntityEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity attacked)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 
 		LivingEntity caster = getAttacker(event);
@@ -73,7 +73,6 @@ public class GiveDamageListener extends PassiveListener {
 			if (itemData == null || !contains(itemData)) return;
 		}
 
-		LivingEntity attacked = (LivingEntity) event.getEntity();
 		boolean casted = passiveSpell.activate(caster, attacked);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
@@ -4,7 +4,6 @@ import java.util.Set;
 import java.util.HashSet;
 
 import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.EntityEquipment;
@@ -41,7 +40,7 @@ public class HitArrowListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDamage(EntityDamageByEntityEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity attacked)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 
 		LivingEntity caster = getAttacker(event);
@@ -55,17 +54,13 @@ public class HitArrowListener extends PassiveListener {
 			if (itemData == null || !contains(itemData)) return;
 		}
 
-		LivingEntity attacked = (LivingEntity) event.getEntity();
 		boolean casted = passiveSpell.activate(caster, attacked);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}
 	
 	private LivingEntity getAttacker(EntityDamageByEntityEvent event) {
-		Entity e = event.getDamager();
-		if (!(e instanceof Arrow)) return null;
-		if (((Arrow) e).getShooter() != null && ((Arrow) e).getShooter() instanceof LivingEntity) {
-			return (LivingEntity) ((Arrow) e).getShooter();
-		}
+		if (!(event.getDamager() instanceof Arrow arrow)) return null;
+		if (arrow.getShooter() != null && arrow.getShooter() instanceof LivingEntity shooter) return shooter;
 		return null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryClickListener.java
@@ -52,9 +52,7 @@ public class InventoryClickListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onInvClick(InventoryClickEvent event) {
-		if (!(event.getWhoClicked() instanceof Player)) return;
-
-		Player player = (Player) event.getWhoClicked();
+		if (!(event.getWhoClicked() instanceof Player player)) return;
 		if (!hasSpell(player) || !canTrigger(player)) return;
 
 		// Valid action, but not used.

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryCloseListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryCloseListener.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.inventory.InventoryCloseEvent;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -28,7 +29,7 @@ public class InventoryCloseListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onInventoryClose(InventoryCloseEvent event) {
-		if (!inventoryNames.isEmpty() && !inventoryNames.contains(event.getView().getTitle())) return;
+		if (!inventoryNames.contains(Util.getStringFromComponent(event.getView().title()))) return;
 
 		HumanEntity caster = event.getPlayer();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/InventoryOpenListener.java
@@ -7,6 +7,7 @@ import org.bukkit.entity.HumanEntity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.inventory.InventoryOpenEvent;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -29,7 +30,7 @@ public class InventoryOpenListener extends PassiveListener {
 	@EventHandler
 	public void onInventoryOpen(InventoryOpenEvent event) {
 		if (!isCancelStateOk(event.isCancelled())) return;
-		if (!inventoryNames.isEmpty() && !inventoryNames.contains(event.getView().getTitle())) return;
+		if (!inventoryNames.contains(Util.getStringFromComponent(event.getView().title()))) return;
 
 		HumanEntity caster = event.getPlayer();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
@@ -111,12 +111,9 @@ public class MissArrowListener extends PassiveListener {
 	
 	@EventHandler
 	public void shoot(ProjectileLaunchEvent event) {
-		if (event.getEntity().getShooter() != null && event.getEntity().getShooter() instanceof LivingEntity
-			&& event.getEntity() instanceof Arrow) {
-			LivingEntity p = (LivingEntity) event.getEntity().getShooter();
-			ArrowParticle arrowParticle = new ArrowParticle(p);
-			event.getEntity().setMetadata("mal-" + p.getUniqueId() + '-' + p.getName(), new FixedMetadataValue(MagicSpells.getInstance(), arrowParticle));
-		}
+		if (event.getEntity().getShooter() == null || !(event.getEntity().getShooter() instanceof LivingEntity p) || !(event.getEntity() instanceof Arrow)) return;
+		ArrowParticle arrowParticle = new ArrowParticle(p);
+		event.getEntity().setMetadata("mal-" + p.getUniqueId() + '-' + p.getName(), new FixedMetadataValue(MagicSpells.getInstance(), arrowParticle));
 	}
 	
 	private static class ArrowParticle {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MountListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MountListener.java
@@ -34,11 +34,9 @@ public class MountListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onMount(EntityMountEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (!types.isEmpty() && !types.contains(event.getMount().getType())) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RegainHealthListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RegainHealthListener.java
@@ -36,11 +36,8 @@ public class RegainHealthListener extends PassiveListener {
 		if (!isCancelStateOk(event.isCancelled())) return;
 
 		Entity entity = event.getEntity();
-		if (!(entity instanceof LivingEntity)) return;
-
-		LivingEntity caster = (LivingEntity) entity;
+		if (!(entity instanceof LivingEntity caster)) return;
 		if (!canTrigger(caster) || !hasSpell(caster)) return;
-
 		if (!reasons.isEmpty() && !reasons.contains(event.getRegainReason())) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RespawnListener.java
@@ -4,7 +4,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.player.PlayerRespawnEvent;
 
-import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SignBookListener.java
@@ -1,15 +1,16 @@
 package com.nisovin.magicspells.spells.passive;
 
 import java.util.Set;
-import java.util.List;
 import java.util.Arrays;
 import java.util.HashSet;
 
+import net.kyori.adventure.text.Component;
+
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
-import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.event.player.PlayerEditBookEvent;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
@@ -43,14 +44,11 @@ public class SignBookListener extends PassiveListener {
 			return;
 		}
 
-		BookMeta meta = event.getNewBookMeta();
-		List<String> pages = meta.getPages();
-		for (String page : pages) {
-			if (text.contains(page)) {
-				boolean casted = passiveSpell.activate(player);
-				if (cancelDefaultAction(casted)) event.setCancelled(true);
-				return;
-			}
+		for (Component page : event.getNewBookMeta().pages()) {
+			if (!text.contains(Util.getStringFromComponent(page))) continue;
+			boolean casted = passiveSpell.activate(player);
+			if (cancelDefaultAction(casted)) event.setCancelled(true);
+			return;
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SpellSelectListener.java
@@ -55,11 +55,8 @@ public class SpellSelectListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSpellSelect(SpellSelectionChangedEvent event) {
-		if (!(event.getCaster() instanceof Player)) return;
-
-		Player caster = (Player) event.getCaster();
+		if (!(event.getCaster() instanceof Player caster)) return;
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
-
 		if (filter != null && !filter.check(event.getSpell())) return;
 		passiveSpell.activate(caster);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartGlideListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartGlideListener.java
@@ -18,11 +18,9 @@ public class StartGlideListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onGlide(EntityToggleGlideEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (!event.isGliding()) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSwimListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StartSwimListener.java
@@ -18,11 +18,9 @@ public class StartSwimListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSwim(EntityToggleSwimEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (!event.isSwimming()) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopGlideListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopGlideListener.java
@@ -18,11 +18,9 @@ public class StopGlideListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onGlide(EntityToggleGlideEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (event.isGliding()) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
 
 		boolean casted = passiveSpell.activate(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSwimListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/StopSwimListener.java
@@ -18,13 +18,10 @@ public class StopSwimListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSwim(EntityToggleSwimEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (event.isSwimming()) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
-
 		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -57,12 +57,9 @@ public class TakeDamageListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDamage(EntityDamageEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity)) return;
+		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
-
-		LivingEntity caster = (LivingEntity) event.getEntity();
 		if (!hasSpell(caster) || !canTrigger(caster)) return;
-
 		if (!damageCauses.isEmpty() && !damageCauses.contains(event.getCause())) return;
 
 		LivingEntity attacker = getAttacker(event);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
@@ -53,9 +53,7 @@ public abstract class PassiveListener implements Listener {
 	}
 
 	public boolean hasSpell(LivingEntity entity) {
-		if (entity instanceof Player) {
-			return MagicSpells.getSpellbook((Player) entity).hasSpell(passiveSpell);
-		}
+		if (entity instanceof Player player) return MagicSpells.getSpellbook(player).hasSpell(passiveSpell);
 		return true;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AgeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AgeSpell.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells.spells.targeted;
 
 import org.bukkit.entity.Ageable;
+import org.bukkit.entity.Breedable;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.TargetInfo;
@@ -27,9 +28,7 @@ public class AgeSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetEntityInfo = getTargetedEntity(caster, power);
 			if (targetEntityInfo == null || targetEntityInfo.getTarget() == null) return noTarget(caster);
-			if (!(targetEntityInfo.getTarget() instanceof Ageable)) return noTarget(caster);
-
-			Ageable a = (Ageable) targetEntityInfo.getTarget();
+			if (!(targetEntityInfo.getTarget() instanceof Ageable a)) return noTarget(caster);
 			applyAgeChanges(a);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
@@ -47,9 +46,9 @@ public class AgeSpell extends TargetedSpell implements TargetedEntitySpell {
 		return castAtEntity(null, target, power);
 	}
 
-	private void applyAgeChanges(Ageable a) {
-		if (setMaturity) a.setAge(rawAge);
-		if (applyAgeLock) a.setAgeLock(true);
+	private void applyAgeChanges(Ageable ageable) {
+		if (setMaturity) ageable.setAge(rawAge);
+		((Breedable) ageable).setAgeLock(applyAgeLock);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
@@ -34,7 +34,7 @@ public class BlinkSpell extends TargetedSpell implements TargetedLocationSpell {
 			if (range > 125) range = 125;
 			BlockIterator iter; 
 			try {
-				iter = new BlockIterator(caster, range > 0 && range <= 125 ? range : 125);
+				iter = new BlockIterator(caster, range);
 			} catch (IllegalStateException e) {
 				iter = null;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -75,8 +75,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			ItemStack item = player.getInventory().getItem(slot);
 			if (item == null || !isAllowed(item.getType())) return noTarget(player, strInvalidBlock);
 			

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -90,8 +90,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			Location loc = null;
 			if (targetSelf) loc = player.getLocation();
 			else {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -107,15 +107,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 	public int getDuration() {
 		return fireTicks;
 	}
-	
-	private class CombustData {
-		
-		private float power;
-		
-		CombustData(float power) {
-			this.power = power;
-		}
-		
-	}
+
+	private record CombustData(float power) {}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ConversationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ConversationSpell.java
@@ -46,10 +46,10 @@ public class ConversationSpell extends TargetedSpell implements TargetedEntitySp
 	}
 
 	private void conversate(LivingEntity target) {
-		if (target == null || !(target instanceof Player)) return;
-		Conversation c = conversationFactory.buildConversation((Player) target);
-		ConversationContextUtil.setconversable(c.getContext(), (Player) target);
-		c.begin();
+		if (!(target instanceof Player player)) return;
+		Conversation conversation = conversationFactory.buildConversation(player);
+		ConversationContextUtil.setConversable(conversation.getContext(), player);
+		conversation.begin();
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
@@ -67,8 +67,7 @@ public class CreatureTargetSpell extends TargetedSpell implements TargetedEntity
 	}
 
 	private void castSpells(LivingEntity livingEntity, float power) {
-		if (!(livingEntity instanceof Creature)) return;
-		Creature caster = (Creature) livingEntity;
+		if (!(livingEntity instanceof Creature caster)) return;
 		LivingEntity target = caster.getTarget();
 		if (target == null || !target.isValid()) return;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
@@ -41,8 +41,7 @@ public class DataSpell extends TargetedSpell implements TargetedEntitySpell {
 	
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(player, power);
 			if (targetInfo == null) return noTarget(player);
 			LivingEntity target = targetInfo.getTarget();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
@@ -189,8 +189,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 	@EventHandler(priority=EventPriority.HIGH, ignoreCancelled = true)
 	public void onExplosionPrime(ExplosionPrimeEvent event) {
 		Entity entityRaw = event.getEntity();
-		if (!(entityRaw instanceof Fireball)) return;
-		final Fireball fireball = (Fireball) entityRaw;
+		if (!(entityRaw instanceof Fireball fireball)) return;
 		if (!fireballs.containsKey(fireball)) return;
 		
 		playSpellEffects(EffectPosition.TARGET, fireball.getLocation());
@@ -227,8 +226,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 				}
 			}
 		} else {
-			if (noFire) event.setFire(false);
-			else event.setFire(true);
+			event.setFire(!noFire);
 			if (explosionSize > 0) event.setRadius(explosionSize);
 		}
 
@@ -240,13 +238,11 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
 		if (!(entity instanceof LivingEntity)) return;
-		if (!(event instanceof EntityDamageByEntityEvent)) return;
-		
-		EntityDamageByEntityEvent evt = (EntityDamageByEntityEvent) event;
+		if (!(event instanceof EntityDamageByEntityEvent evt)) return;
+
 		if (event.getCause() != DamageCause.ENTITY_EXPLOSION && event.getCause() != DamageCause.PROJECTILE) return;
 		Entity damager = evt.getDamager();
-		if (!(damager instanceof Fireball || damager instanceof SmallFireball)) return;
-		Fireball fireball = (Fireball) damager;
+		if (!(damager instanceof Fireball fireball)) return;
 		ProjectileSource shooter = fireball.getShooter();
 		if (!(shooter instanceof Player)) return;
 		if (!fireballs.containsKey(fireball)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -202,12 +202,10 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 	@EventHandler
 	public void onProjectileHit(EntityDamageByEntityEvent event) {
 		if (event.getCause() != EntityDamageEvent.DamageCause.PROJECTILE) return;
-		if (!(event.getEntity() instanceof LivingEntity)) return;
-		LivingEntity entity = (LivingEntity) event.getEntity();
+		if (!(event.getEntity() instanceof LivingEntity entity)) return;
 		Entity damagerEntity = event.getDamager();
-		if (!(damagerEntity instanceof Projectile)) return;
+		if (!(damagerEntity instanceof Projectile projectile)) return;
 
-		Projectile projectile = (Projectile) damagerEntity;
 		for (HomingProjectileMonitor monitor : monitors) {
 			if (monitor.projectile == null) continue;
 			if (!monitor.projectile.equals(projectile)) continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -120,9 +120,10 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 		LightningStrike strike = event.getLightning();
 		if (strike == null) return;
 		List<MetadataValue> data = strike.getMetadata("MS" + internalName);
-		if (data == null || data.isEmpty()) return;
-		for (MetadataValue val: data) {
-			ChargeOption option = (ChargeOption)val.value();
+		if (data.isEmpty()) return;
+		for (MetadataValue val : data) {
+			ChargeOption option = (ChargeOption) val.value();
+			if (option == null) continue;
 			if (!option.chargeCreeper) event.setCancelled(true);
 			break;
 		}
@@ -131,25 +132,15 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 	@EventHandler
 	public void onPigZap(PigZapEvent event) {
 		LightningStrike strike = event.getLightning();
-		if (strike == null) return;
 		List<MetadataValue> data = strike.getMetadata("MS" + internalName);
-		if (data == null || data.isEmpty()) return;
+		if (data.isEmpty()) return;
 		for (MetadataValue val: data) {
 			ChargeOption option = (ChargeOption) val.value();
+			if (option == null) continue;
 			if (!option.changePig) event.setCancelled(true);
 		}
 	}
-	
-	private static class ChargeOption {
 
-		private boolean changePig;
-		private boolean chargeCreeper;
-
-		private ChargeOption(boolean creeper, boolean pigmen) {
-			changePig = pigmen;
-			chargeCreeper = creeper;
-		}
-		
-	}
+	private record ChargeOption(boolean chargeCreeper, boolean changePig) {}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -1,12 +1,5 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import java.util.Set;
-import java.util.List;
-import java.util.Random;
-import java.util.HashSet;
-import java.util.ArrayList;
-import java.util.concurrent.ThreadLocalRandom;
-
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -15,6 +8,13 @@ import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
+
+import java.util.Set;
+import java.util.List;
+import java.util.Random;
+import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
@@ -149,8 +149,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			List<Block> lastTwo;
 			try {
 				lastTwo = getLastTwoTargetedBlocks(player, power);
@@ -179,8 +178,8 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 			//This is the top-left edge of the shape array
 			Location patternStart = against.getLocation();
 
-			patternStart.setX(against.getX() - Math.ceil(rowSize / 2));
-			patternStart.setZ(against.getZ() - Math.ceil(columnSize / 2));
+			patternStart.setX(against.getX() - Math.ceil(rowSize / 2F));
+			patternStart.setZ(against.getZ() - Math.ceil(columnSize / 2F));
 
 			//spawnBlock is the current position in the loop where it will spawn the block
 			Location spawnBlock = patternStart;
@@ -245,11 +244,11 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 
 	@Override
 	public boolean castAtLocation(LivingEntity caster, Location target, float power) {
-		if (!(caster instanceof Player)) return false;
+		if (!(caster instanceof Player player)) return false;
 		Block block = target.getBlock();
 		Block against = target.clone().add(target.getDirection()).getBlock();
 		if (block.equals(against)) against = block.getRelative(BlockFace.DOWN);
-		if (block.getType() == Material.AIR) return materialize((Player) caster, block, against);
+		if (block.getType() == Material.AIR) return materialize(player, block, against);
 		Block block2 = block.getRelative(BlockFace.UP);
 		if (block2.getType() == Material.AIR) return materialize(null, block2, block);
 		return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
@@ -6,7 +6,6 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import com.nisovin.magicspells.util.Util;
-import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.DamageSpell;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
@@ -47,40 +47,32 @@ public class ParseSpell extends TargetedSpell implements TargetedEntitySpell {
 			case "translate", "normal", "append" -> {
 				if (expectedValue.isEmpty()) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid expected-value defined!");
-					break;
 				}
 				if (parseToVariable.isEmpty()) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid parse-to-variable defined!");
-					break;
 				}
 				if (variableToParse.isEmpty() || MagicSpells.getVariableManager().getVariable(variableToParse) == null) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid variable-to-parse defined!");
-					break;
 				}
 			}
 			case "difference" -> {
 				if (firstVariable.isEmpty() || MagicSpells.getVariableManager().getVariable(firstVariable) == null) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid first-variable defined!");
-					break;
 				}
 				if (secondVariable.isEmpty() || MagicSpells.getVariableManager().getVariable(secondVariable) == null) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid second-variable defined!");
-					break;
 				}
 			}
 			case "regex", "regexp" -> {
 				if (parseTo.isEmpty()) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid parse-to defined!");
-					break;
 				}
 				regexPattern = Pattern.compile(expectedValue);
 				if (parseToVariable.isEmpty()) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid parse-to-variable defined!");
-					break;
 				}
 				if (variableToParse.isEmpty() || MagicSpells.getVariableManager().getVariable(variableToParse) == null) {
 					MagicSpells.error("ParseSpell '" + internalName + "' has an invalid variable-to-parse defined!");
-					break;
 				}
 			}
 			default -> MagicSpells.error("ParseSpell '" + internalName + "' has invalid operation defined: " + operationName);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
@@ -228,9 +228,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 				try {
 					Block block = getTargetedBlock(caster, power);
 					if (block != null && !BlockUtils.isAir(block.getType())) loc = block.getLocation();
-				} catch (IllegalStateException e) {
-					loc = null;
-				}
+				} catch (IllegalStateException ignored) {}
 			}
 			if (loc == null) return noTarget(caster);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RegrowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RegrowSpell.java
@@ -52,9 +52,9 @@ public class RegrowSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power);
 			if (target == null) return PostCastAction.ALREADY_HANDLED;
-			if (!(target.getTarget() instanceof Sheep)) return PostCastAction.ALREADY_HANDLED;
+			if (!(target.getTarget() instanceof Sheep sheep)) return PostCastAction.ALREADY_HANDLED;
 
-			boolean done = grow((Sheep) target.getTarget());
+			boolean done = grow(sheep);
 			if (!done) return noTarget(caster);
 
 			sendMessages(caster, target.getTarget(), args);
@@ -65,14 +65,14 @@ public class RegrowSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!(target instanceof Sheep)) return false;
-		return grow((Sheep) target);
+		if (!(target instanceof Sheep sheep)) return false;
+		return grow(sheep);
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!(target instanceof Sheep)) return false;
-		return grow((Sheep) target);
+		if (!(target instanceof Sheep sheep)) return false;
+		return grow(sheep);
 	}
 
 	private boolean grow(Sheep sheep) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -178,8 +178,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 						// Place block.
 						if (replaceRandom) block.setType(replaceWith.get(Util.getRandomInt(replaceWith.size())));
 						else block.setType(replaceWith.get(i));
-						if (checkPlugins && caster instanceof Player) {
-							Player player = (Player) caster;
+						if (checkPlugins && caster instanceof Player player) {
 							Block against = target.clone().add(target.getDirection()).getBlock();
 							if (block.equals(against)) against = block.getRelative(BlockFace.DOWN);
 							MagicSpellsBlockPlaceEvent event = new MagicSpellsBlockPlaceEvent(block, previousState, against, player.getInventory().getItemInMainHand(), player, true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -6,11 +6,12 @@ import java.util.UUID;
 import java.util.HashMap;
 import java.util.concurrent.ConcurrentHashMap;
 
+import io.papermc.paper.event.player.AsyncChatEvent;
+
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.player.AsyncPlayerChatEvent;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
 import com.nisovin.magicspells.Subspell;
@@ -153,9 +154,9 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 	}
 	
 	public class ChatListener implements Listener {
-		
-		@EventHandler(ignoreCancelled=true)
-		public void onChat(AsyncPlayerChatEvent event) {
+
+		@EventHandler(ignoreCancelled = true)
+		public void onChat(AsyncChatEvent event) {
 			if (!silenced.containsKey(event.getPlayer().getUniqueId())) return;
 			event.setCancelled(true);
 			if (preventChatSpell != null) preventChatSpell.cast(event.getPlayer(), 1);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
@@ -34,15 +34,15 @@ public class SkinSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!(target instanceof Player)) return false;
-		Util.setSkin((Player) target, texture, signature);
+		if (!(target instanceof Player player)) return false;
+		Util.setSkin(player, texture, signature);
 		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!(target instanceof Player)) return false;
-		Util.setSkin((Player) target, texture, signature);
+		if (!(target instanceof Player player)) return false;
+		Util.setSkin(player, texture, signature);
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlimeSizeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlimeSizeSpell.java
@@ -72,11 +72,9 @@ public class SlimeSizeSpell extends TargetedSpell implements TargetedEntitySpell
 	}
 
 	private void setSize(LivingEntity caster, LivingEntity target) {
-		if (!(target instanceof Slime)) return;
-		if (!(caster instanceof Player)) return;
-
-		Slime slime = (Slime) target;
-		double rawOutputValue = variableMod.getValue((Player) caster, null, slime.getSize());
+		if (!(target instanceof Slime slime)) return;
+		if (!(caster instanceof Player player)) return;
+		double rawOutputValue = variableMod.getValue(player, null, slime.getSize());
 		int finalSize = Util.clampValue(minSize, maxSize, (int) rawOutputValue);
 		slime.setSize(finalSize);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlotSelectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlotSelectSpell.java
@@ -58,8 +58,7 @@ public class SlotSelectSpell extends TargetedSpell implements TargetedEntitySpel
 	}
 
 	private boolean slotChange(LivingEntity target) {
-		if (!(target instanceof Player)) return false;
-		Player player = (Player) target;
+		if (!(target instanceof Player player)) return false;
 		int newSlot = -1;
 		if (isVariable) {
 			if (variable == null || variable.isEmpty() || MagicSpells.getVariableManager().getVariable(variable) == null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -192,8 +192,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 					if (split.length > 1) duration = Integer.parseInt(split[1]);
 					int strength = 0;
 					if (split.length > 2) strength = Integer.parseInt(split[2]);
-					boolean ambient = false;
-					if (split.length > 3 && split[3].equalsIgnoreCase("ambient")) ambient = true;
+					boolean ambient = split.length > 3 && split[3].equalsIgnoreCase("ambient");
 					potionEffects.add(new PotionEffect(type, duration, strength, ambient));
 				} catch (Exception e) {
 					MagicSpells.error("SpawnMonsterSpell '" + spellName + "' has an invalid potion effect defined: " + data);
@@ -366,8 +365,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 
 		if (removeAI) {
 			if (addLookAtPlayerAI) {
-				if (entity instanceof Mob) {
-					Mob mob = (Mob) entity;
+				if (entity instanceof Mob mob) {
 					MobGoals mobGoals = Bukkit.getMobGoals();
 					mobGoals.removeAllGoals(mob);
 					mobGoals.addGoal(mob, 1, new LookAtEntityGoal(mob, HumanEntity.class, 10.0F, 1.0F));
@@ -446,8 +444,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 
 	@EventHandler
 	private void onEntityDeath(EntityDeathEvent event) {
-		Entity entity = event.getEntity();
-		if (!(entity instanceof LivingEntity)) return;
+		LivingEntity entity = event.getEntity();
 		if (!entities.contains(entity)) return;
 		if (removeMob) entities.remove(entity);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
@@ -127,17 +127,7 @@ public class SpawnTntSpell extends TargetedSpell implements TargetedLocationSpel
 
 		spellToCast.castAtLocation(info.caster, event.getEntity().getLocation(), info.power);
 	}
-	
-	private static class TntInfo {
-		
-		private LivingEntity caster;
-		private float power;
-		
-		private TntInfo(LivingEntity caster, float power) {
-			this.caster = caster;
-			this.power = power;
-		}
-		
-	}
+
+	private record TntInfo(LivingEntity caster, float power) {}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
@@ -113,21 +113,7 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 		stunnedLivingEntities.remove(entity.getUniqueId());
 	}
 
-	private static class StunnedInfo {
-
-		private final Long until;
-		private final LivingEntity caster;
-		private final LivingEntity target;
-		private final Location targetLocation;
-
-		private StunnedInfo(LivingEntity caster, LivingEntity target, Long until, Location targetLocation) {
-			this.caster = caster;
-			this.target = target;
-			this.until = until;
-			this.targetLocation = targetLocation;
-		}
-
-	}
+	private record StunnedInfo(LivingEntity caster, LivingEntity target, Long until, Location targetLocation) {}
 
 	private class StunListener implements Listener {
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -86,7 +86,7 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 			}
 			
 			// Check location
-			if (landLoc == null || !BlockUtils.isSafeToStand(landLoc.clone())) {
+			if (!BlockUtils.isSafeToStand(landLoc.clone())) {
 				sendMessage(strUsage, caster, args);
 				return PostCastAction.ALREADY_HANDLED;
 			}
@@ -98,7 +98,7 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 				if (target != null && !target.getName().equalsIgnoreCase(targetName)) target = null;
 			} else {
 				List<Player> players = Bukkit.getServer().matchPlayer(targetName);
-				if (players != null && players.size() == 1) {
+				if (players.size() == 1) {
 					target = players.get(0);
 				}
 			}
@@ -113,7 +113,7 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 				target.teleport(landLoc);
 				sendMessage(strSummonAccepted, target, args, "%a", ((Player) caster).getDisplayName());
 			}
-			
+
 			sendMessages(caster, target, args);
 			return PostCastAction.NO_MESSAGES;
 			

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -15,12 +15,9 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.TimeUtil;
-import com.nisovin.magicspells.util.BlockUtils;
-import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.PlayerNameUtils;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
 
@@ -62,7 +59,7 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			// Get target name and landing location
 			String targetName = "";
 			Location landLoc = null;
@@ -72,8 +69,8 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 			} else {
 				Block block = getTargetedBlock(caster, 10);
 				if (block != null && (block.getType().name().contains("SIGN"))) {
-					Sign sign = (Sign)block.getState();
-					targetName = sign.getLine(0);
+					Sign sign = (Sign) block.getState();
+					targetName = Util.getStringFromComponent(sign.line(0));
 					landLoc = block.getLocation().add(.5, .25, .5);
 				}
 			}
@@ -105,13 +102,14 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 			if (target == null) return noTarget(caster);
 
 			// Teleport player
+			String displayName = Util.getStringFromComponent(player.displayName());
 			if (requireAcceptance) {
 				pendingSummons.put(target, landLoc);
 				pendingTimes.put(target, System.currentTimeMillis());
-				sendMessage(strSummonPending, target, args, "%a", ((Player) caster).getDisplayName());
+				sendMessage(strSummonPending, target, args, "%a", displayName);
 			} else {
 				target.teleport(landLoc);
-				sendMessage(strSummonAccepted, target, args, "%a", ((Player) caster).getDisplayName());
+				sendMessage(strSummonAccepted, target, args, "%a", displayName);
 			}
 
 			sendMessages(caster, target, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
@@ -2,7 +2,6 @@ package com.nisovin.magicspells.spells.targeted;
 
 import java.util.HashSet;
 
-import com.nisovin.magicspells.util.Util;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.block.Block;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TreeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TreeSpell.java
@@ -12,6 +12,8 @@ import org.bukkit.entity.LivingEntity;
 import org.bukkit.BlockChangeDelegate;
 import org.bukkit.block.data.BlockData;
 
+import org.jetbrains.annotations.NotNull;
+
 import com.nisovin.magicspells.util.BlockUtils;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.SpellAnimation;
@@ -28,9 +30,13 @@ public class TreeSpell extends TargetedSpell implements TargetedLocationSpell {
 	
 	public TreeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
-		treeType = TreeType.valueOf(getConfigString("tree-type", "tree").toUpperCase().replace(" ", "_"));
-		if (treeType == null) treeType = TreeType.TREE;
+
+		try {
+			treeType = TreeType.valueOf(getConfigString("tree-type", "tree").toUpperCase().replace(" ", "_"));
+		}
+		catch (IllegalArgumentException ignored) {
+			treeType = TreeType.TREE;
+		}
 
 		speed = getConfigInt("animation-speed", 20);
 	}
@@ -142,7 +148,7 @@ public class TreeSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 
 		@Override
-		public boolean setBlockData(int x, int y, int z, BlockData data) {
+		public boolean setBlockData(int x, int y, int z, @NotNull BlockData data) {
 			BlockState state = loc.getWorld().getBlockAt(x, y, z).getState();
 			state.setBlockData(data);
 			blockStates.add(state);
@@ -150,6 +156,7 @@ public class TreeSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 		
 		@Override
+		@NotNull
 		public BlockData getBlockData(int x, int y, int z) {
 			return loc.getWorld().getBlockAt(x, y, z).getBlockData();
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
@@ -6,10 +6,10 @@ import java.util.TreeSet;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
-import org.bukkit.material.Vine;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.block.data.MultipleFacing;
 
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.SpellAnimation;
@@ -38,13 +38,13 @@ public class VinesSpell extends TargetedSpell {
 			if (target == null || target.size() != 2) return noTarget(caster);
 			if (target.get(0).getType() != Material.AIR || !target.get(1).getType().isSolid()) return noTarget(caster);
 
-			boolean success = growVines(caster, target.get(0), target.get(1));
+			boolean success = growVines(target.get(0), target.get(1));
 			if (!success) return noTarget(caster);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 	
-	private boolean growVines(LivingEntity caster, final Block air, Block solid) {
+	private boolean growVines(final Block air, Block solid) {
 		BlockFace face = air.getFace(solid);
 		int x = 0;
 		int z = 0;
@@ -86,16 +86,14 @@ public class VinesSpell extends TargetedSpell {
 	}
 	
 	private void setBlockToVine(Block block, BlockFace face) {
-		if (block.getType() == Material.AIR) {
-			BlockState state = block.getState();
-			state.setType(Material.VINE);
-			if (state.getData() instanceof Vine) {
-				Vine data = (Vine) state.getData();
-				data.putOnFace(face);
-				state.setData(data);
-			}
-			state.update(true, false);
-		}
+		if (block.getType() != Material.AIR) return;
+		BlockState state = block.getState();
+		state.setType(Material.VINE);
+		MultipleFacing facing = (MultipleFacing) state.getBlockData();
+		if (!facing.getAllowedFaces().contains(face)) return;
+		facing.setFace(face, true);
+		state.setBlockData(facing);
+		state.update(true, false);
 	}
 	
 	private void growVinesVert(Set<VineBlock> blocks, Block air, Block solid, Block center) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -174,11 +174,10 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 		if (event.getCause() != DamageCause.PROJECTILE) return;
 		if (!(event.getEntity() instanceof LivingEntity)) return;
 		Entity damagerEntity = event.getDamager();
-		if (!(damagerEntity instanceof Arrow) || !damagerEntity.hasMetadata(METADATA_KEY)) return;
+		if (!(damagerEntity instanceof Arrow a) || !damagerEntity.hasMetadata(METADATA_KEY)) return;
 		MetadataValue meta = damagerEntity.getMetadata(METADATA_KEY).iterator().next();
 		if (!meta.value().equals("VolleySpell" + internalName)) return;
 
-		Arrow a = (Arrow) damagerEntity;
 		event.setDamage(damage);
 		SpellPreImpactEvent preImpactEvent = new SpellPreImpactEvent(thisSpell, thisSpell, (LivingEntity) a.getShooter(), (LivingEntity) event.getEntity(), 1);
 		EventUtil.call(preImpactEvent);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
@@ -56,8 +56,7 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && livingEntity instanceof Player) {
-			Player caster = (Player) livingEntity;
+		if (state == SpellCastState.NORMAL && livingEntity instanceof Player caster) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power);
 			if (targetInfo == null) return noTarget(caster);
 			LivingEntity target = targetInfo.getTarget();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/PlaceholderAPIDataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/PlaceholderAPIDataSpell.java
@@ -1,13 +1,14 @@
 package com.nisovin.magicspells.spells.targeted.ext;
 
-import com.nisovin.magicspells.MagicSpells;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
 import me.clip.placeholderapi.PlaceholderAPI;
+
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
-
-import org.bukkit.entity.LivingEntity;
-import org.bukkit.entity.Player;
 
 // NOTE: PLACEHOLDERAPI IS REQUIRED FOR THIS
 public class PlaceholderAPIDataSpell extends TargetedSpell {
@@ -45,8 +46,7 @@ public class PlaceholderAPIDataSpell extends TargetedSpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && caster instanceof Player) {
-			Player player = (Player) caster;
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			TargetInfo<Player> targetInfo = getTargetedPlayer(player, power);
 			if (targetInfo == null) return noTarget(player);
 			Player target = targetInfo.getTarget();

--- a/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BlockUtils.java
@@ -99,12 +99,10 @@ public class BlockUtils {
 	}
 
 	public static boolean isChest(Material m) {
-		switch (m) {
-			case CHEST:
-			case TRAPPED_CHEST:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case CHEST, TRAPPED_CHEST -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isLiquid(Block block) {
@@ -112,13 +110,11 @@ public class BlockUtils {
 	}
 
 	public static boolean isLiquid(Material m) {
-		switch (m) {
-			case WATER:
-			case LAVA:
-				return true;
-		}
+		return switch (m) {
+			case WATER, LAVA -> true;
+			default -> false;
+		};
 
-		return false;
 	}
 
 	public static boolean isPathable(Block block) {
@@ -138,104 +134,48 @@ public class BlockUtils {
 	}
 
 	public static boolean isWoodDoor(Material m) {
-		switch (m) {
-			case OAK_DOOR:
-			case ACACIA_DOOR:
-			case JUNGLE_DOOR:
-			case SPRUCE_DOOR:
-			case DARK_OAK_DOOR:
-			case BIRCH_DOOR:
-			case CRIMSON_DOOR:
-			case WARPED_DOOR:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case OAK_DOOR, ACACIA_DOOR, JUNGLE_DOOR, SPRUCE_DOOR, DARK_OAK_DOOR, BIRCH_DOOR, CRIMSON_DOOR, WARPED_DOOR -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isWoodButton(Material m) {
-		switch (m) {
-			case OAK_BUTTON:
-			case ACACIA_BUTTON:
-			case JUNGLE_BUTTON:
-			case SPRUCE_BUTTON:
-			case DARK_OAK_BUTTON:
-			case BIRCH_BUTTON:
-			case CRIMSON_BUTTON:
-			case WARPED_BUTTON:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case OAK_BUTTON, ACACIA_BUTTON, JUNGLE_BUTTON, SPRUCE_BUTTON, DARK_OAK_BUTTON, BIRCH_BUTTON, CRIMSON_BUTTON, WARPED_BUTTON -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isWoodPressurePlate(Material m) {
-		switch (m) {
-			case OAK_PRESSURE_PLATE:
-			case ACACIA_PRESSURE_PLATE:
-			case JUNGLE_PRESSURE_PLATE:
-			case SPRUCE_PRESSURE_PLATE:
-			case DARK_OAK_PRESSURE_PLATE:
-			case BIRCH_PRESSURE_PLATE:
-			case CRIMSON_PRESSURE_PLATE:
-			case WARPED_PRESSURE_PLATE:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case OAK_PRESSURE_PLATE, ACACIA_PRESSURE_PLATE, JUNGLE_PRESSURE_PLATE, SPRUCE_PRESSURE_PLATE, DARK_OAK_PRESSURE_PLATE, BIRCH_PRESSURE_PLATE, CRIMSON_PRESSURE_PLATE, WARPED_PRESSURE_PLATE -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isWoodTrapdoor(Material m) {
-		switch (m) {
-			case OAK_TRAPDOOR:
-			case ACACIA_TRAPDOOR:
-			case JUNGLE_TRAPDOOR:
-			case SPRUCE_TRAPDOOR:
-			case BIRCH_TRAPDOOR:
-			case DARK_OAK_TRAPDOOR:
-			case CRIMSON_TRAPDOOR:
-			case WARPED_TRAPDOOR:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case OAK_TRAPDOOR, ACACIA_TRAPDOOR, JUNGLE_TRAPDOOR, SPRUCE_TRAPDOOR, BIRCH_TRAPDOOR, DARK_OAK_TRAPDOOR, CRIMSON_TRAPDOOR, WARPED_TRAPDOOR -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isWoodFenceGate(Material m) {
-		switch (m) {
-			case OAK_FENCE_GATE:
-			case ACACIA_FENCE_GATE:
-			case JUNGLE_FENCE_GATE:
-			case SPRUCE_FENCE_GATE:
-			case BIRCH_FENCE_GATE:
-			case DARK_OAK_FENCE_GATE:
-			case CRIMSON_FENCE_GATE:
-			case WARPED_FENCE_GATE:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case OAK_FENCE_GATE, ACACIA_FENCE_GATE, JUNGLE_FENCE_GATE, SPRUCE_FENCE_GATE, BIRCH_FENCE_GATE, DARK_OAK_FENCE_GATE, CRIMSON_FENCE_GATE, WARPED_FENCE_GATE -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isShulkerBox(Material m) {
-		switch (m) {
-			case BLACK_SHULKER_BOX:
-			case BLUE_SHULKER_BOX:
-			case BROWN_SHULKER_BOX:
-			case CYAN_SHULKER_BOX:
-			case GRAY_SHULKER_BOX:
-			case GREEN_SHULKER_BOX:
-			case LIGHT_BLUE_SHULKER_BOX:
-			case LIGHT_GRAY_SHULKER_BOX:
-			case LIME_SHULKER_BOX:
-			case MAGENTA_SHULKER_BOX:
-			case ORANGE_SHULKER_BOX:
-			case PINK_SHULKER_BOX:
-			case PURPLE_SHULKER_BOX:
-			case RED_SHULKER_BOX:
-			case SHULKER_BOX:
-			case SHULKER_SHELL:
-			case SHULKER_SPAWN_EGG:
-			case WHITE_SHULKER_BOX:
-			case YELLOW_SHULKER_BOX:
-				return true;
-		}
-		return false;
+		return switch (m) {
+			case BLACK_SHULKER_BOX, BLUE_SHULKER_BOX, BROWN_SHULKER_BOX, CYAN_SHULKER_BOX, GRAY_SHULKER_BOX, GREEN_SHULKER_BOX,
+					LIGHT_BLUE_SHULKER_BOX, LIGHT_GRAY_SHULKER_BOX, LIME_SHULKER_BOX, MAGENTA_SHULKER_BOX, ORANGE_SHULKER_BOX,
+					PINK_SHULKER_BOX, PURPLE_SHULKER_BOX, RED_SHULKER_BOX, SHULKER_BOX, SHULKER_SHELL, SHULKER_SPAWN_EGG,
+					WHITE_SHULKER_BOX, YELLOW_SHULKER_BOX -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isWood(Material m) {
@@ -257,54 +197,14 @@ public class BlockUtils {
 		if (name.contains("FAN")) return true;
 		if (name.contains("RAIL")) return true;
 		if (name.contains("_AIR")) return true;
-		switch (mat) {
-			case AIR:
-			case WATER:
-			case LAVA:
-			case TALL_GRASS:
-			case LARGE_FERN:
-			case GRASS:
-			case DEAD_BUSH:
-			case FERN:
-			case SEAGRASS:
-			case TALL_SEAGRASS:
-			case LILY_PAD:
-			case DANDELION:
-			case POPPY:
-			case BLUE_ORCHID:
-			case ALLIUM:
-			case AZURE_BLUET:
-			case OXEYE_DAISY:
-			case SUNFLOWER:
-			case LILAC:
-			case PEONY:
-			case ROSE_BUSH:
-			case BROWN_MUSHROOM:
-			case RED_MUSHROOM:
-			case TORCH:
-			case FIRE:
-			case REDSTONE_WIRE:
-			case WHEAT:
-			case LADDER:
-			case LEVER:
-			case REDSTONE_TORCH:
-			case SNOW:
-			case SUGAR_CANE:
-			case VINE:
-			case NETHER_WART:
-			case TUBE_CORAL:
-			case BRAIN_CORAL:
-			case BUBBLE_CORAL:
-			case FIRE_CORAL:
-			case HORN_CORAL:
-			case DEAD_TUBE_CORAL:
-			case DEAD_BRAIN_CORAL:
-			case DEAD_BUBBLE_CORAL:
-			case DEAD_FIRE_CORAL:
-			case DEAD_HORN_CORAL:
-				return true;
-		}
-		return false;
+		return switch (mat) {
+			case AIR, WATER, LAVA, TALL_GRASS, LARGE_FERN, GRASS, DEAD_BUSH, FERN, SEAGRASS, TALL_SEAGRASS, LILY_PAD,
+					DANDELION, POPPY, BLUE_ORCHID, ALLIUM, AZURE_BLUET, OXEYE_DAISY, SUNFLOWER, LILAC, PEONY, ROSE_BUSH,
+					BROWN_MUSHROOM, RED_MUSHROOM, TORCH, FIRE, REDSTONE_WIRE, WHEAT, LADDER, LEVER, REDSTONE_TORCH, SNOW,
+					SUGAR_CANE, VINE, NETHER_WART, TUBE_CORAL, BRAIN_CORAL, BUBBLE_CORAL, FIRE_CORAL, HORN_CORAL,
+					DEAD_TUBE_CORAL, DEAD_BRAIN_CORAL, DEAD_BUBBLE_CORAL, DEAD_FIRE_CORAL, DEAD_HORN_CORAL -> true;
+			default -> false;
+		};
 	}
 
 	public static boolean isSafeToStand(Location location) {
@@ -314,16 +214,14 @@ public class BlockUtils {
 	}
 
 	public static void activatePowerable(Block block) {
-		if (block.getBlockData() instanceof Powerable) {
-			Powerable powerable = (Powerable) block.getBlockData();
+		if (block.getBlockData() instanceof Powerable powerable) {
 			powerable.setPowered(true);
 			block.setBlockData(powerable, true);
 		}
 
-		if (block.getBlockData() instanceof AnaloguePowerable) {
-			AnaloguePowerable analoguePowerable = (AnaloguePowerable) block.getBlockData();
-			analoguePowerable.setPower(analoguePowerable.getMaximumPower());
-			block.setBlockData(analoguePowerable, true);
+		if (block.getBlockData() instanceof AnaloguePowerable powerable) {
+			powerable.setPower(powerable.getMaximumPower());
+			block.setBlockData(powerable, true);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/BoundingBox.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/BoundingBox.java
@@ -39,12 +39,12 @@ public class BoundingBox implements Space {
 	
 	public BoundingBox(Location corner1, Location corner2) {
 		world = corner1.getWorld();
-		lowX = min(corner1.getX(), corner2.getX());
-		highX = max(corner1.getX(), corner2.getX());
-		lowY = min(corner1.getY(), corner2.getY());
-		highY = max(corner1.getY(), corner2.getY());
-		lowZ = min(corner1.getZ(), corner2.getZ());
-		highZ = max(corner1.getZ(), corner2.getZ());
+		lowX = Math.min(corner1.getX(), corner2.getX());
+		highX = Math.max(corner1.getX(), corner2.getX());
+		lowY = Math.min(corner1.getY(), corner2.getY());
+		highY = Math.max(corner1.getY(), corner2.getY());
+		lowZ = Math.min(corner1.getZ(), corner2.getZ());
+		highZ = Math.max(corner1.getZ(), corner2.getZ());
 	}
 	
 	public void setCenter(Location center) {
@@ -83,14 +83,6 @@ public class BoundingBox implements Space {
 	@Override
 	public boolean contains(Block block) {
 		return contains(block.getLocation().add(0.5, 0, 0.5));
-	}
-	
-	private double min(double d1, double d2) {
-		return d1 < d2 ? d1 : d2;
-	}
-	
-	private double max(double d1, double d2) {
-		return d1 > d2 ? d1 : d2;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/CastItem.java
@@ -119,8 +119,8 @@ public class CastItem {
 
 	@Override
 	public boolean equals(Object o) {
-		if (o instanceof CastItem) return equalsCastItem((CastItem) o);
-		if (o instanceof ItemStack) return equalsCastItem(new CastItem((ItemStack) o));
+		if (o instanceof CastItem item) return equalsCastItem(item);
+		if (o instanceof ItemStack item) return equalsCastItem(new CastItem(item));
 		return false;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
@@ -67,7 +67,7 @@ public class ConfigReaderUtil {
 		
 		// Handle the prefix
 		String prefix = section.getString("prefix", null);
-		if (prefix != null && !prefix.isEmpty()) ret = ret.withPrefix(new MagicConversationPrefix(prefix));
+		if (prefix != null && !prefix.isEmpty()) ret = ret.withPrefix(new MagicConversationPrefix(Util.colorize(prefix)));
 		
 		// Handle local echo
 		boolean localEcho = section.getBoolean("local-echo", true);

--- a/core/src/main/java/com/nisovin/magicspells/util/DataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/DataUtil.java
@@ -1,0 +1,54 @@
+package com.nisovin.magicspells.util;
+
+import java.util.function.Consumer;
+
+import com.nisovin.magicspells.MagicSpells;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.persistence.PersistentDataType;
+import org.bukkit.persistence.PersistentDataContainer;
+
+public class DataUtil {
+
+	private static NamespacedKey createKey(String key) {
+		return new NamespacedKey(MagicSpells.getInstance(), key);
+	}
+
+	private static Object get(ItemStack item, String key, PersistentDataType<?, ?> type) {
+		return item.getItemMeta().getPersistentDataContainer().get(createKey(key), type);
+	}
+
+	private static void handle(ItemStack item, Consumer<PersistentDataContainer> consumer) {
+		ItemMeta meta = item.getItemMeta();
+		consumer.accept(meta.getPersistentDataContainer());
+		item.setItemMeta(meta);
+	}
+
+	private static <T, Z> void set(ItemStack item, String key, PersistentDataType<T, Z> type, Z value) {
+		handle(item, container -> container.set(createKey(key), type, value));
+	}
+
+	public static void remove(ItemStack item, String key) {
+		handle(item, container -> container.remove(createKey(key)));
+	}
+
+	public static String getString(ItemStack item, String key) {
+		return (String) get(item, key, PersistentDataType.STRING);
+	}
+
+	public static void setString(ItemStack item, String key, String value) {
+		set(item, key, PersistentDataType.STRING, value);
+	}
+
+	public static boolean getBool(ItemStack item, String key) {
+		Byte old = (Byte) get(item, key, PersistentDataType.BYTE);
+		return old != null && old == 1;
+	}
+
+	public static void setBoolean(ItemStack item, String key, boolean value) {
+		set(item, key, PersistentDataType.BYTE, (byte) (value ? 1 : 0));
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -104,67 +104,67 @@ public class EntityData {
 		String mainGeneType = section.getString("main-gene", "");
 		String hiddenGeneType = section.getString("hidden-gene", "");
 		switch (entity.toLowerCase()) {
-			case "player":
+			case "player" -> {
 				entityType = EntityType.PLAYER;
 				isPlayer = true;
-				break;
-			case "pillager":
+			}
+			case "pillager" -> {
 				entityType = EntityType.PILLAGER;
 				isMob = true;
-				break;
-			case "ravager":
+			}
+			case "ravager" -> {
 				entityType = EntityType.RAVAGER;
 				isMob = true;
-				break;
-			case "trader_llama":
+			}
+			case "trader_llama" -> {
 				entityType = EntityType.TRADER_LLAMA;
 				isMob = true;
-				break;
-			case "wandering_trader":
+			}
+			case "wandering_trader" -> {
 				entityType = EntityType.WANDERING_TRADER;
 				isMob = true;
-				break;
-			case "hoglin":
+			}
+			case "hoglin" -> {
 				entityType = EntityType.HOGLIN;
 				isMob = true;
-				break;
-			case "piglin":
+			}
+			case "piglin" -> {
 				entityType = EntityType.PIGLIN;
 				isMob = true;
-				break;
-			case "piglin_brute":
+			}
+			case "piglin_brute" -> {
 				entityType = EntityType.PIGLIN_BRUTE;
 				isMob = true;
-				break;
-			case "zoglin":
+			}
+			case "zoglin" -> {
 				entityType = EntityType.ZOGLIN;
 				isMob = true;
-				break;
-			case "strider":
+			}
+			case "strider" -> {
 				entityType = EntityType.STRIDER;
 				isMob = true;
-				break;
-			case "bee":
+			}
+			case "bee" -> {
 				entityType = EntityType.BEE;
 				isMob = true;
-				break;
-			case "wither_skeleton":
+			}
+			case "wither_skeleton" -> {
 				entityType = EntityType.WITHER_SKELETON;
 				isMob = true;
-				break;
-			case "zombie_villager":
+			}
+			case "zombie_villager" -> {
 				entityType = EntityType.ZOMBIE_VILLAGER;
 				isMob = true;
-				break;
-			case "creeper":
+			}
+			case "creeper" -> {
 				entityType = EntityType.CREEPER;
 				isMob = true;
-				break;
-			case "panda":
+			}
+			case "panda" -> {
 				entityType = EntityType.PANDA;
 				isMob = true;
 				try {
-					 mainGene = Panda.Gene.valueOf(mainGeneType.toUpperCase());
+					mainGene = Panda.Gene.valueOf(mainGeneType.toUpperCase());
 				} catch (Exception exception) {
 					MagicSpells.error("Invalid panda main gene: " + mainGeneType);
 					mainGene = null;
@@ -175,8 +175,8 @@ public class EntityData {
 					MagicSpells.error("Invalid panda hidden gene: " + hiddenGeneType);
 					hiddenGene = null;
 				}
-				break;
-			case "villager":
+			}
+			case "villager" -> {
 				entityType = EntityType.VILLAGER;
 				isMob = true;
 				try {
@@ -185,8 +185,8 @@ public class EntityData {
 					MagicSpells.error("Invalid villager profession: " + type);
 					profession = null;
 				}
-				break;
-			case "sheep":
+			}
+			case "sheep" -> {
 				entityType = EntityType.SHEEP;
 				isMob = true;
 				try {
@@ -195,8 +195,8 @@ public class EntityData {
 					MagicSpells.error("Invalid sheep color: " + color);
 					dyeColor = null;
 				}
-				break;
-			case "rabbit":
+			}
+			case "rabbit" -> {
 				entityType = EntityType.RABBIT;
 				isMob = true;
 				try {
@@ -205,8 +205,8 @@ public class EntityData {
 					MagicSpells.error("Invalid rabbit type: " + type);
 					rabbitType = null;
 				}
-				break;
-			case "wolf":
+			}
+			case "wolf" -> {
 				entityType = EntityType.WOLF;
 				isMob = true;
 				try {
@@ -215,8 +215,8 @@ public class EntityData {
 					MagicSpells.error("Invalid wolf collar color: " + color);
 					dyeColor = null;
 				}
-				break;
-			case "fox":
+			}
+			case "fox" -> {
 				entityType = EntityType.FOX;
 				isMob = true;
 				try {
@@ -225,8 +225,8 @@ public class EntityData {
 					MagicSpells.error("Invalid fox type: " + type);
 					foxType = null;
 				}
-				break;
-			case "cat":
+			}
+			case "cat" -> {
 				entityType = EntityType.CAT;
 				isMob = true;
 				try {
@@ -235,16 +235,16 @@ public class EntityData {
 					MagicSpells.error("Invalid cat type: " + type);
 					catType = null;
 				}
-				break;
-			case "pig":
+			}
+			case "pig" -> {
 				entityType = EntityType.PIG;
 				isMob = true;
-				break;
-			case "iron_golem":
+			}
+			case "iron_golem" -> {
 				entityType = EntityType.IRON_GOLEM;
 				isMob = true;
-				break;
-			case "mooshroom":
+			}
+			case "mooshroom" -> {
 				entityType = EntityType.MUSHROOM_COW;
 				isMob = true;
 				try {
@@ -253,28 +253,28 @@ public class EntityData {
 					MagicSpells.error("Invalid mooshroom type: " + type);
 					cowVariant = null;
 				}
-				break;
-			case "magma_cube":
+			}
+			case "magma_cube" -> {
 				entityType = EntityType.MAGMA_CUBE;
 				isMob = true;
-				break;
-			case "ocelot":
+			}
+			case "ocelot" -> {
 				entityType = EntityType.OCELOT;
 				isMob = true;
-				break;
-			case "snow_golem":
+			}
+			case "snow_golem" -> {
 				entityType = EntityType.SNOWMAN;
 				isMob = true;
-				break;
-			case "wither":
+			}
+			case "wither" -> {
 				entityType = EntityType.WITHER;
 				isMob = true;
-				break;
-			case "ender_dragon":
+			}
+			case "ender_dragon" -> {
 				entityType = EntityType.ENDER_DRAGON;
 				isMob = true;
-				break;
-			case "horse":
+			}
+			case "horse" -> {
 				entityType = EntityType.HORSE;
 				isMob = true;
 				try {
@@ -283,51 +283,50 @@ public class EntityData {
 					MagicSpells.error("Invalid horse color: " + color);
 					horseColor = null;
 				}
-
 				try {
 					horseStyle = Horse.Style.valueOf(style.toUpperCase());
 				} catch (Exception exception) {
 					MagicSpells.error("Invalid horse style: " + style);
 					horseStyle = null;
 				}
-				break;
-			case "skeleton_horse":
+			}
+			case "skeleton_horse" -> {
 				entityType = EntityType.SKELETON_HORSE;
 				isMob = true;
-				break;
-			case "zombie_horse":
+			}
+			case "zombie_horse" -> {
 				entityType = EntityType.ZOMBIE_HORSE;
 				isMob = true;
-				break;
-			case "mule":
+			}
+			case "mule" -> {
 				entityType = EntityType.MULE;
 				isMob = true;
-				break;
-			case "donkey":
+			}
+			case "donkey" -> {
 				entityType = EntityType.DONKEY;
 				isMob = true;
-				break;
-			case "elder_guardian":
+			}
+			case "elder_guardian" -> {
 				entityType = EntityType.ELDER_GUARDIAN;
 				isMob = true;
-				break;
-			case "slime":
+			}
+			case "slime" -> {
 				entityType = EntityType.SLIME;
 				isMob = true;
-				break;
-			case "cod":
+			}
+			case "cod" -> {
 				entityType = EntityType.COD;
 				isMob = true;
-				break;
-			case "salmon":
+			}
+			case "salmon" -> {
 				entityType = EntityType.SALMON;
 				isMob = true;
-				break;
-			case "pufferfish":
+			}
+			case "pufferfish" -> {
 				entityType = EntityType.PUFFERFISH;
 				isMob = true;
-				break;
-			case "tropical_fish":
+			}
+			case "tropical_fish" -> {
 				entityType = EntityType.TROPICAL_FISH;
 				isMob = true;
 				try {
@@ -336,22 +335,20 @@ public class EntityData {
 					MagicSpells.error("Invalid fish pattern: " + type);
 					fishPattern = null;
 				}
-
 				try {
 					dyeColor = DyeColor.valueOf(color.toUpperCase());
 				} catch (Exception exception) {
 					MagicSpells.error("Invalid fish body color: " + color);
 					dyeColor = null;
 				}
-
 				try {
 					patternDyeColor = DyeColor.valueOf(patternColor.toUpperCase());
 				} catch (Exception exception) {
 					MagicSpells.error("Invalid fish pattern color: " + patternColor);
 					patternDyeColor = null;
 				}
-				break;
-			case "llama":
+			}
+			case "llama" -> {
 				entityType = EntityType.LLAMA;
 				isMob = true;
 				try {
@@ -360,34 +357,33 @@ public class EntityData {
 					MagicSpells.error("Invalid llama color: " + color);
 					llamaColor = null;
 				}
-
 				material = Util.getMaterial(mat);
 				if (material == null) {
 					MagicSpells.error("Invalid llama material: " + mat);
 					material = null;
 				}
-				break;
-			case "polar_bear":
+			}
+			case "polar_bear" -> {
 				entityType = EntityType.POLAR_BEAR;
 				isMob = true;
-				break;
-			case "armor_stand":
+			}
+			case "armor_stand" -> {
 				entityType = EntityType.ARMOR_STAND;
 				isMisc = true;
-				break;
-			case "bat":
+			}
+			case "bat" -> {
 				entityType = EntityType.BAT;
 				isMob = true;
-				break;
-			case "blaze":
+			}
+			case "blaze" -> {
 				entityType = EntityType.BLAZE;
 				isMob = true;
-				break;
-			case "dolphin":
+			}
+			case "dolphin" -> {
 				entityType = EntityType.DOLPHIN;
 				isMob = true;
-				break;
-			case "enderman":
+			}
+			case "enderman" -> {
 				entityType = EntityType.ENDERMAN;
 				isMob = true;
 				material = Util.getMaterial(mat);
@@ -395,81 +391,80 @@ public class EntityData {
 					MagicSpells.error("Invalid enderman material: " + mat);
 					material = null;
 				}
-				break;
-			case "ghast":
+			}
+			case "ghast" -> {
 				entityType = EntityType.GHAST;
 				isMob = true;
-				break;
-			case "guardian":
+			}
+			case "guardian" -> {
 				entityType = EntityType.GUARDIAN;
 				isMob = true;
-				break;
-			case "illusioner":
+			}
+			case "illusioner" -> {
 				entityType = EntityType.ILLUSIONER;
 				isMob = true;
-				break;
-			case "vindicator":
+			}
+			case "vindicator" -> {
 				entityType = EntityType.VINDICATOR;
 				isMob = true;
-				break;
-			case "evoker":
+			}
+			case "evoker" -> {
 				entityType = EntityType.EVOKER;
 				isMob = true;
-				break;
-			case "skeleton":
+			}
+			case "skeleton" -> {
 				entityType = EntityType.SKELETON;
 				isMob = true;
-				break;
-			case "spider":
+			}
+			case "spider" -> {
 				entityType = EntityType.SPIDER;
 				isMob = true;
-				break;
-			case "cave_spider":
+			}
+			case "cave_spider" -> {
 				entityType = EntityType.CAVE_SPIDER;
 				isMob = true;
-				break;
-			case "giant":
+			}
+			case "giant" -> {
 				entityType = EntityType.GIANT;
 				isMob = true;
-				break;
-			case "zombie":
+			}
+			case "zombie" -> {
 				entityType = EntityType.ZOMBIE;
 				isMob = true;
-				break;
-			case "zombie_pigman":
-			case "zombified_piglin":
+			}
+			case "zombie_pigman", "zombified_piglin" -> {
 				entityType = MobUtil.getPigZombieEntityType();
 				isMob = true;
-				break;
-			case "silverfish":
+			}
+			case "silverfish" -> {
 				entityType = EntityType.SILVERFISH;
 				isMob = true;
-				break;
-			case "witch":
+			}
+			case "witch" -> {
 				entityType = EntityType.WITCH;
 				isMob = true;
-				break;
-			case "endermite":
+			}
+			case "endermite" -> {
 				entityType = EntityType.ENDERMITE;
 				isMob = true;
-				break;
-			case "shulker":
+			}
+			case "shulker" -> {
 				entityType = EntityType.SHULKER;
 				isMob = true;
-				break;
-			case "cow":
+			}
+			case "cow" -> {
 				entityType = EntityType.COW;
 				isMob = true;
-				break;
-			case "chicken":
+			}
+			case "chicken" -> {
 				entityType = EntityType.CHICKEN;
 				isMob = true;
-				break;
-			case "squid":
+			}
+			case "squid" -> {
 				entityType = EntityType.SQUID;
 				isMob = true;
-				break;
-			case "parrot":
+			}
+			case "parrot" -> {
 				entityType = EntityType.PARROT;
 				isMob = true;
 				try {
@@ -478,20 +473,20 @@ public class EntityData {
 					MagicSpells.error("Invalid parrot variant: " + type);
 					parrotVariant = null;
 				}
-				break;
-			case "turtle":
+			}
+			case "turtle" -> {
 				entityType = EntityType.TURTLE;
 				isMob = true;
-				break;
-			case "phantom":
+			}
+			case "phantom" -> {
 				entityType = EntityType.PHANTOM;
 				isMob = true;
-				break;
-			case "drowned":
+			}
+			case "drowned" -> {
 				entityType = EntityType.DROWNED;
 				isMob = true;
-				break;
-			case "falling_block":
+			}
+			case "falling_block" -> {
 				entityType = EntityType.FALLING_BLOCK;
 				isMisc = true;
 				material = Util.getMaterial(mat);
@@ -499,13 +494,13 @@ public class EntityData {
 					MagicSpells.error("Invalid falling block material: " + mat);
 					material = null;
 				}
-				break;
-			case "item":
+			}
+			case "item" -> {
 				entityType = EntityType.DROPPED_ITEM;
 				isMisc = true;
 				material = Util.getMaterial(mat);
 				if (material == null) MagicSpells.error("Invalid item material: " + mat);
-				break;
+			}
 		}
 	}
 
@@ -632,17 +627,11 @@ public class EntityData {
 		startLoc.add(startLoc.getDirection().clone().multiply(relativeOffset.getX()));
 		startLoc.setY(startLoc.getY() + relativeOffset.getY());
 		
-		Entity entity;
-		switch (entityType) {
-			case FALLING_BLOCK:
-				entity = startLoc.getWorld().spawnFallingBlock(startLoc, material.createBlockData());
-				break;
-			case DROPPED_ITEM:
-				entity = startLoc.getWorld().dropItem(startLoc, new ItemStack(material));
-				break;
-			default:
-				entity = startLoc.getWorld().spawnEntity(startLoc, entityType);
-		}
+		Entity entity = switch (entityType) {
+			case FALLING_BLOCK -> startLoc.getWorld().spawnFallingBlock(startLoc, material.createBlockData());
+			case DROPPED_ITEM -> startLoc.getWorld().dropItem(startLoc, new ItemStack(material));
+			default -> startLoc.getWorld().spawnEntity(startLoc, entityType);
+		};
 
 		if (entity instanceof Ageable) {
 			if (isBaby()) ((Ageable) entity).setBaby();
@@ -658,7 +647,7 @@ public class EntityData {
 		if (entity instanceof Phantom) ((Phantom) entity).setSize(getSize());
 
 		switch (entityType) {
-			case ARMOR_STAND:
+			case ARMOR_STAND -> {
 				((ArmorStand) entity).setSmall(small);
 				((ArmorStand) entity).setArms(hasArms);
 				((ArmorStand) entity).setMarker(marker);
@@ -670,66 +659,46 @@ public class EntityData {
 				((ArmorStand) entity).setRightArmPose(rightArmAngle);
 				((ArmorStand) entity).setLeftLegPose(leftLegAngle);
 				((ArmorStand) entity).setRightLegPose(rightLegAngle);
-				break;
-			case ZOMBIE:
-				((Zombie) entity).setBaby(isBaby());
-				break;
-			case CREEPER:
-				((Creeper) entity).setPowered(isPowered());
-				break;
-			case ENDERMAN:
-				((Enderman) entity).setCarriedBlock(material.createBlockData());
-				break;
-			case WOLF:
+			}
+			case ZOMBIE -> {
+				if (isBaby()) ((Ageable) entity).setBaby();
+			}
+			case CREEPER -> ((Creeper) entity).setPowered(isPowered());
+			case ENDERMAN -> ((Enderman) entity).setCarriedBlock(material.createBlockData());
+			case WOLF -> {
 				((Wolf) entity).setAngry(isAngry());
 				((Wolf) entity).setTamed(isTamed());
 				if (isTamed()) ((Wolf) entity).setCollarColor(getDyeColor());
-				break;
-			case VILLAGER:
-				((Villager) entity).setProfession(getProfession());
-				break;
-			case PIG:
-				((Pig) entity).setSaddle(isSaddled());
-				break;
-			case SHEEP:
+			}
+			case VILLAGER -> ((Villager) entity).setProfession(getProfession());
+			case PIG -> ((Pig) entity).setSaddle(isSaddled());
+			case SHEEP -> {
 				((Sheep) entity).setSheared(isSheared());
 				((Sheep) entity).setColor(getDyeColor());
-				break;
-			case RABBIT:
-				((Rabbit) entity).setRabbitType(getRabbitType());
-				break;
-			case HORSE:
+			}
+			case RABBIT -> ((Rabbit) entity).setRabbitType(getRabbitType());
+			case HORSE -> {
 				((Horse) entity).setColor(getHorseColor());
 				((Horse) entity).setStyle(getHorseStyle());
-				break;
-			case LLAMA:
+			}
+			case LLAMA -> {
 				((Llama) entity).setColor(getLlamaColor());
 				((Llama) entity).getInventory().setDecor(new ItemStack(getMaterial()));
-				break;
-			case PUFFERFISH:
-				((PufferFish) entity).setPuffState(getSize());
-				break;
-			case TROPICAL_FISH:
+			}
+			case PUFFERFISH -> ((PufferFish) entity).setPuffState(getSize());
+			case TROPICAL_FISH -> {
 				((TropicalFish) entity).setBodyColor(getDyeColor());
 				((TropicalFish) entity).setPatternColor(getPatternDyeColor());
 				((TropicalFish) entity).setPattern(getFishPattern());
-				break;
-			case PARROT:
-				((Parrot) entity).setVariant(getParrotVariant());
-				break;
-			case FOX:
-				((Fox) entity).setFoxType(getFoxType());
-				break;
-			case CAT:
-				((Cat) entity).setCatType(getCatType());
-				break;
-			case MUSHROOM_COW:
-				((MushroomCow) entity).setVariant(getCowVariant());
-				break;
-			case PANDA:
+			}
+			case PARROT -> ((Parrot) entity).setVariant(getParrotVariant());
+			case FOX -> ((Fox) entity).setFoxType(getFoxType());
+			case CAT -> ((Cat) entity).setCatType(getCatType());
+			case MUSHROOM_COW -> ((MushroomCow) entity).setVariant(getCowVariant());
+			case PANDA -> {
 				((Panda) entity).setMainGene(getMainGene());
 				((Panda) entity).setHiddenGene(getMainGene());
-				break;
+			}
 		}
 
 		return entity;

--- a/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
@@ -6,9 +6,6 @@ import org.bukkit.NamespacedKey;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.meta.Damageable;
-import org.bukkit.persistence.PersistentDataType;
-
-import com.nisovin.magicspells.MagicSpells;
 
 public class ItemUtil {
 
@@ -77,26 +74,6 @@ public class ItemUtil {
 		StonecuttingRecipe recipe = new StonecuttingRecipe(namespaceKey, result, ingredient);
 		recipe.setGroup(group);
 		return recipe;
-	}
-
-	private static NamespacedKey createKey(String key) {
-		return new NamespacedKey(MagicSpells.getInstance(), key);
-	}
-
-	public static String getPersistentString(ItemStack item, String key) {
-		return item.getItemMeta().getPersistentDataContainer().get(createKey(key), PersistentDataType.STRING);
-	}
-
-	public static void setPersistentString(ItemStack item, String key, String value) {
-		ItemMeta meta = item.getItemMeta();
-		meta.getPersistentDataContainer().set(createKey(key), PersistentDataType.STRING, value);
-		item.setItemMeta(meta);
-	}
-
-	public static void removePersistentString(ItemStack item, String key) {
-		ItemMeta meta = item.getItemMeta();
-		meta.getPersistentDataContainer().remove(createKey(key));
-		item.setItemMeta(meta);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ItemUtil.java
@@ -14,13 +14,11 @@ public class ItemUtil {
 
 	public static void addFakeEnchantment(ItemMeta meta) {
 		if (meta == null) return;
-
 		meta.addItemFlags(ItemFlag.HIDE_ENCHANTS);
 		meta.addEnchant(Enchantment.FROST_WALKER, -1, true);
 	}
 
 	public static boolean hasFakeEnchantment(ItemMeta meta) {
-
 		return meta.hasItemFlag(ItemFlag.HIDE_ENCHANTS)
 			&& meta.hasEnchant(Enchantment.FROST_WALKER)
 			&& meta.getEnchantLevel(Enchantment.FROST_WALKER) == 65535;
@@ -63,16 +61,15 @@ public class ItemUtil {
 	}
 
 	public static Recipe createCookingRecipe(String type, NamespacedKey namespaceKey, String group, ItemStack result, Material ingredient, float experience, int cookingTime) {
-		Recipe recipe = null;
+		CookingRecipe<?> recipe = null;
 
 		switch (type.toLowerCase()) {
-			case "smoking": recipe = new SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime);
-			case "campfire": recipe = new CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime);
-			case "blasting": recipe = new BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime);
+			case "smoking" -> recipe = new SmokingRecipe(namespaceKey, result, ingredient, experience, cookingTime);
+			case "campfire" -> recipe = new CampfireRecipe(namespaceKey, result, ingredient, experience, cookingTime);
+			case "blasting" -> recipe = new BlastingRecipe(namespaceKey, result, ingredient, experience, cookingTime);
 		}
 
-		if (recipe instanceof CookingRecipe) ((CookingRecipe) recipe).setGroup(group);
-
+		if (recipe != null) recipe.setGroup(group);
 		return recipe;
 	}
 
@@ -82,15 +79,24 @@ public class ItemUtil {
 		return recipe;
 	}
 
-	public static String getPersistentString(ItemStack itemStack, String key) {
-		return itemStack.getItemMeta().getPersistentDataContainer().get(new NamespacedKey(MagicSpells.getInstance(), key), PersistentDataType.STRING);
+	private static NamespacedKey createKey(String key) {
+		return new NamespacedKey(MagicSpells.getInstance(), key);
 	}
 
-	public static ItemStack setPersistentString(ItemStack itemStack, String key, String value) {
-		ItemMeta meta = itemStack.getItemMeta();
-		meta.getPersistentDataContainer().set(new NamespacedKey(MagicSpells.getInstance(), key), PersistentDataType.STRING, value);
-		itemStack.setItemMeta(meta);
-		return itemStack;
+	public static String getPersistentString(ItemStack item, String key) {
+		return item.getItemMeta().getPersistentDataContainer().get(createKey(key), PersistentDataType.STRING);
+	}
+
+	public static void setPersistentString(ItemStack item, String key, String value) {
+		ItemMeta meta = item.getItemMeta();
+		meta.getPersistentDataContainer().set(createKey(key), PersistentDataType.STRING, value);
+		item.setItemMeta(meta);
+	}
+
+	public static void removePersistentString(ItemStack item, String key) {
+		ItemMeta meta = item.getItemMeta();
+		meta.getPersistentDataContainer().remove(createKey(key));
+		item.setItemMeta(meta);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/MagicConversationPrefix.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MagicConversationPrefix.java
@@ -1,5 +1,7 @@
 package com.nisovin.magicspells.util;
 
+import org.jetbrains.annotations.NotNull;
+
 import org.bukkit.conversations.ConversationPrefix;
 import org.bukkit.conversations.ConversationContext;
 
@@ -12,7 +14,8 @@ public class MagicConversationPrefix implements ConversationPrefix {
 	}
 	
 	@Override
-	public String getPrefix(ConversationContext paramConversationContext) {
+	@NotNull
+	public String getPrefix(@NotNull ConversationContext paramConversationContext) {
 		return prefix;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
@@ -45,8 +45,8 @@ public class MobUtil {
 	}
 
 	public static void setTarget(LivingEntity mob, LivingEntity target) {
-		if (!(mob instanceof Creature)) return;
-		((Creature) mob).setTarget(target);
+		if (!(mob instanceof Creature creature)) return;
+		creature.setTarget(target);
 	}
 
 	public static EntityType getPigZombieEntityType() {

--- a/core/src/main/java/com/nisovin/magicspells/util/ParticleUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ParticleUtil.java
@@ -129,9 +129,7 @@ public class ParticleUtil {
 
 			try {
 				particle = Particle.valueOf(particleName.toUpperCase());
-			} catch (IllegalArgumentException ex) {
-				particle = null;
-			}
+			} catch (IllegalArgumentException ignored) {}
 
 			return particle;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/PlayerNameUtils.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/PlayerNameUtils.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.util;
 
 import org.bukkit.Bukkit;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
 
 public class PlayerNameUtils {
@@ -14,11 +13,6 @@ public class PlayerNameUtils {
 	public static Player getPlayer(String playername) {
 		//TODO come up with a non depreciated system
 		return Bukkit.getPlayer(playername);
-	}
-	
-	public static OfflinePlayer getOfflinePlayer(String name) {
-		//TODO come up with a non depreciated system
-		return Bukkit.getOfflinePlayer(name);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellReagents.java
@@ -170,9 +170,7 @@ public class SpellReagents {
 		other.money = money;
 		if (variables != null) {
 			other.variables = new HashMap<>();
-			for (Map.Entry<String, Double> entry : variables.entrySet()) {
-				other.variables.put(entry.getKey(), entry.getValue());
-			}
+			other.variables.putAll(variables);
 		}
 		return other;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TxtUtil.java
@@ -35,8 +35,8 @@ public class TxtUtil {
 	
 	public static List<String> tabCompleteSpellName(CommandSender sender, String partial) {
 		List<String> matches = new ArrayList<>();
-		if (sender instanceof Player) {
-			Spellbook spellbook = MagicSpells.getSpellbook((Player) sender);
+		if (sender instanceof Player player) {
+			Spellbook spellbook = MagicSpells.getSpellbook(player);
 			for (Spell spell : spellbook.getSpells()) {
 				if (!spellbook.canTeach(spell)) continue;
 				if (spell.getName().toLowerCase().startsWith(partial)) {

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -3,6 +3,8 @@ package com.nisovin.magicspells.util;
 import java.io.File;
 import java.io.FileOutputStream;
 
+import net.md_5.bungee.api.ChatColor;
+
 import java.net.URL;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
@@ -23,7 +25,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.potion.PotionEffect;
-import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.inventory.meta.SkullMeta;
 
@@ -84,8 +85,7 @@ public class Util {
 			}
 		}
 
-		boolean ambient = false;
-		if (data.length > 3 && (BooleanUtils.isYes(data[3]) || data[3].equalsIgnoreCase("ambient"))) ambient = true;
+		boolean ambient = data.length > 3 && (BooleanUtils.isYes(data[3]) || data[3].equalsIgnoreCase("ambient"));
 		return new PotionEffect(t, duration, level, ambient);
 	}
 
@@ -129,73 +129,6 @@ public class Util {
 			c[i] = Color.fromRGB(colors[i]);
 		}
 		return c;
-	}
-
-	// Just checks to see if the passed string could be lore data
-	public static boolean isLoreData(String line) {
-		if (line == null) return false;
-		line = decolorize(line);
-		return line.startsWith("MS$:");
-	}
-
-	public static void setLoreData(ItemStack item, String data) {
-		ItemMeta meta = item.getItemMeta();
-		List<String> lore;
-		if (meta.hasLore()) {
-			lore = meta.getLore();
-			if (!lore.isEmpty()) {
-				for (int i = 0; i < lore.size(); i++) {
-					if (!isLoreData(lore.get(i))) continue;
-					lore.remove(i);
-					break;
-				}
-			}
-		} else {
-			lore = new ArrayList<>();
-		}
-		lore.add(ChatColor.BLACK.toString() + ChatColor.MAGIC.toString() + "MS$:" + data);
-		meta.setLore(lore);
-		item.setItemMeta(meta);
-	}
-
-	public static String getLoreData(ItemStack item) {
-		ItemMeta meta = item.getItemMeta();
-		if (meta == null) return null;
-		if (!meta.hasLore()) return null;
-
-		List<String> lore = meta.getLore();
-		if (lore.isEmpty()) return null;
-
-		for (int i = 0; i < lore.size(); i++) {
-			String s = decolorize(lore.get(lore.size() - 1));
-			if (s.startsWith("MS$:")) return s.substring(4);
-		}
-
-		return null;
-	}
-
-	public static void removeLoreData(ItemStack item) {
-		ItemMeta meta = item.getItemMeta();
-		List<String> lore;
-		if (!meta.hasLore()) return;
-
-		lore = meta.getLore();
-		if (lore.isEmpty()) return;
-
-		boolean removed = false;
-		for (int i = 0; i < lore.size(); i++) {
-			String s = decolorize(lore.get(i));
-			if (!s.startsWith("MS$:")) continue;
-			lore.remove(i);
-			removed = true;
-			break;
-		}
-
-		if (removed) {
-			if (!lore.isEmpty()) meta.setLore(lore);
-			else meta.setLore(null);
-			item.setItemMeta(meta);
-		}
 	}
 
 	public static PotionEffectType getPotionEffectType(String type) {
@@ -652,14 +585,12 @@ public class Util {
 	}
 
 	public static String colorize(String string) {
-		Matcher matcher = ColorUtil.HEX_PATTERN.matcher(org.bukkit.ChatColor.translateAlternateColorCodes('&', string));
-		StringBuffer buffer = new StringBuffer();
+		Matcher matcher = ColorUtil.HEX_PATTERN.matcher(ChatColor.translateAlternateColorCodes('&', string));
+		StringBuilder buffer = new StringBuilder();
 		while (matcher.find()) {
 			try {
-				matcher.appendReplacement(buffer, net.md_5.bungee.api.ChatColor.of(matcher.group(1).toUpperCase()).toString());
-			} catch (IllegalArgumentException ex) {
-				// ignored
-			}
+				matcher.appendReplacement(buffer, ChatColor.of(matcher.group(1).toUpperCase()).toString());
+			} catch (IllegalArgumentException ignored) {}
 		}
 		return matcher.appendTail(buffer).toString();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -242,7 +242,7 @@ public class Util {
 
 		if (!building.isEmpty()) list.add(building);
 
-		return list.toArray(new String[list.size()]);
+		return list.toArray(new String[0]);
 	}
 
 	public static String[] splitParams(String string) {

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -42,6 +42,11 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.handlers.PotionEffectHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 
+import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.minimessage.MiniMessage;
+import net.kyori.adventure.text.serializer.legacy.LegacyComponentSerializer;
+import net.kyori.adventure.text.serializer.plain.PlainTextComponentSerializer;
+
 public class Util {
 
 	private static final Random random = ThreadLocalRandom.current();
@@ -582,6 +587,24 @@ public class Util {
 	public static Vector getVector(String str) {
 		String[] vecStrings = str.split(",");
 		return new Vector(Double.parseDouble(vecStrings[0]), Double.parseDouble(vecStrings[1]), Double.parseDouble(vecStrings[2]));
+	}
+
+	public static Component getMiniMessage(String input) {
+		// Let's handle MS color patterns. Replace ampersand with section (§).
+		input = colorize(input);
+		// Translate legacy section (§) to Adventure colors.
+		Component component = LegacyComponentSerializer.legacySection().deserialize(input);
+		input = PlainTextComponentSerializer.plainText().serialize(component);
+		// Parse the actual MiniMessage.
+		return MiniMessage.get().parse(input);
+	}
+
+	public static Component getMiniMessageWithVars(Player player, String input) {
+		return getMiniMessage(MagicSpells.doVariableReplacements(player, input));
+	}
+
+	public static String getStringFromComponent(Component component) {
+		return component == null ? "" : MiniMessage.get().serialize(component);
 	}
 
 	public static String colorize(String string) {

--- a/core/src/main/java/com/nisovin/magicspells/util/ValidTargetList.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ValidTargetList.java
@@ -125,12 +125,15 @@ public class ValidTargetList {
 		boolean targetIsPlayer = target instanceof Player;
 
 		// Todo, Make it optional for both CREATIVE and SPECTATOR to be no target
-		if (targetIsPlayer && ((Player) target).getGameMode() == GameMode.CREATIVE) return false;
-		if (targetIsPlayer && ((Player) target).getGameMode() == GameMode.SPECTATOR) return false;
+		if (targetIsPlayer) {
+			GameMode gameMode = ((Player) target).getGameMode();
+			if (gameMode == GameMode.CREATIVE) return false;
+			if (gameMode == GameMode.SPECTATOR) return false;
+		}
 		if (targetSelf && target.equals(caster)) return true;
 		if (!targetSelf && target.equals(caster)) return false;
 
-		if (!targetInvisibles && targetIsPlayer && caster instanceof Player && !((Player) caster).canSee((Player) target)) return false;
+		if (!targetInvisibles && targetIsPlayer && caster instanceof Player player && !player.canSee((Player) target)) return false;
 		if (targetPlayers && targetIsPlayer) return true;
 		if (targetNonPlayers && !targetIsPlayer) return true;
 
@@ -142,7 +145,7 @@ public class ValidTargetList {
 		if (targetCasterPassenger && target instanceof LivingEntity && target.isInsideVehicle() && target.getVehicle().equals(caster)) return true;
 		if (targetCasterMount && target instanceof LivingEntity && caster.isInsideVehicle() && caster.getVehicle().equals(target)) return true;
 
-		if (targetEntityTarget && (caster instanceof Creature) && ((Creature) caster).getTarget() != null && ((Creature) caster).getTarget().equals(target)) return true;
+		if (targetEntityTarget && (caster instanceof Creature creature) && creature.getTarget() != null && ((Creature) caster).getTarget().equals(target)) return true;
 		if (types.contains(target.getType())) return true;
 		return false;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
@@ -39,22 +39,15 @@ public class VariableMod {
 		
 		static Operation fromPrefix(String s) {
 			char c = s.charAt(0);
-			switch (c) {
-				case '=':
-					return SET;
-				case '*':
-					return MULTIPLY;
-				case '/':
-					return DIVIDE;
-				case '^':
-					return POWER;
-				case '%':
-					return MODULO;
-				case '?':
-					return RANDOM;
-				default:
-					return ADD;
-			}
+			return switch (c) {
+				case '=' -> SET;
+				case '*' -> MULTIPLY;
+				case '/' -> DIVIDE;
+				case '^' -> POWER;
+				case '%' -> MODULO;
+				case '?' -> RANDOM;
+				default -> ADD;
+			};
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
@@ -85,7 +85,7 @@ public class VariableMod {
 			if (data.contains(":")) {
 				// Then there is an explicit statement of who's variable it is
 				String[] dataSplits = data.split(":");
-				if (dataSplits[0].toLowerCase().equals("target")) variableOwner = VariableOwner.TARGET;
+				if (dataSplits[0].equalsIgnoreCase("target")) variableOwner = VariableOwner.TARGET;
 				varName = dataSplits[1];
 			}
 			modifyingVariableName = varName;

--- a/core/src/main/java/com/nisovin/magicspells/util/dynamicvalues/VariableDouble.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/dynamicvalues/VariableDouble.java
@@ -1,11 +1,12 @@
 package com.nisovin.magicspells.util.dynamicvalues;
 
-import com.nisovin.magicspells.util.VariableMod;
 import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.VariableMod;
 
 public class VariableDouble {
 	
-	private VariableMod primaryValue = null;
+	private VariableMod primaryValue;
 	private VariableMod secondaryValue = null;
 	
 	public VariableDouble(VariableMod primaryValue, VariableMod secondaryValue) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -19,10 +19,8 @@ public class BannerHandler {
 	private static final String CONFIG_NAME = PATTERNS.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BannerMeta)) return;
+		if (!(meta instanceof BannerMeta bannerMeta)) return;
 		if (!config.isList(CONFIG_NAME)) return;
-
-		BannerMeta bannerMeta = (BannerMeta) meta;
 
 		// patternType dyeColor
 		List<String> strPatterns = config.getStringList(CONFIG_NAME);

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
@@ -22,20 +22,18 @@ public class DurabilityHandler {
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Damageable)) return;
-
-		if (data.hasAttribute(DURABILITY)) ((Damageable) meta).setDamage((int) data.getAttribute(DURABILITY));
+		if (!data.hasAttribute(DURABILITY)) return;
+		((Damageable) meta).setDamage((int) data.getAttribute(DURABILITY));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Damageable)) return;
-
-		Damageable damageableMeta = (Damageable) meta;
-		if (damageableMeta.hasDamage()) data.setAttribute(DURABILITY, damageableMeta.getDamage());
+		if (!(meta instanceof Damageable damageableMeta)) return;
+		if (!damageableMeta.hasDamage()) return;
+		data.setAttribute(DURABILITY, damageableMeta.getDamage());
 	}
 
 	public static int getDurability(ItemMeta meta) {
 		if (!(meta instanceof Damageable)) return -1;
-
 		return ((Damageable) meta).getDamage();
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkEffectHandler.java
@@ -20,7 +20,7 @@ public class FireworkEffectHandler {
 	private static final String FADE_COLORS_CONFIG_NAME = "fade-colors";
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkEffectMeta)) return;
+		if (!(meta instanceof FireworkEffectMeta fireworkMeta)) return;
 
 		String type = "BALL";
 
@@ -31,7 +31,7 @@ public class FireworkEffectHandler {
 		Color[] fadeColors = null;
 
 		if (config.isString(TYPE_CONFIG_NAME)) {
-			type = config.getString(TYPE_CONFIG_NAME).trim().toUpperCase();
+			type = config.getString(TYPE_CONFIG_NAME, "").trim().toUpperCase();
 		}
 
 		if (config.isBoolean(TRAIL_CONFIG_NAME)) {
@@ -70,21 +70,20 @@ public class FireworkEffectHandler {
 				.withFade(fadeColors)
 				.build();
 
-		((FireworkEffectMeta) meta).setEffect(effect);
+		fireworkMeta.setEffect(effect);
 		data.setAttribute(FIREWORK_EFFECT, effect);
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkEffectMeta)) return;
-
-		if (data.hasAttribute(FIREWORK_EFFECT)) ((FireworkEffectMeta) meta).setEffect((FireworkEffect) data.getAttribute(FIREWORK_EFFECT));
+		if (!(meta instanceof FireworkEffectMeta fireworkMeta)) return;
+		if (!data.hasAttribute(FIREWORK_EFFECT)) return;
+		fireworkMeta.setEffect((FireworkEffect) data.getAttribute(FIREWORK_EFFECT));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkEffectMeta)) return;
-
-		FireworkEffectMeta effectMeta = (FireworkEffectMeta) meta;
-		if (effectMeta.hasEffect()) data.setAttribute(FIREWORK_EFFECT, effectMeta.getEffect());
+		if (!(meta instanceof FireworkEffectMeta effectMeta)) return;
+		if (!effectMeta.hasEffect()) return;
+		data.setAttribute(FIREWORK_EFFECT, effectMeta.getEffect());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/FireworkHandler.java
@@ -21,10 +21,8 @@ public class FireworkHandler {
 	private static final String POWER_CONFIG_NAME = POWER.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkMeta)) return;
+		if (!(meta instanceof FireworkMeta fireworkMeta)) return;
 		if (!config.isList(FIREWORK_EFFECTS_CONFIG_NAME)) return;
-
-		FireworkMeta fireworkMeta = (FireworkMeta) meta;
 
 		int power = 0;
 		if (config.isInt(POWER_CONFIG_NAME)) power = config.getInt(POWER_CONFIG_NAME);
@@ -79,22 +77,18 @@ public class FireworkHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkMeta)) return;
+		if (!(meta instanceof FireworkMeta fireworkMeta)) return;
 
-		FireworkMeta fireworkMeta = (FireworkMeta) meta;
 		if (data.hasAttribute(POWER)) fireworkMeta.setPower((int) data.getAttribute(POWER));
 		if (data.hasAttribute(FIREWORK_EFFECTS)) fireworkMeta.addEffects((List<FireworkEffect>) data.getAttribute(FIREWORK_EFFECTS));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof FireworkMeta)) return;
-
-		FireworkMeta fireworkMeta = (FireworkMeta) meta;
+		if (!(meta instanceof FireworkMeta fireworkMeta)) return;
 		data.setAttribute(POWER, fireworkMeta.getPower());
-		if (fireworkMeta.hasEffects()) {
-			List<FireworkEffect> effects = fireworkMeta.getEffects();
-			if (!effects.isEmpty()) data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
-		}
+		if (!fireworkMeta.hasEffects()) return;
+		List<FireworkEffect> effects = fireworkMeta.getEffects();
+		if (!effects.isEmpty()) data.setAttribute(FIREWORK_EFFECTS, fireworkMeta.getEffects());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LeatherArmorHandler.java
@@ -14,13 +14,11 @@ public class LeatherArmorHandler {
 	private final static String CONFIG_NAME = COLOR.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof LeatherArmorMeta)) return;
+		if (!(meta instanceof LeatherArmorMeta armorMeta)) return;
 		if (!config.isString(CONFIG_NAME)) return;
 
-		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
-
 		try {
-			int color = Integer.parseInt(config.getString(CONFIG_NAME).replace("#", ""), 16);
+			int color = Integer.parseInt(config.getString(CONFIG_NAME, "").replace("#", ""), 16);
 			Color c = Color.fromRGB(color);
 
 			armorMeta.setColor(c);
@@ -31,10 +29,8 @@ public class LeatherArmorHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof LeatherArmorMeta)) return;
+		if (!(meta instanceof LeatherArmorMeta armorMeta)) return;
 		if (!data.hasAttribute(COLOR)) return;
-
-		LeatherArmorMeta armorMeta = (LeatherArmorMeta) meta;
 		armorMeta.setColor((Color) data.getAttribute(COLOR));
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -1,7 +1,9 @@
 package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
-import java.util.Collections;
+import java.util.ArrayList;
+
+import net.kyori.adventure.text.Component;
 
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
@@ -17,26 +19,22 @@ public class LoreHandler {
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!config.contains(CONFIG_NAME)) return;
 
+		List<Component> lore = new ArrayList<>();
 		if (config.isList(CONFIG_NAME)) {
-			List<String> lore = config.getStringList(CONFIG_NAME);
-			for (int i = 0; i < lore.size(); i++) {
-				lore.set(i, Util.colorize(lore.get(i)));
-			}
-
-			if (!lore.isEmpty()) {
-				meta.setLore(lore);
-				data.setAttribute(LORE, meta.getLore());
+			for (String line : config.getStringList(CONFIG_NAME)) {
+				lore.add(Util.getMiniMessage(line));
 			}
 		} else if (config.isString(CONFIG_NAME)) {
-			List<String> lore = Collections.singletonList(Util.colorize(config.getString(CONFIG_NAME)));
-
-			meta.setLore(lore);
-			data.setAttribute(LORE, lore);
+			lore.add(Util.getMiniMessage(config.getString(CONFIG_NAME)));
 		}
+		if (lore.isEmpty()) return;
+		meta.lore(lore);
+		data.setAttribute(LORE, lore);
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (data.hasAttribute(LORE)) meta.setLore((List<String>) data.getAttribute(LORE));
+		if (!data.hasAttribute(LORE)) return;
+		meta.lore((List<Component>) data.getAttribute(LORE));
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/NameHandler.java
@@ -1,5 +1,7 @@
 package com.nisovin.magicspells.util.itemreader;
 
+import net.kyori.adventure.text.Component;
+
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -14,17 +16,18 @@ public class NameHandler {
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
 		if (!config.isString(CONFIG_NAME)) return;
 
-		String name = Util.colorize(config.getString(CONFIG_NAME));
-		meta.setDisplayName(name);
-		data.setAttribute(NAME, meta.getDisplayName());
+		meta.displayName(Util.getMiniMessage(config.getString(CONFIG_NAME)));
+		data.setAttribute(NAME, meta.displayName());
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (data.hasAttribute(NAME)) meta.setDisplayName((String) data.getAttribute(NAME));
+		if (!data.hasAttribute(NAME)) return;
+		meta.displayName((Component) data.getAttribute(NAME));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (meta.hasDisplayName()) data.setAttribute(NAME, meta.getDisplayName());
+		if (!meta.hasDisplayName()) return;
+		data.setAttribute(NAME, meta.displayName());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/PotionHandler.java
@@ -25,10 +25,8 @@ public class PotionHandler {
 	public static final String POTION_COLOR_CONFIG_NAME = "potion-color";
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof PotionMeta)) return;
-		
-		PotionMeta potionMeta = (PotionMeta) meta;
-		
+		if (!(meta instanceof PotionMeta potionMeta)) return;
+
 		if (config.isList(POTION_EFFECT_CONFIG_NAME)) {
 			potionMeta.clearCustomEffects();
 			List<String> potionEffectStrings = config.getStringList(POTION_EFFECT_CONFIG_NAME);
@@ -47,7 +45,7 @@ public class PotionHandler {
 
 		if (config.isString(POTION_COLOR_CONFIG_NAME)) {
 			try {
-				int color = Integer.parseInt(config.getString(POTION_COLOR_CONFIG_NAME).replace("#", ""), 16);
+				int color = Integer.parseInt(config.getString(POTION_COLOR_CONFIG_NAME, "").replace("#", ""), 16);
 				Color c = Color.fromRGB(color);
 
 				potionMeta.setColor(c);
@@ -58,7 +56,7 @@ public class PotionHandler {
 		}
 
 		if (config.isString(POTION_DATA_CONFIG_NAME)) {
-			String potionDataString = config.getString(POTION_DATA_CONFIG_NAME);
+			String potionDataString = config.getString(POTION_DATA_CONFIG_NAME, "");
 			String[] args = potionDataString.split(" ");
 
 			boolean extended = false, upgraded = false;
@@ -82,9 +80,8 @@ public class PotionHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof PotionMeta)) return;
+		if (!(meta instanceof PotionMeta potionMeta)) return;
 
-		PotionMeta potionMeta = (PotionMeta) meta;
 		if (data.hasAttribute(POTION_EFFECTS)) {
 			potionMeta.clearCustomEffects();
 			((List<PotionEffect>) data.getAttribute(POTION_EFFECTS)).forEach(potionEffect -> potionMeta.addCustomEffect(potionEffect, true));
@@ -94,9 +91,8 @@ public class PotionHandler {
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof PotionMeta)) return;
+		if (!(meta instanceof PotionMeta potionMeta)) return;
 
-		PotionMeta potionMeta = (PotionMeta) meta;
 		data.setAttribute(POTION_DATA, potionMeta.getBasePotionData());
 		if (potionMeta.hasCustomEffects()) {
 			List<PotionEffect> effects = potionMeta.getCustomEffects();
@@ -106,9 +102,7 @@ public class PotionHandler {
 	}
 
 	public static PotionData getPotionData(ItemMeta meta) {
-		if (!(meta instanceof PotionMeta)) return null;
-
-		PotionMeta potionMeta = (PotionMeta) meta;
+		if (!(meta instanceof PotionMeta potionMeta)) return null;
 		return potionMeta.getBasePotionData();
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/RepairableHandler.java
@@ -21,16 +21,15 @@ public class RepairableHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Repairable)) return;
-
-		if (data.hasAttribute(REPAIR_COST)) ((Repairable) meta).setRepairCost((int) data.getAttribute(REPAIR_COST));
+		if (!(meta instanceof Repairable repairable)) return;
+		if (!data.hasAttribute(REPAIR_COST)) return;
+		repairable.setRepairCost((int) data.getAttribute(REPAIR_COST));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof Repairable)) return;
-
-		Repairable repairMeta = (Repairable) meta;
-		if (repairMeta.hasRepairCost()) data.setAttribute(REPAIR_COST, repairMeta.getRepairCost());
+		if (!(meta instanceof Repairable repairable)) return;
+		if (!repairable.hasRepairCost()) return;
+		data.setAttribute(REPAIR_COST, repairable.getRepairCost());
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -25,15 +25,13 @@ public class SkullHandler {
 	private static final String TEXTURE_CONFIG_NAME = TEXTURE.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SkullMeta)) return;
-		
-		SkullMeta skullMeta = (SkullMeta) meta;
+		if (!(meta instanceof SkullMeta skullMeta)) return;
 
 		String signature = null, skullOwner = null, texture = null;
 		UUID uuid = null;
 
 		if (config.isString(UUID_CONFIG_NAME)) {
-			String uuidString = config.getString(UUID_CONFIG_NAME);
+			String uuidString = config.getString(UUID_CONFIG_NAME, "");
 
 			try {
 				uuid = UUID.fromString(uuidString);

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SuspiciousStewHandler.java
@@ -17,10 +17,9 @@ public class SuspiciousStewHandler {
 	private static final String CONFIG_NAME = POTION_EFFECTS.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SuspiciousStewMeta)) return;
+		if (!(meta instanceof SuspiciousStewMeta stewMeta)) return;
 		if (!config.isList(CONFIG_NAME)) return;
 
-		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
 		stewMeta.clearCustomEffects();
 
 		List<String> effects = config.getStringList(CONFIG_NAME);
@@ -36,23 +35,17 @@ public class SuspiciousStewHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SuspiciousStewMeta)) return;
-
-		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
-		if (data.hasAttribute(POTION_EFFECTS)) {
-			stewMeta.clearCustomEffects();
-			((List<PotionEffect>) data.getAttribute(POTION_EFFECTS)).forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
-		}
+		if (!(meta instanceof SuspiciousStewMeta stewMeta)) return;
+		if (!data.hasAttribute(POTION_EFFECTS)) return;
+		stewMeta.clearCustomEffects();
+		((List<PotionEffect>) data.getAttribute(POTION_EFFECTS)).forEach(potionEffect -> stewMeta.addCustomEffect(potionEffect, true));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof SuspiciousStewMeta)) return;
-
-		SuspiciousStewMeta stewMeta = (SuspiciousStewMeta) meta;
-		if (stewMeta.hasCustomEffects()) {
-			List<PotionEffect> effects = stewMeta.getCustomEffects();
-			if (!effects.isEmpty()) data.setAttribute(POTION_EFFECTS, effects);
-		}
+		if (!(meta instanceof SuspiciousStewMeta stewMeta)) return;
+		if (!stewMeta.hasCustomEffects()) return;
+		List<PotionEffect> effects = stewMeta.getCustomEffects();
+		if (!effects.isEmpty()) data.setAttribute(POTION_EFFECTS, effects);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -19,9 +19,7 @@ public class WrittenBookHandler {
 	private static final String TITLE_CONFIG_NAME = TITLE.toString();
 
 	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BookMeta)) return;
-		
-		BookMeta bookMeta = (BookMeta) meta;
+		if (!(meta instanceof BookMeta bookMeta)) return;
 
 		if (config.isString(TITLE_CONFIG_NAME)) {
 			String title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
@@ -51,18 +49,16 @@ public class WrittenBookHandler {
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BookMeta)) return;
+		if (!(meta instanceof BookMeta bookMeta)) return;
 
-		BookMeta bookMeta = (BookMeta) meta;
 		if (data.hasAttribute(TITLE)) bookMeta.setTitle((String) data.getAttribute(TITLE));
 		if (data.hasAttribute(AUTHOR)) bookMeta.setAuthor((String) data.getAttribute(AUTHOR));
 		if (data.hasAttribute(PAGES)) bookMeta.setPages((List<String>) data.getAttribute(PAGES));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
-		if (!(meta instanceof BookMeta)) return;
+		if (!(meta instanceof BookMeta bookMeta)) return;
 
-		BookMeta bookMeta = (BookMeta) meta;
 		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.getAuthor());
 		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.getTitle());
 		if (bookMeta.hasPages()) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -1,6 +1,9 @@
 package com.nisovin.magicspells.util.itemreader;
 
 import java.util.List;
+import java.util.ArrayList;
+
+import net.kyori.adventure.text.Component;
 
 import org.bukkit.inventory.meta.BookMeta;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -36,15 +39,14 @@ public class WrittenBookHandler {
 		}
 
 		if (config.isList(PAGES_CONFIG_NAME)) {
-			List<String> pages = config.getStringList(PAGES_CONFIG_NAME);
-			for (int i = 0; i < pages.size(); i++) {
-				pages.set(i, Util.colorize(pages.get(i)));
+			List<Component> pages = new ArrayList<>();
+			for (String page : config.getStringList(PAGES_CONFIG_NAME)) {
+				pages.add(Util.getMiniMessage(page));
 			}
 
-			if (!pages.isEmpty()) {
-				bookMeta.setPages(pages);
-				data.setAttribute(PAGES, bookMeta.getPages());
-			}
+			if (pages.isEmpty()) return;
+			bookMeta.pages(pages);
+			data.setAttribute(PAGES, pages);
 		}
 	}
 
@@ -53,7 +55,7 @@ public class WrittenBookHandler {
 
 		if (data.hasAttribute(TITLE)) bookMeta.setTitle((String) data.getAttribute(TITLE));
 		if (data.hasAttribute(AUTHOR)) bookMeta.setAuthor((String) data.getAttribute(AUTHOR));
-		if (data.hasAttribute(PAGES)) bookMeta.setPages((List<String>) data.getAttribute(PAGES));
+		if (data.hasAttribute(PAGES)) bookMeta.pages((List<Component>) data.getAttribute(PAGES));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
@@ -62,7 +64,7 @@ public class WrittenBookHandler {
 		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.getAuthor());
 		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.getTitle());
 		if (bookMeta.hasPages()) {
-			List<String> pages = bookMeta.getPages();
+			List<Component> pages = bookMeta.pages();
 			if (!pages.isEmpty()) data.setAttribute(PAGES, pages);
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -11,6 +11,8 @@ import java.util.Collection;
 
 import com.google.common.collect.Multimap;
 
+import net.kyori.adventure.text.Component;
+
 import org.bukkit.Color;
 import org.bukkit.Material;
 import org.bukkit.FireworkEffect;
@@ -22,6 +24,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.attribute.AttributeModifier;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.TxtUtil;
 import com.nisovin.magicspells.util.AttributeUtil.AttributeModifierData;
 
@@ -155,7 +158,7 @@ public class MagicItemData {
     public enum MagicItemAttribute {
 
         TYPE(Material.class),
-        NAME(String.class),
+        NAME(Component.class),
         AMOUNT(Integer.class),
         DURABILITY(Integer.class),
         REPAIR_COST(Integer.class),
@@ -213,7 +216,7 @@ public class MagicItemData {
 
             output
                 .append("\"name\":\"")
-                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.NAME)))
+                .append(TxtUtil.escapeJSON(Util.getStringFromComponent((Component) getAttribute(MagicItemAttribute.NAME))))
                 .append('"');
 
             previous = true;
@@ -517,15 +520,15 @@ public class MagicItemData {
             if (previous) output.append(',');
             else output.append('{');
 
-            List<String> lore = (List<String>) getAttribute(MagicItemAttribute.LORE);
+            List<Component> lore = (List<Component>) getAttribute(MagicItemAttribute.LORE);
             boolean previousLore = false;
             output.append("\"lore\":[");
-            for (String line : lore) {
+            for (Component line : lore) {
                 if (previousLore) output.append(',');
 
                 output
                     .append('"')
-                    .append(TxtUtil.escapeJSON(line))
+                    .append(TxtUtil.escapeJSON(Util.getStringFromComponent(line)))
                     .append('"');
 
                 previousLore = true;
@@ -539,15 +542,15 @@ public class MagicItemData {
             if (previous) output.append(',');
             else output.append('{');
 
-            List<String> pages = (List<String>) getAttribute(MagicItemAttribute.PAGES);
+            List<Component> pages = (List<Component>) getAttribute(MagicItemAttribute.PAGES);
             boolean previousPages = false;
             output.append("\"pages\":[");
-            for (String page : pages) {
+            for (Component page : pages) {
                 if (previousPages) output.append(',');
 
                 output
                     .append('"')
-                    .append(TxtUtil.escapeJSON(page))
+                    .append(TxtUtil.escapeJSON(Util.getStringFromComponent(page)))
                     .append('"');
 
                 previousPages = true;

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -130,9 +130,7 @@ public class MagicItemData {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof MagicItemData)) return false;
-
-        MagicItemData other = (MagicItemData) o;
+        if (!(o instanceof MagicItemData other)) return false;
         return itemAttributes.equals(other.itemAttributes)
             && ignoredAttributes.equals(other.ignoredAttributes)
             && blacklistedAttributes.equals(other.blacklistedAttributes);

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -22,6 +22,8 @@ import com.google.common.collect.Multimap;
 import com.google.gson.JsonSyntaxException;
 import com.google.common.collect.HashMultimap;
 
+import net.kyori.adventure.text.Component;
+
 import org.bukkit.Color;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
@@ -97,7 +99,7 @@ public class MagicItemDataParser {
 
 					switch (key.toLowerCase()) {
 						case "name":
-							data.setAttribute(NAME, Util.colorize(value.getAsString()));
+							data.setAttribute(NAME, Util.getMiniMessage(value.getAsString()));
 							break;
 						case "amount":
 							data.setAttribute(AMOUNT, value.getAsInt());
@@ -282,10 +284,10 @@ public class MagicItemDataParser {
 						case "lore":
 							if (!value.isJsonArray()) continue;
 
-							List<String> lore = new ArrayList<>();
+							List<Component> lore = new ArrayList<>();
 							JsonArray jsonArray = value.getAsJsonArray();
 							for (JsonElement elementInside : jsonArray) {
-								lore.add(Util.colorize(elementInside.getAsString()));
+								lore.add(Util.getMiniMessage(elementInside.getAsString()));
 							}
 
 							if (!lore.isEmpty()) data.setAttribute(LORE, lore);
@@ -293,10 +295,10 @@ public class MagicItemDataParser {
 						case "pages":
 							if (!value.isJsonArray()) continue;
 
-							List<String> pages = new ArrayList<>();
+							List<Component> pages = new ArrayList<>();
 							JsonArray pageArray = value.getAsJsonArray();
 							for (JsonElement page : pageArray) {
-								pages.add(Util.colorize(page.getAsString()));
+								pages.add(Util.getMiniMessage(page.getAsString()));
 							}
 
 							if (!pages.isEmpty()) data.setAttribute(PAGES, pages);

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -388,8 +388,7 @@ public class MagicItems {
 					else meta.addEnchant(e, level, true);
 				}
 
-				if (meta instanceof EnchantmentStorageMeta) {
-					EnchantmentStorageMeta storageMeta = (EnchantmentStorageMeta) meta;
+				if (meta instanceof EnchantmentStorageMeta storageMeta) {
 
 					if (storageMeta.hasStoredEnchants()) {
 						Map<Enchantment, Integer> enchantments = storageMeta.getStoredEnchants();

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -1,10 +1,8 @@
 package com.nisovin.magicspells.util.magicitems;
 
-import java.util.Map;
-import java.util.List;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.Collection;
+import java.util.*;
+
+import net.kyori.adventure.text.Component;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.HashMultimap;
@@ -154,7 +152,7 @@ public class MagicItems {
 
 		// lore
 		if (meta.hasLore()) {
-			List<String> lore = meta.getLore();
+			List<Component> lore = meta.lore();
 			if (lore != null && !lore.isEmpty()) data.setAttribute(LORE, lore);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ExperienceBarManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ExperienceBarManager.java
@@ -7,8 +7,6 @@ import java.util.Objects;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
 
-import com.nisovin.magicspells.MagicSpells;
-
 public class ExperienceBarManager {
 
 	private final Map<Player, Object> locks = new HashMap<>();

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.BufferedWriter;
+import java.nio.charset.StandardCharsets;
 
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
@@ -427,7 +428,7 @@ public class VariableManager {
 		}
 
 		try {
-			Scanner scanner = new Scanner(file);
+			Scanner scanner = new Scanner(file, StandardCharsets.UTF_8);
 			while (scanner.hasNext()) {
 				String line = scanner.nextLine().trim();
 				if (!line.isEmpty()) {
@@ -466,7 +467,7 @@ public class VariableManager {
 
 		BufferedWriter writer = null;
 		try {
-			writer = new BufferedWriter(new FileWriter(file, false));
+			writer = new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8, false));
 			for (String line : lines) {
 				writer.write(line);
 				writer.newLine();
@@ -500,7 +501,7 @@ public class VariableManager {
 		}
 
 		try {
-			Scanner scanner = new Scanner(file);
+			Scanner scanner = new Scanner(file, StandardCharsets.UTF_8);
 			while (scanner.hasNext()) {
 				String line = scanner.nextLine().trim();
 				if (!line.isEmpty()) {
@@ -540,7 +541,7 @@ public class VariableManager {
 
 		BufferedWriter writer = null;
 		try {
-			writer = new BufferedWriter(new FileWriter(file, false));
+			writer = new BufferedWriter(new FileWriter(file, StandardCharsets.UTF_8, false));
 			for (String line : lines) {
 				writer.write(line);
 				writer.newLine();

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -12,6 +12,7 @@ import org.bukkit.boss.BarColor;
 import org.bukkit.boss.BarStyle;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.scoreboard.Objective;
+import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.DisplaySlot;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -204,13 +205,10 @@ public class VariableManager {
 			if (scoreName != null && scorePos != null) {
 				String objName = "MSV_" + var;
 				if (objName.length() > 16) objName = objName.substring(0, 16);
-				objective = Bukkit.getScoreboardManager().getMainScoreboard().getObjective(objName);
-				if (objective != null) {
-					objective.unregister();
-					objective = null;
-				}
-				objective = Bukkit.getScoreboardManager().getMainScoreboard().registerNewObjective(objName, objName, objName);
-				objective.setDisplayName(Util.colorize(scoreName));
+				Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+				objective = scoreboard.getObjective(objName);
+				if (objective != null) objective.unregister();
+				objective = scoreboard.registerNewObjective(objName, "dummy", Util.getMiniMessage(scoreName));
 				if (scorePos.equalsIgnoreCase("nameplate")) objective.setDisplaySlot(DisplaySlot.BELOW_NAME);
 				else if (scorePos.equalsIgnoreCase("playerlist")) objective.setDisplaySlot(DisplaySlot.PLAYER_LIST);
 				else objective.setDisplaySlot(DisplaySlot.SIDEBAR);

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/ConversationContextUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/ConversationContextUtil.java
@@ -18,7 +18,7 @@ public class ConversationContextUtil {
 		return (Conversable)context.get(CONVERSABLE_KEY);
 	}
 	
-	public static void setconversable(ConversationContext context, Conversable conversable) {
+	public static void setConversable(ConversationContext context, Conversable conversable) {
 		setConversable(context.getAllSessionData(), conversable);
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicEnumSetPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicEnumSetPrompt.java
@@ -5,6 +5,9 @@ import java.util.List;
 import java.util.ArrayList;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 
 import org.bukkit.conversations.Prompt;
@@ -43,12 +46,13 @@ public class MagicEnumSetPrompt extends FixedSetPrompt {
 	}
 	
 	@Override
-	public String getPromptText(ConversationContext context) {
+	@NotNull
+	public String getPromptText(@NotNull ConversationContext context) {
 		return promptText;
 	}
 
 	@Override
-	protected Prompt acceptValidatedInput(ConversationContext context, String input) {
+	protected Prompt acceptValidatedInput(@NotNull ConversationContext context, @NotNull String input) {
 		return responder.acceptValidatedInput(context, input);
 	}
 	
@@ -69,7 +73,7 @@ public class MagicEnumSetPrompt extends FixedSetPrompt {
 		
 		MagicEnumSetPrompt ret = new MagicEnumSetPrompt(parsedValues);
 		ret.responder = new MagicPromptResponder(section);
-		ret.promptText = section.getString("prompt-text", "");
+		ret.promptText = Util.colorize(section.getString("prompt-text", ""));
 		return ret;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicFixedSetPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicFixedSetPrompt.java
@@ -3,6 +3,10 @@ package com.nisovin.magicspells.util.prompt;
 import java.util.List;
 import java.util.ArrayList;
 
+import com.nisovin.magicspells.util.Util;
+
+import org.jetbrains.annotations.NotNull;
+
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.FixedSetPrompt;
 import org.bukkit.conversations.ConversationContext;
@@ -24,12 +28,13 @@ public class MagicFixedSetPrompt extends FixedSetPrompt {
 	}
 	
 	@Override
-	public String getPromptText(ConversationContext context) {
+	@NotNull
+	public String getPromptText(@NotNull ConversationContext context) {
 		return promptText;
 	}
 
 	@Override
-	protected Prompt acceptValidatedInput(ConversationContext context, String input) {
+	protected Prompt acceptValidatedInput(@NotNull ConversationContext context, @NotNull String input) {
 		return responder.acceptValidatedInput(context, input);
 	}
 	
@@ -40,7 +45,7 @@ public class MagicFixedSetPrompt extends FixedSetPrompt {
 
 		MagicFixedSetPrompt ret = new MagicFixedSetPrompt(options);
 		ret.responder = new MagicPromptResponder(section);
-		ret.promptText = section.getString("prompt-text", "");
+		ret.promptText = Util.colorize(section.getString("prompt-text", ""));
 		return ret;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicPromptResponder.java
@@ -19,7 +19,7 @@ public class MagicPromptResponder {
 	public Prompt acceptValidatedInput(ConversationContext paramConversationContext, String paramString) {
 		String playerName = null;
 		Conversable who = ConversationContextUtil.getConversable(paramConversationContext.getAllSessionData());
-		if (who instanceof Player) playerName = ((Player)who).getName();
+		if (who instanceof Player player) playerName = player.getName();
 
 		// Try to save response to a variable.
 		MagicSpells.getVariableManager().set(variableName, playerName, paramString);

--- a/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicRegexPrompt.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/prompt/MagicRegexPrompt.java
@@ -2,6 +2,10 @@ package com.nisovin.magicspells.util.prompt;
 
 import java.util.regex.Pattern;
 
+import com.nisovin.magicspells.util.Util;
+
+import org.jetbrains.annotations.NotNull;
+
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.RegexPrompt;
 import org.bukkit.configuration.ConfigurationSection;
@@ -22,12 +26,13 @@ public class MagicRegexPrompt extends RegexPrompt {
 	}
 
 	@Override
-	public String getPromptText(ConversationContext paramConversationContext) {
+	@NotNull
+	public String getPromptText(@NotNull ConversationContext paramConversationContext) {
 		return promptText;
 	}
 
 	@Override
-	protected Prompt acceptValidatedInput(ConversationContext paramConversationContext, String paramString) {
+	protected Prompt acceptValidatedInput(@NotNull ConversationContext paramConversationContext, @NotNull String paramString) {
 		return responder.acceptValidatedInput(paramConversationContext, paramString);
 	}
 	
@@ -39,7 +44,7 @@ public class MagicRegexPrompt extends RegexPrompt {
 
 		MagicRegexPrompt ret = new MagicRegexPrompt(regexp);
 		ret.responder = new MagicPromptResponder(section);
-		ret.promptText = section.getString("prompt-text", "");
+		ret.promptText = Util.colorize(section.getString("prompt-text", ""));
 		return ret;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
@@ -79,10 +79,6 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 	private int taskId;
 	private int count = 0;
 
-	public ItemProjectileTracker() {
-
-	}
-
 	public ItemProjectileTracker(LivingEntity caster, Location startLocation, float power) {
 		this.caster = caster;
 		this.power = power;
@@ -204,7 +200,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			if (entity != null) spell.playEffects(EffectPosition.DELAYED, entity.getLocation());
 			if (removeTracker) ItemProjectileSpell.getProjectileTrackers().remove(this);
 		}
-		entity.remove();
+		if (entity != null) entity.remove();
 		MagicSpells.cancelTask(taskId);
 		stopped = true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -140,10 +140,6 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 
 	private static final double ANGLE_Y = FastMath.toRadians(-90);
 
-	public ParticleProjectileTracker() {
-
-	}
-
 	public ParticleProjectileTracker(LivingEntity caster, float power) {
 		this.caster = caster;
 		this.power = power;
@@ -360,8 +356,8 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 				effectLoc = spellEffect.getSpellEffect().applyOffsets(currentLocation.clone());
 				effect.setLocation(effectLoc);
 
-				if (effect instanceof ModifiedEffect) {
-					Effect modifiedEffect = ((ModifiedEffect) effect).getInnerEffect();
+				if (effect instanceof ModifiedEffect mod) {
+					Effect modifiedEffect = mod.getInnerEffect();
 					if (modifiedEffect != null) modifiedEffect.setLocation(effectLoc);
 				}
 			}

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -1,11 +1,11 @@
 package com.nisovin.magicspells.util.trackers;
 
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
-
 import org.bukkit.Location;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
+
+import java.util.Random;
+import java.util.concurrent.ThreadLocalRandom;
 
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.util.Util;
@@ -77,10 +77,6 @@ public class ProjectileTracker implements Runnable, Tracker {
 
 	private boolean stopped = false;
 
-	public ProjectileTracker() {
-
-	}
-
 	public ProjectileTracker(LivingEntity caster, Location startLocation, float power) {
 		this.caster = caster;
 		this.power = power;
@@ -89,7 +85,6 @@ public class ProjectileTracker implements Runnable, Tracker {
 	}
 
 	public void start() {
-
 		initialize();
 	}
 
@@ -124,8 +119,8 @@ public class ProjectileTracker implements Runnable, Tracker {
 			projectile.setCustomName(projectileName);
 			projectile.setCustomNameVisible(true);
 		}
-		if (projectile instanceof WitherSkull) ((WitherSkull) projectile).setCharged(charged);
-		if (projectile instanceof Explosive) ((Explosive) projectile).setIsIncendiary(incendiary);
+		if (projectile instanceof WitherSkull witherSkull) witherSkull.setCharged(charged);
+		if (projectile instanceof Explosive explosive) explosive.setIsIncendiary(incendiary);
 
 		if (spell != null) {
 			spell.playEffects(EffectPosition.CASTER, startLocation);
@@ -181,14 +176,14 @@ public class ProjectileTracker implements Runnable, Tracker {
 		counter++;
 
 		for (Entity e : projectile.getNearbyEntities(hitRadius, verticalHitRadius, hitRadius)) {
-			if (!(e instanceof LivingEntity)) continue;
+			if (!(e instanceof LivingEntity livingEntity)) continue;
 			if (!targetList.canTarget(caster, e)) continue;
 
-			SpellTargetEvent event = new SpellTargetEvent(spell, caster, (LivingEntity) e, power);
+			SpellTargetEvent event = new SpellTargetEvent(spell, caster, livingEntity, power);
 			EventUtil.call(event);
 			if (event.isCancelled()) continue;
 
-			if (hitSpell != null) hitSpell.castAtEntity(caster, (LivingEntity) e, event.getPower());
+			if (hitSpell != null) hitSpell.castAtEntity(caster, livingEntity, event.getPower());
 			stop();
 			return;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampDaysVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampDaysVariable.java
@@ -10,7 +10,7 @@ public class TimestampDaysVariable extends MetaVariable {
     public double getValue(String player) {
         Instant instant = Instant.now();
         long mins = instant.getEpochSecond();
-        return Math.floor(mins / 60 / 60 / 24);
+        return Math.floor(mins / 60F / 60F / 24F);
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampHoursVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampHoursVariable.java
@@ -10,7 +10,7 @@ public class TimestampHoursVariable extends MetaVariable {
     public double getValue(String player) {
         Instant instant = Instant.now();
         long mins = instant.getEpochSecond();
-        return Math.floor(mins / 60 / 60);
+        return Math.floor(mins / 60F / 60F);
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampMinutesVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/TimestampMinutesVariable.java
@@ -10,7 +10,7 @@ public class TimestampMinutesVariable extends MetaVariable {
     public double getValue(String player) {
         Instant instant = Instant.now();
         long mins = instant.getEpochSecond();
-        return Math.floor(mins / 60);
+        return Math.floor(mins / 60F);
     }
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/DistanceToLocationVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/DistanceToLocationVariable.java
@@ -35,12 +35,10 @@ public class DistanceToLocationVariable extends Variable {
 		Player p = PlayerNameUtils.getPlayer(player);
 		if (p == null) return defaultValue;
 		
-		Location originLocation = p.getLocation();
-		if (originLocation == null) return defaultValue;
-		
 		Location targetLoc = targetLocation.getLocation();
 		if (targetLoc == null) return defaultValue;
-		
+
+		Location originLocation = p.getLocation();
 		if (!crossWorld && !LocationUtil.isSameWorld(originLocation, targetLoc)) return defaultValue;
 		
 		double multiplier = !LocationUtil.isSameWorld(originLocation, targetLoc) ? crossWorldDistanceMultiplier : 1.0;

--- a/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/variabletypes/PlayerVariable.java
@@ -3,10 +3,7 @@ package com.nisovin.magicspells.variables.variabletypes;
 import java.util.Map;
 import java.util.HashMap;
 
-import org.bukkit.Bukkit;
-
 import com.nisovin.magicspells.variables.Variable;
-import com.nisovin.magicspells.util.PlayerNameUtils;
 
 public class PlayerVariable extends Variable {
 
@@ -17,7 +14,8 @@ public class PlayerVariable extends Variable {
 		if (amount > maxValue) amount = maxValue;
 		else if (amount < minValue) amount = minValue;
 		map.put(player, amount);
-		if (objective != null) objective.getScore(PlayerNameUtils.getOfflinePlayer(player)).setScore((int) amount);
+		if (objective == null) return;
+		objective.getScore(player).setScore((int) amount);
 	}
 
 	@Override
@@ -28,7 +26,8 @@ public class PlayerVariable extends Variable {
 	@Override
 	public void reset(String player) {
 		map.remove(player);
-		if (objective != null) objective.getScore(Bukkit.getOfflinePlayer(player)).setScore((int) defaultValue);
+		if (objective == null) return;
+		objective.getScore(player).setScore((int) defaultValue);
 	}
 
 }


### PR DESCRIPTION
* Conversation spell supports colors.
* Variable scoreboards support colors.
* Added `required` (bool) and `prompt` (string) to ResourcePack spell.
* Cast commands tabcomplete tempgranted spells.
* Variable saving is now properly encoded in UTF8.
* Added `open-instead` (bool) to ConjureBook spell. 
* Added Adventure support across the plugin. You can use the MiniMessage format in places like `str-` messages, magic items (names, lore, book pages), conjure book, etc.