### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -126,8 +126,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 			if (loc == null) return noTarget(caster);
 			
 			boolean done = doAoe(caster, loc, power);
-			
-			if (!done && failIfNoTargets) return noTarget(caster);
+			if (!done) return noTarget(caster);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
@@ -225,12 +224,13 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 			if (maxTargets > 0 && count >= maxTargets) break;
 		}
 
-		if (count > 0 || !failIfNoTargets) {
+		boolean success = count > 0 || !failIfNoTargets;
+		if (success) {
 			playSpellEffects(EffectPosition.SPECIAL, location);
 			if (caster != null) playSpellEffects(EffectPosition.CASTER, caster);
 		}
-		
-		return count > 0;
+
+		return success;
 	}
 
 	private void castSpells(LivingEntity caster, Location location, LivingEntity target, float power) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -303,7 +303,10 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 	private void initLoop(LivingEntity caster, LivingEntity targetEntity, Location targetLocation, float power, String[] args) {
 		Loop loop = new Loop(caster, targetEntity, targetLocation, power, args);
+
 		if (targetEntity != null) activeLoops.put(targetEntity.getUniqueId(), loop);
+		else if (caster != null) activeLoops.put(caster.getUniqueId(), loop);
+		else activeLoops.put(null, loop);
 	}
 
 	public class Loop implements Runnable {
@@ -448,10 +451,10 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private void cancel(boolean remove) {
 			MagicSpells.cancelTask(taskId);
 
-			if (targetEntity != null) {
-				if (remove) activeLoops.remove(targetEntity.getUniqueId(), this);
-				playSpellEffects(EffectPosition.DELAYED, targetEntity);
-			} else if (targetLocation != null) playSpellEffects(EffectPosition.DELAYED, targetLocation);
+			if (remove) activeLoops.remove(targetEntity == null ? null : targetEntity.getUniqueId(), this);
+
+			if (targetEntity != null) playSpellEffects(EffectPosition.DELAYED, targetEntity);
+			else if (targetLocation != null) playSpellEffects(EffectPosition.DELAYED, targetLocation);
 			else if (caster != null) playSpellEffects(EffectPosition.DELAYED, caster);
 
 			if (caster != null || targetEntity != null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -451,7 +451,13 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private void cancel(boolean remove) {
 			MagicSpells.cancelTask(taskId);
 
-			if (remove) activeLoops.remove(targetEntity == null ? null : targetEntity.getUniqueId(), this);
+			if (remove) {
+				UUID key = null;
+				if (targetEntity != null) key = targetEntity.getUniqueId();
+				else if (caster != null) key = caster.getUniqueId();
+
+				activeLoops.remove(key, this);
+			}
 
 			if (targetEntity != null) playSpellEffects(EffectPosition.DELAYED, targetEntity);
 			else if (targetLocation != null) playSpellEffects(EffectPosition.DELAYED, targetLocation);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -32,6 +32,7 @@ import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.util.managers.VariableManager;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
@@ -236,6 +237,12 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 					if (block != null) {
 						locationTarget = block.getLocation();
 						locationTarget.add(0.5, yOffset + 0.5, 0.5);
+
+						SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, locationTarget, power);
+						if (!event.callEvent()) return noTarget(caster);
+
+						locationTarget = event.getTargetLocation();
+						power = event.getPower();
 					}
 				}
 


### PR DESCRIPTION
- `AreaEffectSpell` no longer fails when casted as a subspell if `fail-if-no-targets: false`.
- Fixed an issue where `LoopSpell` loops were not properly stopped on reload if they did not have an entity target.
- `LoopSpell` loops now count the caster as having the loop active for the `loopactive` and `ownedloopactive` conditions if the loop does not have an entity target.
- `LoopSpell` now calls `SpellTargetLocationEvent` when first targeting a location, allowing usage of `location-modifiers`.