### PR TITLE
Add `error-log-limit` option, revert to previous minimessage version, extend MinionSpell to Mob instead of Creature, fix issue with /ms resetcd

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -10,7 +10,7 @@ dependencies {
     shadow(group: "org.apache.commons", name: "commons-math3", version: "3.6.1")
     shadow(group: "com.github.elBukkit", name: "EffectLib", version: "master-SNAPSHOT")
     shadow(group: "co.aikar", name: "acf-paper", version: "0.5.0-SNAPSHOT")
-    shadow(group: "net.kyori", name: "adventure-text-minimessage", version: "4.10.0-SNAPSHOT")
+    shadow(group: "net.kyori", name: "adventure-text-minimessage", version: "4.2.0-SNAPSHOT")
     shadow(group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8", version: "1.6.10")
 
     implementation(group: "com.comphenix.protocol", name: "ProtocolLib", version: "4.7.0") { transitive = false }

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1642,9 +1642,9 @@ public class MagicSpells extends JavaPlugin {
 			ex.printStackTrace();
 		}
 
+		// Delete old errors if the folder exceeds the limit.
 		int limit = getErrorLogLimit();
 		if (limit > 0) {
-			// Delete old errors if the folder exceeds the limit.
 			try (Stream<Path> errorPaths = Files.list(folder.toPath())) {
 				errorPaths
 					.map(Path::toFile)

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -4,6 +4,7 @@ import java.io.*;
 
 import java.util.*;
 import java.util.logging.Level;
+import java.util.stream.Stream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -14,6 +15,9 @@ import java.lang.annotation.Annotation;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.MalformedURLException;
+
+import java.nio.file.Path;
+import java.nio.file.Files;
 
 import de.slikey.effectlib.EffectManager;
 
@@ -175,6 +179,7 @@ public class MagicSpells extends JavaPlugin {
 	private int debugLevel;
 	private int spellIconSlot;
 	private int globalRadius;
+	private int errorLogLimit;
 	private int globalCooldown;
 	private int broadcastRange;
 	private int effectlibInstanceLimit;
@@ -262,6 +267,7 @@ public class MagicSpells extends JavaPlugin {
 		terminateEffectlibInstances = config.getBoolean(path + "terminate-effectlib-instances", true);
 
 		enableErrorLogging = config.getBoolean(path + "enable-error-logging", true);
+		errorLogLimit = config.getInt(path + "error-log-limit", -1);
 		enableProfiling = config.getBoolean(path + "enable-profiling", false);
 		textColor = ChatColor.getByChar(config.getString(path + "text-color", ChatColor.DARK_AQUA.getChar() + ""));
 		broadcastRange = config.getInt(path + "broadcast-range", 20);
@@ -1077,6 +1083,10 @@ public class MagicSpells extends JavaPlugin {
 		return plugin.debugLevelOriginal;
 	}
 
+	public static int getErrorLogLimit() {
+		return plugin.errorLogLimit;
+	}
+
 	public static void setDebug(boolean debug) {
 		plugin.debug = debug;
 	}
@@ -1603,27 +1613,17 @@ public class MagicSpells extends JavaPlugin {
 		Bukkit.getScheduler().cancelTask(taskId);
 	}
 
-	public static void handleException(Exception ex) {
+	public static void handleException(@NotNull Exception ex) {
 		if (!plugin.enableErrorLogging) {
 			ex.printStackTrace();
 			return;
 		}
 
+		File folder = new File(plugin.getDataFolder(), "errors");
+		if (!folder.exists()) folder.mkdir();
+
 		plugin.getLogger().severe("AN EXCEPTION HAS OCCURED:");
-		PrintWriter writer = null;
-		try {
-			File folder = new File(plugin.getDataFolder(), "errors");
-			if (!folder.exists()) folder.mkdir();
-
-			// Delete old errors if the folder is too many.
-			File[] oldErrors = folder.listFiles();
-			if (oldErrors != null && oldErrors.length >= 50) {
-				for (File file : oldErrors) {
-					file.delete();
-				}
-			}
-
-			writer = new PrintWriter(new File(folder, System.currentTimeMillis() + ".txt"));
+		try (PrintWriter writer = new PrintWriter(new File(folder, System.currentTimeMillis() + ".txt"));) {
 			Throwable t = ex;
 			while (t != null) {
 				plugin.getLogger().severe("    " + t.getMessage() + " (" + t.getClass().getName() + ')');
@@ -1631,16 +1631,30 @@ public class MagicSpells extends JavaPlugin {
 				writer.println();
 				t = t.getCause();
 			}
-			plugin.getLogger().severe("This error has been saved in the errors folder");
+
+			plugin.getLogger().severe("This error has been saved in the errors folder.");
 			writer.println("Server version: " + Bukkit.getServer().getVersion());
 			writer.println("MagicSpells version: " + plugin.getDescription().getVersion());
 			writer.println("Error log date: " + new Date());
-		} catch (Exception x) {
-			plugin.getLogger().severe("ERROR HANDLING EXCEPTION");
-			x.printStackTrace();
+		} catch (Exception e) {
+			plugin.getLogger().severe("ERROR WHILE HANDLING EXCEPTION:");
+			e.printStackTrace();
 			ex.printStackTrace();
-		} finally {
-			if (writer != null) writer.close();
+		}
+
+		int limit = getErrorLogLimit();
+		if (limit > 0) {
+			// Delete old errors if the folder exceeds the limit.
+			try (Stream<Path> errorPaths = Files.list(folder.toPath())) {
+				errorPaths
+					.map(Path::toFile)
+					.sorted(Comparator.comparing(File::lastModified, Comparator.reverseOrder()))
+					.skip(limit)
+					.forEach(File::delete);
+			} catch (Exception e) {
+				plugin.getLogger().severe("Error while cleaning up error folder:");
+				e.printStackTrace();
+			}
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -318,7 +318,7 @@ public class MagicCommand extends BaseCommand {
 		else spells.add(spell);
 		for (Spell s : spells) {
 			if (player == null) s.getCooldowns().clear();
-			else s.setCooldown(player, 0);
+			else s.setCooldown(player, 0, false);
 		}
 		issuer.sendMessage(MagicSpells.getTextColor() + "Cooldowns reset" + (player == null ? "" : " for " + player.getName()) + (spell == null ? "" : " for spell " + Util.colorize(spell.getName())) + ".");
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -260,15 +260,15 @@ public class MinionSpell extends BuffSpell {
 
 		// Spawn creature
 		LivingEntity minion = (LivingEntity) player.getWorld().spawnEntity(loc, creatureType);
-		if (!(minion instanceof Creature)) {
+		if (!(minion instanceof Mob)) {
 			minion.remove();
-			MagicSpells.error("MinionSpell '" + internalName + "' Can only summon creatures!");
+			MagicSpells.error("MinionSpell '" + internalName + "' can only summon mobs!");
 			return false;
 		}
 
-		if (minion instanceof Ageable) {
-			if (baby) ((Ageable) minion).setBaby();
-			else ((Ageable) minion).setAdult();
+		if (minion instanceof Ageable ageable) {
+			if (baby) ageable.setBaby();
+			else ageable.setAdult();
 		}
 
 		minion.setGravity(gravity);
@@ -512,7 +512,7 @@ public class MinionSpell extends BuffSpell {
 
 				Location loc = pl.getLocation().clone();
 				loc.add(loc.getDirection().setY(0).normalize().multiply(followRange));
-				((Creature) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
+				((Mob) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
 			}
 		}
 	}
@@ -568,7 +568,7 @@ public class MinionSpell extends BuffSpell {
 			// The distance between minion and his owner is greater that the defined max distance or the minion has no targets, he will follow his owner
 			Location loc = pl.getLocation().clone();
 			loc.add(loc.getDirection().setY(0).normalize().multiply(followRange));
-			((Creature) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
+			((Mob) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
@@ -4,7 +4,7 @@ import java.util.Map;
 import java.util.HashMap;
 
 import org.bukkit.Material;
-import org.bukkit.entity.Creature;
+import org.bukkit.entity.Mob;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
@@ -45,8 +45,7 @@ public class MobUtil {
 	}
 
 	public static void setTarget(LivingEntity mob, LivingEntity target) {
-		if (!(mob instanceof Creature creature)) return;
-		creature.setTarget(target);
+		if (mob instanceof Mob m) m.setTarget(target);
 	}
 
 	public static EntityType getPigZombieEntityType() {

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -6,6 +6,7 @@ tab-complete-internal-names: false
 terminate-effectlib-instances: true
 enable-error-logging: true
 enable-profiling: false
+error-log-limit: -1
 text-color: 3
 broadcast-range: 20
 effectlib-instance-limit: 20000


### PR DESCRIPTION
- Added `error-log-limit` option. Defaults to -1. When greater than 0, deletes old errors to ensure the `errors` folder has at most `error-log-limit` number of files.
- Reverted minimessage version to `4.2.0` due to incompatibilities with current paper versions.
- `MinionSpell` now requires the entity type to be a `Mob` instead of a `Creature`.