### PR TITLE
Allow onblock for location modifiers, section format for PotionEffectSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -741,6 +741,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		return config.getDouble("spells." + internalName + '.' + key, defaultValue);
 	}
 
+	protected List<?> getConfigList(String key, List<?> defaultValue) {
+		return config.getList("spells." + internalName + "." + key, defaultValue);
+	}
+
 	protected List<Integer> getConfigIntList(String key, List<Integer> defaultValue) {
 		return config.getIntList("spells." + internalName + '.' + key, defaultValue);
 	}
@@ -755,6 +759,14 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	protected ConfigurationSection getConfigSection(String key) {
 		return config.getSection("spells." + internalName + '.' + key);
+	}
+
+	protected ConfigData<Boolean> getConfigDataBoolean(String key, boolean def) {
+		return ConfigDataUtil.getBoolean(config.getMainConfig(), "spells." + internalName + '.' + key, def);
+	}
+
+	protected ConfigData<Boolean> getConfigDataBoolean(String key, ConfigData<Boolean> def) {
+		return ConfigDataUtil.getBoolean(config.getMainConfig(), "spells." + internalName + '.' + key, def);
 	}
 
 	protected ConfigData<Integer> getConfigDataInt(String key, int def) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnBlockCondition.java
@@ -49,21 +49,21 @@ public class OnBlockCondition extends Condition {
 
 	@Override
 	public boolean check(LivingEntity livingEntity) {
-		return onBlock(livingEntity);
+		return onBlock(livingEntity.getLocation());
 	}
 
 	@Override
 	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		return onBlock(target);
+		return onBlock(target.getLocation());
 	}
 
 	@Override
 	public boolean check(LivingEntity livingEntity, Location location) {
-		return false;
+		return onBlock(location.clone());
 	}
 
-	private boolean onBlock(LivingEntity entity) {
-		BlockData bd = entity.getLocation().subtract(0, 1, 0).getBlock().getBlockData();
+	private boolean onBlock(Location location) {
+		BlockData bd = location.subtract(0, 1, 0).getBlock().getBlockData();
 		if (blockData != null) return bd.matches(blockData);
 
 		for (BlockData data : blockDataSet)

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
@@ -1,11 +1,13 @@
 package com.nisovin.magicspells.spells.targeted;
 
+import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import com.nisovin.magicspells.util.Util;
@@ -13,42 +15,47 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.ConfigReaderUtil;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.events.SpellTargetEvent;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
 
 public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private List<PotionEffect> potionEffects;
-	private List<String> potionEffectStrings;
+	private List<ConfigData<PotionEffect>> potionEffects;
+	private List<?> potionEffectData;
 
-	private PotionEffectType type;
+	private ConfigData<PotionEffectType> type;
 
 	private ConfigData<Integer> duration;
 	private ConfigData<Integer> strength;
 
-	private boolean icon;
-	private boolean hidden;
-	private boolean ambient;
+	private ConfigData<Boolean> icon;
+	private ConfigData<Boolean> hidden;
+	private ConfigData<Boolean> ambient;
 
 	private boolean override;
+	private boolean targeted;
 	private boolean spellPowerAffectsDuration;
 	private boolean spellPowerAffectsStrength;
-	
+
 	public PotionEffectSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		potionEffectStrings = getConfigStringList("potion-effects", null);
+		potionEffectData = getConfigList("potion-effects", null);
 
-		type = Util.getPotionEffectType(getConfigString("type", "speed"));
+		type = ConfigDataUtil.getPotionEffectType(config.getMainConfig(), "spells." + internalName + ".type", PotionEffectType.SPEED);
 
 		duration = getConfigDataInt("duration", 0);
 		strength = getConfigDataInt("strength", 0);
 
-		icon = getConfigBoolean("icon", true);
-		hidden = getConfigBoolean("hidden", false);
-		ambient = getConfigBoolean("ambient", false);
+		icon = getConfigDataBoolean("icon", true);
+		hidden = getConfigDataBoolean("hidden", false);
+		ambient = getConfigDataBoolean("ambient", false);
+		targeted = getConfigBoolean("targeted", false);
 		override = getConfigBoolean("override", false);
 		spellPowerAffectsDuration = getConfigBoolean("spell-power-affects-duration", true);
 		spellPowerAffectsStrength = getConfigBoolean("spell-power-affects-strength", true);
@@ -58,76 +65,123 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 	public void initialize() {
 		super.initialize();
 
-		if (potionEffectStrings == null) return;
+		if (potionEffectData == null) return;
 
 		potionEffects = new ArrayList<>();
-		for (String potionEffectString : potionEffectStrings) {
-			String[] data = potionEffectString.split(" ");
-			if (data.length == 0) continue;
+		for (Object potionEffectObj : potionEffectData) {
+			if (potionEffectObj instanceof String potionEffectString) {
+				String[] data = potionEffectString.split(" ");
+				if (data.length == 0) continue;
 
-			PotionEffectType type = Util.getPotionEffectType(data[0]);
-			if (type == null) {
-				MagicSpells.error("Invalid potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
-				continue;
-			}
-
-			int duration = 0;
-			if (data.length >= 2) {
-				try {
-					duration = Integer.parseInt(data[1]);
-				} catch (NumberFormatException e) {
-					MagicSpells.error("Invalid duration '" + duration + "' in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
+				PotionEffectType type = Util.getPotionEffectType(data[0]);
+				if (type == null) {
+					MagicSpells.error("Invalid potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
 					continue;
 				}
-			}
 
-			int strength = 0;
-			if (data.length >= 3) {
-				try {
-					strength = Integer.parseInt(data[2]);
-				} catch (NumberFormatException e) {
-					MagicSpells.error("Invalid strength '" + strength + "' in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
-					continue;
+				int duration = 0;
+				if (data.length >= 2) {
+					try {
+						duration = Integer.parseInt(data[1]);
+					} catch (NumberFormatException e) {
+						MagicSpells.error("Invalid duration '" + duration + "' in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
+						continue;
+					}
 				}
+
+				int strength = 0;
+				if (data.length >= 3) {
+					try {
+						strength = Integer.parseInt(data[2]);
+					} catch (NumberFormatException e) {
+						MagicSpells.error("Invalid strength '" + strength + "' in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
+						continue;
+					}
+				}
+
+				boolean ambient = data.length >= 4 && Boolean.parseBoolean(data[4]);
+				boolean particles = data.length < 5 || !Boolean.parseBoolean(data[3]);
+				boolean icon = data.length < 6 || Boolean.parseBoolean(data[5]);
+
+				if (data.length > 6)
+					MagicSpells.error("Trailing data found in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
+
+				if (spellPowerAffectsDuration || spellPowerAffectsStrength) {
+					int finalDuration = duration;
+					int finalStrength = strength;
+
+					ConfigData<PotionEffect> effect;
+					if (!spellPowerAffectsStrength)
+						effect = (caster, target, power, args) -> new PotionEffect(type, Math.round(finalDuration * power), finalStrength, ambient, particles, icon);
+					else if (!spellPowerAffectsDuration)
+						effect = (caster, target, power, args) -> new PotionEffect(type, finalDuration, Math.round(finalStrength * power), ambient, particles, icon);
+					else
+						effect = (caster, target, power, args) -> new PotionEffect(type, Math.round(finalDuration * power), Math.round(finalStrength * power), ambient, particles, icon);
+
+					potionEffects.add(effect);
+				} else {
+					PotionEffect effect = new PotionEffect(type, duration, strength, ambient, particles, icon);
+					potionEffects.add((caster, target, power, args) -> effect);
+				}
+			} else if (potionEffectObj instanceof Map<?, ?> potionEffectMap) {
+				ConfigurationSection section = ConfigReaderUtil.mapToSection(potionEffectMap);
+
+				ConfigData<PotionEffectType> type = ConfigDataUtil.getPotionEffectType(section, "type", PotionEffectType.SPEED);
+				ConfigData<Integer> duration = ConfigDataUtil.getInteger(section, "duration", 0);
+				ConfigData<Integer> strength = ConfigDataUtil.getInteger(section, "strength", 0);
+				ConfigData<Boolean> ambient = ConfigDataUtil.getBoolean(section, "ambient", false);
+				ConfigData<Boolean> hidden = ConfigDataUtil.getBoolean(section, "hidden", false);
+				ConfigData<Boolean> icon = ConfigDataUtil.getBoolean(section, "icon", true);
+
+				ConfigData<PotionEffect> effect = (caster, target, power, args) -> {
+					int d = duration.get(caster, target, power, args);
+					if (spellPowerAffectsDuration) d = Math.round(d * power);
+
+					int s = strength.get(caster, target, power, args);
+					if (spellPowerAffectsStrength) s = Math.round(s * power);
+
+					return new PotionEffect(
+						type.get(caster, target, power, args),
+						d,
+						s,
+						ambient.get(caster, target, power, args),
+						!hidden.get(caster, target, power, args),
+						icon.get(caster, target, power, args)
+					);
+				};
+
+				potionEffects.add(effect);
 			}
-
-			boolean hidden = false;
-			if (data.length >= 4) hidden = Boolean.parseBoolean(data[3]);
-
-			boolean ambient = false;
-			if (data.length >= 5) ambient = Boolean.parseBoolean(data[4]);
-
-			boolean icon = true;
-			if (data.length >= 6) icon = Boolean.parseBoolean(data[5]);
-
-			if (data.length > 6)
-				MagicSpells.error("Trailing data found in potion effect string '" + potionEffectString + "' in PotionEffectSpell '" + internalName + "'.");
-
-			potionEffects.add(new PotionEffect(type, duration, strength, hidden, ambient, icon));
 		}
 
 		if (potionEffects.isEmpty()) potionEffects = null;
-		potionEffectStrings = null;
-	}
-
-	public PotionEffectType getPotionType() {
-		return type;
+		potionEffectData = null;
 	}
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
+			LivingEntity target;
+			if (targeted) {
+				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
+				if (targetInfo == null) return noTarget(caster);
 
-			LivingEntity target = targetInfo.getTarget();
+				target = targetInfo.getTarget();
+				power = targetInfo.getPower();
+			} else {
+				SpellTargetEvent targetEvent = new SpellTargetEvent(this, caster, caster, power, args);
+				if (!targetEvent.callEvent()) return noTarget(caster);
+
+				target = targetEvent.getTarget();
+				power = targetEvent.getPower();
+			}
 
 			handlePotionEffects(caster, target, power, args);
 			playSpellEffects(caster, target, power, args);
 			sendMessages(caster, target, args);
 
 			return PostCastAction.NO_MESSAGES;
-		}		
+		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
@@ -159,13 +213,19 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 
 	public void handlePotionEffects(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (potionEffects == null) {
+			PotionEffectType type = this.type.get(caster, target, power, args);
+
 			int duration = this.duration.get(caster, target, power, args);
 			if (spellPowerAffectsDuration) duration = Math.round(duration * power);
 
 			int strength = this.strength.get(caster, target, power, args);
 			if (spellPowerAffectsStrength) strength = Math.round(strength * power);
 
-			PotionEffect effect = new PotionEffect(type, duration, strength, ambient, !hidden, icon);
+			boolean ambient = this.ambient.get(caster, target, power, args);
+			boolean particles = !this.hidden.get(caster, target, power, args);
+			boolean icon = this.icon.get(caster, target, power, args);
+
+			PotionEffect effect = new PotionEffect(type, duration, strength, ambient, particles, icon);
 
 			callDamageEvent(caster, target, effect);
 
@@ -175,16 +235,8 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 			return;
 		}
 
-		for (PotionEffect effect : potionEffects) {
-			if (spellPowerAffectsDuration || spellPowerAffectsStrength) {
-				int duration = effect.getDuration();
-				if (spellPowerAffectsDuration) duration = Math.round(duration * power);
-
-				int strength = effect.getAmplifier();
-				if (spellPowerAffectsStrength) strength = Math.round(strength * power);
-
-				effect = new PotionEffect(effect.getType(), duration, strength, effect.isAmbient(), effect.hasParticles(), effect.hasIcon());
-			}
+		for (ConfigData<PotionEffect> effectData : potionEffects) {
+			PotionEffect effect = effectData.get(caster, target, power, args);
 
 			callDamageEvent(caster, target, effect);
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ConfigReaderUtil.java
@@ -1,9 +1,11 @@
 package com.nisovin.magicspells.util;
 
-import org.bukkit.util.Vector;
+import java.util.Map;
 
+import org.bukkit.util.Vector;
 import org.bukkit.conversations.Prompt;
 import org.bukkit.conversations.ConversationFactory;
+import org.bukkit.configuration.MemoryConfiguration;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -24,7 +26,7 @@ public class ConfigReaderUtil {
 	public static MagicLocation readLocation(ConfigurationSection section, String path) {
 		return readLocation(section, path, "world,0,0,0");
 	}
-	
+
 	public static MagicLocation readLocation(ConfigurationSection section, String path, String defaultText) {
 		String s = section.getString(path, defaultText);
 		MagicLocation ret;
@@ -44,11 +46,11 @@ public class ConfigReaderUtil {
 		}
 		return ret;
 	}
-	
+
 	public static Prompt readPrompt(ConfigurationSection section) {
 		return readPrompt(section, Prompt.END_OF_CONVERSATION);
 	}
-	
+
 	public static Prompt readPrompt(ConfigurationSection section, Prompt defaultPrompt) {
 		if (section == null) return defaultPrompt;
 		String type = section.getString("prompt-type");
@@ -56,7 +58,7 @@ public class ConfigReaderUtil {
 		if (promptType == null) return defaultPrompt;
 		return promptType.constructPrompt(section);
 	}
-	
+
 	// prefix accepts a string and defaults to null
 	// local-echo accepts a boolean and defaults to true
 	// first-prompt accepts a configuration section in prompt format
@@ -64,29 +66,35 @@ public class ConfigReaderUtil {
 	// escape-sequence accepts a string and defaults to null
 	public static ConversationFactory readConversationFactory(ConfigurationSection section) {
 		ConversationFactory ret = new ConversationFactory(MagicSpells.plugin);
-		
+
 		// Handle the prefix
 		String prefix = section.getString("prefix", null);
 		if (prefix != null && !prefix.isEmpty()) ret = ret.withPrefix(new MagicConversationPrefix(Util.colorize(prefix)));
-		
+
 		// Handle local echo
 		boolean localEcho = section.getBoolean("local-echo", true);
 		ret = ret.withLocalEcho(localEcho);
-		
+
 		// Handle first prompt loading
 		Prompt firstPrompt = readPrompt(section.getConfigurationSection("first-prompt"));
 		ret = ret.withFirstPrompt(firstPrompt);
-		
+
 		// Handle timeout
 		int timeoutSeconds = section.getInt("timeout-seconds", 30);
 		ret = ret.withTimeout(timeoutSeconds);
-		
+
 		// Handle escape sequence
 		String escapeSequence = section.getString("escape-sequence", null);
 		if (escapeSequence != null && !escapeSequence.isEmpty()) ret = ret.withEscapeSequence("");
-		
+
 		// Return
 		return ret;
 	}
-	
+
+	public static ConfigurationSection mapToSection(Map<?, ?> map) {
+		ConfigurationSection section = new MemoryConfiguration();
+		for (Map.Entry<?, ?> entry : map.entrySet()) section.set(String.valueOf(entry.getKey()), entry.getValue());
+		return section;
+	}
+
 }


### PR DESCRIPTION
- `onblock` modifier can now be used as a location modifier.
- Swapped order of `ambient` and `hidden` options in the string format for `PotionEffectSpell`.
- Fixed issue where `hidden` option was by default `true` in the string format for `PotionEffectSpell`.
- Readded the `targeted` option to `PotionEffectSpell`.
- The `icon`, `hidden` and `ambient` options in `PotionEffectSpell` now support variable replacement.
- Added section format for `potion-effects` in  `PotionEffectSpell`. All of the options for the section style allows for variable replacement. The following are all equivalent:
```yml
test:
  spell-class: ".targeted.PotionEffectSpell"
  potion-effects:
    # <effect> <duration> <strength> <ambient> <hidden> <icon>
    - speed 100 4 false false true
    # Flow style section
    - {type: speed, duration: 100, strength: 4, ambient: false, hidden: false, icon: true}
    # Block style section
    - type: speed
      duration: 100
      strength: 4
      ambient: false
      hidden: false
      icon: true
```