### PR TITLE
Move valid target list check in BuffSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -212,28 +212,29 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
+		if (!validTargetList.canTarget(caster, target)) return false;
 		return activate(caster, target, power, args, true) == PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		if (!validTargetList.canTarget(caster, target)) return false;
 		return activate(caster, target, power, MagicSpells.NULL_ARGS, true) == PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
+		if (!validTargetList.canTarget(target)) return false;
 		return activate(null, target, power, args, true) == PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
+		if (!validTargetList.canTarget(target)) return false;
 		return activate(null, target, power, MagicSpells.NULL_ARGS, true) == PostCastAction.HANDLE_NORMALLY;
 	}
 
 	private PostCastAction activate(LivingEntity caster, LivingEntity target, float power, String[] args, boolean normal) {
-		if (caster == null ? !validTargetList.canTarget(target) : !validTargetList.canTarget(caster, target))
-			return PostCastAction.ALREADY_HANDLED;
-
 		if (isActive(target) && toggle) {
 			turnOff(target);
 			return PostCastAction.ALREADY_HANDLED;


### PR DESCRIPTION
- Fixes issue with checking target list when `targeted: false`.