### PR TITLE
Return false if buff cannot be cast on a non-player entity

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
@@ -116,6 +116,8 @@ public class ArmorSpell extends BuffSpell {
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
 		EntityEquipment inv = entity.getEquipment();
+		if (inv == null) return false;
+
 		if (!replace && ((helmet != null && inv.getHelmet() != null) || (chestplate != null && inv.getChestplate() != null) || (leggings != null && inv.getLeggings() != null) || (boots != null && inv.getBoots() != null))) {
 			// error
 			if (entity instanceof Player) sendMessage(strHasArmor, entity, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
@@ -53,7 +53,7 @@ public class HasteSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.put(entity.getUniqueId(), new HasteData(FastMath.round(strength * power)));
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvisibilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvisibilitySpell.java
@@ -47,7 +47,7 @@ public class InvisibilitySpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player player)) return true;
+		if (!(entity instanceof Player player)) return false;
 		makeInvisible(player);
 		entities.add(entity.getUniqueId());
 		return true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/LightwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/LightwalkSpell.java
@@ -58,7 +58,7 @@ public class LightwalkSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.put(entity.getUniqueId(), getBlockToChange(entity));
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ManaRegenSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ManaRegenSpell.java
@@ -30,7 +30,7 @@ public class ManaRegenSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.add(entity.getUniqueId());
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -234,7 +234,7 @@ public class MinionSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player player)) return true;
+		if (!(entity instanceof Player player)) return false;
 		// Selecting the mob
 		EntityType creatureType = null;
 		int num = random.nextInt(100);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
@@ -69,7 +69,7 @@ public class ReachSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.add(entity.getUniqueId());
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
@@ -44,7 +44,7 @@ public class SeeHealthSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.add(entity.getUniqueId());
 		updater = new Updater();
 		return true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/StonevisionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/StonevisionSpell.java
@@ -69,7 +69,7 @@ public class StonevisionSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		players.put(entity.getUniqueId(), new TransparentBlockSet((Player) entity, radius, transparentTypes));
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
@@ -36,7 +36,7 @@ public class WaterwalkSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 		entities.add(entity.getUniqueId());
 		startTicker();
 		return true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
@@ -55,7 +55,7 @@ public class WindwalkSpell extends BuffSpell {
 
 	@Override
 	public boolean castBuff(LivingEntity entity, float power, String[] args) {
-		if (!(entity instanceof Player)) return true;
+		if (!(entity instanceof Player)) return false;
 
 		if (launchSpeed > 0) {
 			entity.teleport(entity.getLocation().add(0, 0.25, 0));


### PR DESCRIPTION
- Return false instead of true when a buff cannot be cast on a non-player entity.
- Check if an entity's equipment is null before attempting to cast `ArmorSpell`.