### PR TITLE
Move AttributeModifierData to a local record

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -48,34 +48,4 @@ public class AttributeUtil {
 		return operationNameMap.get(operation.toLowerCase());
 	}
 
-	public static class AttributeModifierData {
-
-		private final String name;
-		private final double amount;
-		private final Operation operation;
-		private final EquipmentSlot slot;
-
-		public AttributeModifierData(AttributeModifier mod) {
-			name = mod.getName();
-			amount = mod.getAmount();
-			operation = mod.getOperation();
-			slot = mod.getSlot();
-		}
-
-		@Override
-		public boolean equals(Object o) {
-			if (this == o) return true;
-			if (o == null || getClass() != o.getClass()) return false;
-
-			AttributeModifierData that = (AttributeModifierData) o;
-			return amount == that.amount && Objects.equals(name, that.name) && operation == that.operation && slot == that.slot;
-		}
-
-		@Override
-		public int hashCode() {
-			return Objects.hash(name, amount, operation, slot);
-		}
-
-	}
-
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -26,7 +26,6 @@ import org.bukkit.attribute.AttributeModifier;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.TxtUtil;
-import com.nisovin.magicspells.util.AttributeUtil.AttributeModifierData;
 
 public class MagicItemData {
 
@@ -76,6 +75,14 @@ public class MagicItemData {
         Set<Attribute> keysSelf = attrSelf.keySet();
         Set<Attribute> keysOther = attrOther.keySet();
         if (!keysSelf.equals(keysOther)) return false;
+
+        record AttributeModifierData(String name, double amt, AttributeModifier.Operation op, EquipmentSlot slot) {
+
+            public AttributeModifierData(AttributeModifier mod) {
+                this(mod.getName(), mod.getAmount(), mod.getOperation(), mod.getSlot());
+            }
+
+        }
 
         for (Attribute attr : keysSelf) {
             Collection<AttributeModifier> modsSelf = attrSelf.get(attr);


### PR DESCRIPTION
Class fits being a record, and is more concise being grouped with the only method that uses it.