### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
@@ -27,6 +27,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 	private ConfigData<Double> yOffset;
 	private ConfigData<Double> maxYForce;
 
+	private boolean addYForceInstead;
 	private boolean callTargetEvents;
 	private boolean powerAffectsForce;
 	private boolean addVelocityInstead;
@@ -40,6 +41,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 		yOffset = getConfigDataDouble("y-offset", 0F);
 		maxYForce = getConfigDataDouble("max-vertical-force", 20);
 
+		addYForceInstead = getConfigBoolean("add-y-force-instead", false);
 		callTargetEvents = getConfigBoolean("call-target-events", true);
 		powerAffectsForce = getConfigBoolean("power-affects-force", true);
 		addVelocityInstead = getConfigBoolean("add-velocity-instead", false);
@@ -104,7 +106,6 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 
 			bomb(caster, caster, location, basePower, args);
 
-			playSpellEffects(EffectPosition.TARGET, caster, data);
 			playSpellEffects(EffectPosition.CASTER, caster, data);
 			playSpellEffects(EffectPosition.SPECIAL, location, data);
 			return;
@@ -144,7 +145,10 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 		double yForce = this.yForce.get(caster, target, power, args) / 10;
 		if (powerAffectsForce) yForce *= power;
 
-		v.setY(Math.min(v.getY() + yForce, maxYForce.get(caster, target, power, args) / 10));
+		double maxYForce = this.maxYForce.get(caster, target, power, args) / 10;
+		if (addYForceInstead) v.setY(Math.min(v.getY() + yForce, maxYForce));
+		else v.setY(Math.min(force == 0 ? yForce : v.getY() * yForce, maxYForce));
+
 		v = Util.makeFinite(v);
 
 		if (addVelocityInstead) target.setVelocity(target.getVelocity().add(v));

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -406,19 +406,20 @@ public class ConfigDataUtil {
 		if (value == null) return (caster, target, power, args) -> def;
 
 		try {
-			BlockData val = Bukkit.createBlockData(value);
+			BlockData val = Bukkit.createBlockData(value.trim().toLowerCase());
 			return (caster, target, power, args) -> val;
 		} catch (IllegalArgumentException e) {
 			ConfigData<String> supplier = getString(value);
 
 			return new ConfigData<>() {
+
 				@Override
 				public BlockData get(LivingEntity caster, LivingEntity target, float power, String[] args) {
 					String val = supplier.get(caster, target, power, args);
 					if (val == null) return def;
 
 					try {
-						return Bukkit.createBlockData(val);
+						return Bukkit.createBlockData(val.trim().toLowerCase());
 					} catch (IllegalArgumentException e) {
 						return def;
 					}


### PR DESCRIPTION
- Fixed an issue that prevented proper creation of block data when using `ConfigDataUtil#getBlockData`.
- Restored previous behavior of `ForcebombSpell`. The new behavior is instead available using the `add-y-force-instead` option.