### PR TITLE
Get power and targets after calling events

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -26,7 +26,7 @@ import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
 public class Subspell {
 
 	private static final Random random = ThreadLocalRandom.current();
-	
+
 	private Spell spell;
 	private String spellName;
 	private CastMode mode = CastMode.PARTIAL;
@@ -34,7 +34,7 @@ public class Subspell {
 	private int delay = -1;
 	private float subPower = 1F;
 	private double chance = -1D;
-	
+
 	private boolean isTargetedEntity = false;
 	private boolean isTargetedLocation = false;
 	private boolean isTargetedEntityFromLocation = false;
@@ -42,9 +42,9 @@ public class Subspell {
 	// spellName(mode=hard|h|full|f|partial|p|direct|d;power=[subpower];delay=[delay];chance=[chance])
 	public Subspell(String data) {
 		String[] split = data.split("\\(", 2);
-		
+
 		spellName = split[0].trim();
-		
+
 		if (split.length > 1) {
 			split[1] = split[1].trim();
 			if (split[1].endsWith(")")) split[1] = split[1].substring(0, split[1].length() - 1);
@@ -85,7 +85,7 @@ public class Subspell {
 		}
 
 	}
-	
+
 	public boolean process() {
 		spell = MagicSpells.getSpellByInternalName(spellName);
 		if (spell != null) {
@@ -95,35 +95,35 @@ public class Subspell {
 		}
 		return spell != null;
 	}
-	
+
 	public Spell getSpell() {
 		return spell;
 	}
-	
+
 	public boolean isTargetedEntitySpell() {
 		return isTargetedEntity;
 	}
-	
+
 	public boolean isTargetedLocationSpell() {
 		return isTargetedLocation;
 	}
-	
+
 	public boolean isTargetedEntityFromLocationSpell() {
 		return isTargetedEntityFromLocation;
 	}
-	
+
 	public PostCastAction cast(final LivingEntity caster, final float power) {
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return PostCastAction.ALREADY_HANDLED;
 		if (delay < 0) return castReal(caster, power);
 		MagicSpells.scheduleDelayedTask(() -> castReal(caster, power), delay);
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	private PostCastAction castReal(LivingEntity caster, float power) {
 		if ((mode == CastMode.HARD || mode == CastMode.FULL) && caster != null) {
 			return spell.cast(caster, power * subPower, null).action;
 		}
-		
+
 		if (mode == CastMode.PARTIAL) {
 			SpellCastEvent event = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power * subPower, null, 0, null, 0);
 			EventUtil.call(event);
@@ -134,7 +134,7 @@ public class Subspell {
 			}
 			return PostCastAction.ALREADY_HANDLED;
 		}
-		
+
 		return spell.castSpell(caster, SpellCastState.NORMAL, power * subPower, null);
 	}
 
@@ -147,7 +147,7 @@ public class Subspell {
 		MagicSpells.scheduleDelayedTask(() -> castAtEntityReal(caster, target, power, passTargeting), delay);
 		return true;
 	}
-	
+
 	private boolean castAtEntityReal(LivingEntity caster, LivingEntity target, float power, boolean passTargeting) {
 		if (!isTargetedEntity) {
 			if (isTargetedLocation) castAtLocationReal(caster, target.getLocation(), power);
@@ -226,13 +226,13 @@ public class Subspell {
 		spell.setValidTargetList(originalList);
 		return success;
 	}
-	
+
 	public boolean castAtLocation(final LivingEntity caster, final Location target, final float power) {
 		if (delay < 0) return castAtLocationReal(caster, target, power);
 		MagicSpells.scheduleDelayedTask(() -> castAtLocationReal(caster, target, power), delay);
 		return true;
 	}
-	
+
 	private boolean castAtLocationReal(LivingEntity caster, Location target, float power) {
 		if (!isTargetedLocation) return false;
 
@@ -291,7 +291,7 @@ public class Subspell {
 		MagicSpells.scheduleDelayedTask(() -> castAtEntityFromLocationReal(caster, from, target, power, passTargeting), delay);
 		return true;
 	}
-	
+
 	private boolean castAtEntityFromLocationReal(LivingEntity caster, Location from, LivingEntity target, float power, boolean passTargeting) {
 		if (!isTargetedEntityFromLocation) return false;
 

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -166,12 +166,15 @@ public class Subspell {
 			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, power);
+				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, spellCast.getPower());
 				EventUtil.call(spellTarget);
 
+				target = spellTarget.getTarget();
+				power = spellTarget.getPower();
+
 				if (!spellTarget.isCancelled()) {
-					if (passTargeting) success = passTargetingEntity(caster, target, spellCast.getPower());
-					else success = ((TargetedEntitySpell) spell).castAtEntity(caster, target, spellCast.getPower());
+					if (passTargeting) success = passTargetingEntity(caster, target, power);
+					else success = ((TargetedEntitySpell) spell).castAtEntity(caster, target, power);
 				}
 
 				if (success) {
@@ -191,16 +194,21 @@ public class Subspell {
 
 		if (mode == CastMode.PARTIAL) {
 			SpellCastEvent event = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power * subPower, null, 0, null, 0);
-			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, power);
-			EventUtil.call(spellTarget);
 			EventUtil.call(event);
+
+			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, event.getPower());
+			EventUtil.call(spellTarget);
+
+			target = spellTarget.getTarget();
+			power = spellTarget.getPower();
+
 			if (!spellTarget.isCancelled() && !event.isCancelled() && event.getSpellCastState() == SpellCastState.NORMAL) {
-				if (passTargeting) success = passTargetingEntity(caster, target, event.getPower());
+				if (passTargeting) success = passTargetingEntity(caster, target, power);
 				else {
-					if (caster != null) success = ((TargetedEntitySpell) spell).castAtEntity(caster, target, event.getPower());
-					else success = ((TargetedEntitySpell) spell).castAtEntity(target, event.getPower());
+					if (caster != null) success = ((TargetedEntitySpell) spell).castAtEntity(caster, target, power);
+					else success = ((TargetedEntitySpell) spell).castAtEntity(target, power);
 				}
-				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, event.getPower(), null, 0, null, PostCastAction.HANDLE_NORMALLY));
+				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, power, null, 0, null, PostCastAction.HANDLE_NORMALLY));
 			}
 		} else {
 			if (passTargeting) success = passTargetingEntity(caster, target, power * subPower);
@@ -248,11 +256,11 @@ public class Subspell {
 			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, target, power);
+				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, target, spellCast.getPower());
 				EventUtil.call(spellLocation);
 
 				if (!spellLocation.isCancelled())
-					success = ((TargetedLocationSpell) spell).castAtLocation(caster, target, spellCast.getPower());
+					success = ((TargetedLocationSpell) spell).castAtLocation(caster, spellLocation.getTargetLocation(), spellLocation.getPower());
 
 				if (!success) action = PostCastAction.ALREADY_HANDLED;
 			}
@@ -266,13 +274,18 @@ public class Subspell {
 
 		if (mode == CastMode.PARTIAL) {
 			SpellCastEvent event = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power * subPower, null, 0, null, 0);
-			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, target, power);
-			EventUtil.call(spellLocation);
 			EventUtil.call(event);
+
+			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, target, event.getPower());
+			EventUtil.call(spellLocation);
+
+			target = spellLocation.getTargetLocation();
+			power = spellLocation.getPower();
+
 			if (!spellLocation.isCancelled() && !event.isCancelled() && event.getSpellCastState() == SpellCastState.NORMAL) {
-				if (caster != null) success = ((TargetedLocationSpell) spell).castAtLocation(caster, target, event.getPower());
-				else success = ((TargetedLocationSpell) spell).castAtLocation(target, event.getPower());
-				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, event.getPower(), null, 0, null, PostCastAction.HANDLE_NORMALLY));
+				if (caster != null) success = ((TargetedLocationSpell) spell).castAtLocation(caster, target, power);
+				else success = ((TargetedLocationSpell) spell).castAtLocation(target, power);
+				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, power, null, 0, null, PostCastAction.HANDLE_NORMALLY));
 			}
 		} else {
 			if (caster != null) success = ((TargetedLocationSpell) spell).castAtLocation(caster, target, power * subPower);
@@ -307,14 +320,19 @@ public class Subspell {
 			PostCastAction action = PostCastAction.HANDLE_NORMALLY;
 			boolean success = false;
 			if (spellCast.getSpellCastState() == SpellCastState.NORMAL) {
-				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, power);
-				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, from, power);
-				EventUtil.call(spellLocation);
+				SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, spellCast.getPower());
 				EventUtil.call(spellTarget);
 
+				SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, from, spellTarget.getPower());
+				EventUtil.call(spellLocation);
+
+				target = spellTarget.getTarget();
+				power = spellLocation.getPower();
+				from = spellLocation.getTargetLocation();
+
 				if (!spellLocation.isCancelled() && !spellTarget.isCancelled()) {
-					if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, spellCast.getPower());
-					else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, spellCast.getPower());
+					if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, power);
+					else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, power);
 				}
 				if (success) {
 					if (spell instanceof TargetedSpell targetedSpell) {
@@ -333,18 +351,25 @@ public class Subspell {
 
 		if (mode == CastMode.PARTIAL) {
 			SpellCastEvent event = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power * subPower, null, 0, null, 0);
-			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, power);
-			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, from, power);
-			EventUtil.call(spellLocation);
-			EventUtil.call(spellTarget);
 			EventUtil.call(event);
+
+			SpellTargetEvent spellTarget = new SpellTargetEvent(spell, caster, target, event.getPower());
+			EventUtil.call(spellTarget);
+
+			SpellTargetLocationEvent spellLocation = new SpellTargetLocationEvent(spell, caster, from, spellTarget.getPower());
+			EventUtil.call(spellLocation);
+
+			target = spellTarget.getTarget();
+			power = spellLocation.getPower();
+			from = spellLocation.getTargetLocation();
+
 			if (!spellLocation.isCancelled() && !spellTarget.isCancelled() && !event.isCancelled() && event.getSpellCastState() == SpellCastState.NORMAL) {
-				if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, event.getPower());
+				if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, power);
 				else {
-					if (caster != null) success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, event.getPower());
-					else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(from, target, event.getPower());
+					if (caster != null) success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, power);
+					else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(from, target, power);
 				}
-				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, event.getPower(), null, 0, null, PostCastAction.HANDLE_NORMALLY));
+				if (success) EventUtil.call(new SpellCastedEvent(spell, caster, SpellCastState.NORMAL, power, null, 0, null, PostCastAction.HANDLE_NORMALLY));
 			}
 		} else {
 			if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, power * subPower);


### PR DESCRIPTION
Passes the power along from the `SpellCastEvent` to the `SpellTargetEvent` and `SpellLocationEvent`, and uses the power and targets from the respective events.