### PR TITLE
MagneticSpell, CombustSpell bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
@@ -89,8 +89,7 @@ public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
 	private void magnet(Location origin, Item item, float power) {
 		if (removeItemGravity) item.setGravity(false);
 		if (teleport) item.teleport(origin);
-		else
-			item.setVelocity(origin.toVector().subtract(item.getLocation().toVector()).normalize().multiply(velocity * power));
+		else item.setVelocity(origin.toVector().subtract(item.getLocation().toVector()).normalize().multiply(velocity * power));
 		playSpellEffects(EffectPosition.PROJECTILE, item);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/MagnetSpell.java
@@ -18,14 +18,14 @@ import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
 public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
-	
+
 	private double radius;
 	private double velocity;
-	
+
 	private boolean teleport;
 	private boolean forcePickup;
 	private boolean removeItemGravity;
-	
+
 	public MagnetSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
@@ -44,8 +44,10 @@ public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
 		if (state == SpellCastState.NORMAL) {
 			List<Item> items = getNearbyItems(caster.getLocation(), radius * power);
 			magnet(caster.getLocation(), items, power);
+
+			playSpellEffects(EffectPosition.CASTER, caster);
 		}
-		playSpellEffects(EffectPosition.CASTER, caster);
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
@@ -64,7 +66,7 @@ public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
 	private List<Item> getNearbyItems(Location center, double radius) {
 		Collection<Entity> entities = center.getWorld().getNearbyEntities(center, radius, radius, radius);
 		List<Item> ret = new ArrayList<>();
-		for (Entity e: entities) {
+		for (Entity e : entities) {
 			if (!(e instanceof Item i)) continue;
 			ItemStack stack = i.getItemStack();
 			if (InventoryUtil.isNothing(stack)) continue;
@@ -87,7 +89,8 @@ public class MagnetSpell extends InstantSpell implements TargetedLocationSpell {
 	private void magnet(Location origin, Item item, float power) {
 		if (removeItemGravity) item.setGravity(false);
 		if (teleport) item.teleport(origin);
-		else item.setVelocity(origin.toVector().subtract(item.getLocation().toVector()).normalize().multiply(velocity * power));
+		else
+			item.setVelocity(origin.toVector().subtract(item.getLocation().toVector()).normalize().multiply(velocity * power));
 		playSpellEffects(EffectPosition.PROJECTILE, item);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -25,7 +25,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 	private Map<UUID, CombustData> combusting;
 
 	private int fireTicks;
-	private int fireTickDamage;
+	private double fireTickDamage;
 
 	private boolean checkPlugins;
 	private boolean preventImmunity;
@@ -34,7 +34,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 		super(config, spellName);
 		
 		fireTicks = getConfigInt("fire-ticks", 100);
-		fireTickDamage = getConfigInt("fire-tick-damage", 1);
+		fireTickDamage = getConfigDouble("fire-tick-damage", 1);
 
 		checkPlugins = getConfigBoolean("check-plugins", true);
 		preventImmunity = getConfigBoolean("prevent-immunity", true);
@@ -100,7 +100,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 		CombustData data = combusting.get(entity.getUniqueId());
 		if (data == null) return;
 		
-		event.setDamage(Math.round(fireTickDamage * data.power));
+		event.setDamage(fireTickDamage * data.power);
 		if (preventImmunity) MagicSpells.scheduleDelayedTask(() -> ((LivingEntity) entity).setNoDamageTicks(0), 0);
 	}
 


### PR DESCRIPTION
- `MagneticSpell` no longer plays spell effects if it isn't cast on `SpellCastState.NORMAL`.
- `CombustSpell` now supports fractional damage values.