### PR TITLE
Add new options to BowSpell and Magic Items

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -29,9 +29,9 @@ import com.nisovin.magicspells.util.TxtUtil;
 
 public class MagicItemData {
 
-    private EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
-    private EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
-    private EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+    private final EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
+    private final EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+    private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
 
     public Object getAttribute(MagicItemAttribute attr) {
         return itemAttributes.get(attr);
@@ -56,16 +56,8 @@ public class MagicItemData {
         return blacklistedAttributes;
     }
 
-    public void setBlacklistedAttributes(EnumSet<MagicItemAttribute> blacklistedAttributes) {
-        this.blacklistedAttributes = blacklistedAttributes;
-    }
-
     public EnumSet<MagicItemAttribute> getIgnoredAttributes() {
         return ignoredAttributes;
-    }
-
-    public void setIgnoredAttributes(EnumSet<MagicItemAttribute> ignoredAttributes) {
-        this.ignoredAttributes = ignoredAttributes;
     }
 
     private boolean hasEqualAttributes(MagicItemData other) {

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -33,6 +33,9 @@ public class MagicItemData {
     private final EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
     private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
 
+    private boolean strictEnchantLevel = true;
+    private boolean strictEnchants = true;
+
     public Object getAttribute(MagicItemAttribute attr) {
         return itemAttributes.get(attr);
     }
@@ -58,6 +61,22 @@ public class MagicItemData {
 
     public EnumSet<MagicItemAttribute> getIgnoredAttributes() {
         return ignoredAttributes;
+    }
+
+    public boolean isStrictEnchantLevel() {
+        return strictEnchantLevel;
+    }
+
+    public void setStrictEnchantLevel(boolean strictEnchantLevel) {
+        this.strictEnchantLevel = strictEnchantLevel;
+    }
+
+    public boolean isStrictEnchants() {
+        return strictEnchants;
+    }
+
+    public void setStrictEnchants(boolean strictEnchants) {
+        this.strictEnchants = strictEnchants;
     }
 
     private boolean hasEqualAttributes(MagicItemData other) {
@@ -121,9 +140,37 @@ public class MagicItemData {
         for (MagicItemAttribute attr : keysSelf) {
             if (ignoredAttributes.contains(attr)) continue;
 
-            if (attr == MagicItemAttribute.ATTRIBUTES) {
-                if (!hasEqualAttributes(data)) return false;
-            } else if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
+            switch (attr) {
+                case ATTRIBUTES -> {
+                    if (!hasEqualAttributes(data)) return false;
+                }
+                case ENCHANTS -> {
+                    if (strictEnchants && strictEnchantLevel) {
+                        if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
+                            return false;
+
+                        continue;
+                    }
+
+                    Map<Enchantment, Integer> enchantsSelf = (Map<Enchantment, Integer>) itemAttributes.get(attr);
+                    Map<Enchantment, Integer> enchantsOther = (Map<Enchantment, Integer>) data.itemAttributes.get(attr);
+
+                    if (strictEnchants && enchantsSelf.size() != enchantsOther.size()) return false;
+
+                    for (Enchantment enchant : enchantsSelf.keySet()) {
+                        if (!enchantsOther.containsKey(enchant)) return false;
+
+                        Integer levelSelf = enchantsSelf.get(enchant);
+                        Integer levelOther = enchantsOther.get(enchant);
+
+                        int compare = levelSelf.compareTo(levelOther);
+                        if ((strictEnchantLevel && compare != 0) || (!strictEnchantLevel && compare > 0)) return false;
+                    }
+                }
+                default -> {
+                    if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
+                }
+            }
         }
 
         return true;
@@ -697,6 +744,22 @@ public class MagicItemData {
             }
 
             output.append(']');
+            previous = true;
+        }
+
+        if (!strictEnchants) {
+            if (previous) output.append(",");
+            else output.append('{');
+
+            output.append("\"strict-enchants\": false");
+            previous = true;
+        }
+
+        if (!strictEnchantLevel) {
+            if (previous) output.append(",");
+            else output.append('{');
+
+            output.append("\"strict-enchant-level\": false");
             previous = true;
         }
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -427,6 +427,16 @@ public class MagicItemDataParser {
 								}
 							}
 							break;
+						case "strictenchants":
+						case "strict-enchants":
+						case "strict_enchants":
+							data.setStrictEnchants(value.getAsBoolean());
+							break;
+						case "strictenchantlevel":
+						case "strict-enchant-level":
+						case "strict_enchant_level":
+							data.setStrictEnchantLevel(value.getAsBoolean());
+							break;
 					}
 				}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -322,6 +322,12 @@ public class MagicItems {
 					}
 				}
 
+				if (section.isBoolean("strict-enchants"))
+					magicItem.getMagicItemData().setStrictEnchants(section.getBoolean("strict-enchants"));
+
+				if (section.isBoolean("strict-enchant-level"))
+					magicItem.getMagicItemData().setStrictEnchantLevel(section.getBoolean("strict-enchant-level"));
+
 				return magicItem;
 			}
 
@@ -514,6 +520,12 @@ public class MagicItems {
 					}
 				}
 			}
+
+			if (section.isBoolean("strict-enchants"))
+				itemData.setStrictEnchants(section.getBoolean("strict-enchants"));
+
+			if (section.isBoolean("strict-enchant-level"))
+				itemData.setStrictEnchantLevel(section.getBoolean("strict-enchant-level"));
 
 			return new MagicItem(item, itemData);
 		} catch (Exception e) {


### PR DESCRIPTION
- Added `bow-items`, `ammo-items`, `disallowed-bow-items` and `disallowed-ammo-items` options to `BowSpell`. `bow-items` and `ammo-items` are whitelist magic item filters for the bow and ammo used in a `BowSpell`, respectively. `disallowed-bow-items` and `disallowed-ammo-items` are correspondingly blacklist magic item filters.
- Added `strict-enchants` and `strict-enchant-level` options to magic items. Both options are `true` by default. When a magic item with `strict-enchants: false` is used to match an item, enchantments other than those specified on the magic item no longer cause the match to fail. With `strict-enchant-level: false`, items being matched require at least the level of enchantments specified on the magic item, rather than the exact level.