### PR TITLE
Update to 1.18.2

### DIFF
--- a/core/build.gradle
+++ b/core/build.gradle
@@ -1,16 +1,15 @@
 plugins {
     id("java-library")
     id("org.jetbrains.kotlin.jvm") version "1.6.0"
-    id("io.papermc.paperweight.userdev") version "1.3.4"
+    id("io.papermc.paperweight.userdev") version "1.3.5"
 }
 
 dependencies {
-    paperweightDevelopmentBundle(group: "io.papermc.paper", name: "dev-bundle", version: "1.18.1-R0.1-SNAPSHOT")
+    paperweightDevelopmentBundle(group: "io.papermc.paper", name: "dev-bundle", version: "1.18.2-R0.1-SNAPSHOT")
 
     shadow(group: "org.apache.commons", name: "commons-math3", version: "3.6.1")
     shadow(group: "com.github.elBukkit", name: "EffectLib", version: "master-SNAPSHOT")
     shadow(group: "co.aikar", name: "acf-paper", version: "0.5.0-SNAPSHOT")
-    shadow(group: "net.kyori", name: "adventure-text-minimessage", version: "4.2.0-SNAPSHOT")
     shadow(group: "org.jetbrains.kotlin", name: "kotlin-stdlib-jdk8", version: "1.6.10")
 
     implementation(group: "com.comphenix.protocol", name: "ProtocolLib", version: "4.7.0") { transitive = false }
@@ -41,7 +40,6 @@ dependencies {
 
 shadowJar {
     setArchivesBaseName("MagicSpells")
-    relocate("net.kyori.adventure.text.minimessage", "com.nisovin.magicspells.shaded.minimessage")
     relocate("org.apache.commons.math3", "com.nisovin.magicspells.shaded.org.apache.commons")
     relocate("de.slikey.effectlib", "com.nisovin.magicspells.shaded.effectlib")
     relocate("ru.xezard.glow", "com.nisovin.magicspells.shaded.xglow")

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RiptideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RiptideSpell.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spells.targeted;
 
+import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -23,26 +24,38 @@ public class RiptideSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state != SpellCastState.NORMAL) return PostCastAction.HANDLE_NORMALLY;
 
-		TargetInfo<LivingEntity> target = getTargetedEntity(caster, power);
-		if (target == null) return noTarget(caster);
-		playSpellEffects(caster, target.getTarget());
+		TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power);
+		if (targetInfo == null) return noTarget(caster);
 
-		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target.getTarget(), duration);
+		Player target = targetInfo.getTarget();
+		if (target == null) return noTarget(caster);
+
+		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target, duration);
+		playSpellEffects(caster, target);
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target, duration);
-		playSpellEffects(caster, target);
-		return true;
+		if (target instanceof Player player) {
+			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration);
+			playSpellEffects(caster, target);
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target, duration);
-		playSpellEffects(EffectPosition.TARGET, target);
-		return true;
+		if (target instanceof Player player) {
+			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration);
+			playSpellEffects(EffectPosition.TARGET, target);
+			return true;
+		}
+
+		return false;
 	}
 
 	public int getDuration() {

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeDisabled.java
@@ -47,7 +47,7 @@ public class VolatileCodeDisabled implements VolatileCodeHandle {
 	}
 
 	@Override
-	public void startAutoSpinAttack(LivingEntity entity, int ticks) {
+	public void startAutoSpinAttack(Player player, int ticks) {
 
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -21,6 +21,6 @@ public interface VolatileCodeHandle {
 
 	void setInventoryTitle(Player player, String title);
 
-	void startAutoSpinAttack(LivingEntity entity, int ticks);
+	void startAutoSpinAttack(Player player, int ticks);
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_18_R2/VolatileCode1_18_R2.kt
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/v1_18_R2/VolatileCode1_18_R2.kt
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.volatilecode.v1_18_R1
+package com.nisovin.magicspells.volatilecode.v1_18_R2
 
 import org.bukkit.Bukkit
 import org.bukkit.entity.*
@@ -7,10 +7,10 @@ import org.bukkit.util.Vector
 import org.bukkit.inventory.ItemStack
 import org.bukkit.event.entity.ExplosionPrimeEvent
 
-import org.bukkit.craftbukkit.v1_18_R1.entity.*
-import org.bukkit.craftbukkit.v1_18_R1.CraftWorld
-import org.bukkit.craftbukkit.v1_18_R1.CraftServer
-import org.bukkit.craftbukkit.v1_18_R1.inventory.CraftItemStack
+import org.bukkit.craftbukkit.v1_18_R2.entity.*
+import org.bukkit.craftbukkit.v1_18_R2.CraftWorld
+import org.bukkit.craftbukkit.v1_18_R2.CraftServer
+import org.bukkit.craftbukkit.v1_18_R2.inventory.CraftItemStack
 
 import net.minecraft.world.phys.Vec3
 import net.minecraft.world.entity.EntityType
@@ -28,7 +28,7 @@ import com.nisovin.magicspells.volatilecode.VolatileCodeHandle
 
 private typealias nmsItemStack = net.minecraft.world.item.ItemStack
 
-class VolatileCode1_18_R1: VolatileCodeHandle {
+class VolatileCode1_18_R2: VolatileCodeHandle {
 
     private var entityLivingPotionEffectColor: EntityDataAccessor<Int>? = null
 
@@ -124,9 +124,9 @@ class VolatileCode1_18_R1: VolatileCodeHandle {
         player.updateInventory()
     }
 
-    override fun startAutoSpinAttack(entity: LivingEntity?, ticks: Int) {
-        val livingEntity = (entity as CraftLivingEntity).handle
-        livingEntity.startAutoSpinAttack(ticks)
+    override fun startAutoSpinAttack(player: Player?, ticks: Int) {
+        val entityPlayer = (player as CraftPlayer).handle
+        entityPlayer.startAutoSpinAttack(ticks)
     }
 
 }


### PR DESCRIPTION
- Old legacy color code support no longer functions with new MiniMessage deserializer. Instead, old color codes are converted into MiniMessage format, and then serialized.
- Updated volatile code handler. `net.minecraft.world.entity.LivingEntity#startAutoSpinAttack(int)` was relocated to `net.minecraft.world.entity.player.Player#startAutoSpinAttack(int)`, so `VolatileCodeHandle#startAutoSpinAttack(LivingEntity, int)` was updated to `VolatileCodeHandle#startAutoSpinAttack(Player, int)` accordingly.