### PR TITLE
Fix castinstead in target modifiers, bugfixes and cleanup

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1409,14 +1409,14 @@ public class MagicSpells extends JavaPlugin {
 		if (string == null || string.isEmpty() || plugin.variableManager == null) return string;
 
 		Matcher matcher = chatVarMatchPattern.matcher(string);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 
 		while (matcher.find()) {
 			String varName = matcher.group(1), place = matcher.group(2);
 
 			Variable variable = plugin.variableManager.getVariable(varName);
 			if (variable == null) {
-				matcher.appendReplacement(buffer, "0");
+				matcher.appendReplacement(builder, "0");
 				continue;
 			}
 
@@ -1431,10 +1431,10 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(player);
 			}
 
-			matcher.appendReplacement(buffer, Matcher.quoteReplacement(value));
+			matcher.appendReplacement(builder, Matcher.quoteReplacement(value));
 		}
 
-		return matcher.appendTail(buffer).toString();
+		return matcher.appendTail(builder).toString();
 	}
 
 	private static final Pattern chatPlayerVarMatchPattern = Pattern.compile("%playervar:(" + RegexUtil.USERNAME_REGEXP + "):(\\w+)(?::(\\d+))?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
@@ -1443,14 +1443,14 @@ public class MagicSpells extends JavaPlugin {
 		if (string == null || string.isEmpty() || plugin.variableManager == null) return string;
 
 		Matcher matcher = chatPlayerVarMatchPattern.matcher(string);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 
 		while (matcher.find()) {
 			String variableOwnerName = matcher.group(1), varName = matcher.group(2), place = matcher.group(3);
 
 			Variable variable = plugin.variableManager.getVariable(varName);
 			if (variable == null) {
-				matcher.appendReplacement(buffer, "0");
+				matcher.appendReplacement(builder, "0");
 				continue;
 			}
 
@@ -1465,10 +1465,10 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(variableOwnerName);
 			}
 
-			matcher.appendReplacement(buffer, Matcher.quoteReplacement(value));
+			matcher.appendReplacement(builder, Matcher.quoteReplacement(value));
 		}
 
-		return matcher.appendTail(buffer).toString();
+		return matcher.appendTail(builder).toString();
 	}
 
 	private static final Pattern chatTargetedVarMatchPattern = Pattern.compile("%(castervar|targetvar):(\\w+)(?::(\\d+))?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
@@ -1476,14 +1476,14 @@ public class MagicSpells extends JavaPlugin {
 		if (string == null || string.isEmpty() || plugin.variableManager == null) return string;
 
 		Matcher matcher = chatTargetedVarMatchPattern.matcher(string);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 		Player varOwner;
 
 		while (matcher.find()) {
 			String varName = matcher.group(2);
 			Variable variable = plugin.variableManager.getVariable(varName);
 			if (variable == null) {
-				matcher.appendReplacement(buffer, "0");
+				matcher.appendReplacement(builder, "0");
 				continue;
 			}
 
@@ -1501,10 +1501,10 @@ public class MagicSpells extends JavaPlugin {
 				value = variable.getStringValue(varOwner);
 			}
 
-			matcher.appendReplacement(buffer, Matcher.quoteReplacement(value));
+			matcher.appendReplacement(builder, Matcher.quoteReplacement(value));
 		}
 
-		return matcher.appendTail(buffer).toString();
+		return matcher.appendTail(builder).toString();
 	}
 
 	//%arg:(index):defaultValue%
@@ -1513,7 +1513,7 @@ public class MagicSpells extends JavaPlugin {
 		if (string == null || string.isEmpty()) return string;
 
 		Matcher matcher = argumentSubstitutionPattern.matcher(string);
-		StringBuffer buffer = new StringBuffer();
+		StringBuilder builder = new StringBuilder();
 
 		while (matcher.find()) {
 			int argIndex = Integer.parseInt(matcher.group(1)) - 1;
@@ -1521,10 +1521,10 @@ public class MagicSpells extends JavaPlugin {
 			String newValue = matcher.group(2);
 			if (args != null && argIndex >= 0 && argIndex < args.length) newValue = args[argIndex];
 
-			matcher.appendReplacement(buffer, Matcher.quoteReplacement(newValue));
+			matcher.appendReplacement(builder, Matcher.quoteReplacement(newValue));
 		}
 
-		return matcher.appendTail(buffer).toString();
+		return matcher.appendTail(builder).toString();
 	}
 
 	public static String doArgumentAndVariableSubstitution(String string, Player player, String[] args) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -720,6 +720,9 @@ public enum ModifierType {
 				if (data.spell.isTargetedEntitySpell()) data.spell.castAtEntity(event.getCaster(), event.getTarget(), event.getPower());
 				else if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(event.getCaster(), event.getTarget().getLocation(), event.getPower());
 				else data.spell.cast(event.getCaster(), event.getPower());
+
+				event.setCancelled(true);
+				event.setCastCancelled(true);
 			}
 			return !check;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
@@ -16,6 +16,7 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	private String[] args;
 	private float power;
 	private boolean cancelled = false;
+	private boolean castCancelled = false;
 
 	public SpellTargetEvent(Spell spell, LivingEntity caster, LivingEntity target, float power, String[] args) {
 		super(spell, caster);
@@ -88,5 +89,13 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 	public void setCancelled(boolean cancelled) {
 		this.cancelled = cancelled;		
 	}
-	
+
+	public boolean isCastCancelled() {
+		return castCancelled;
+	}
+
+	public void setCastCancelled(boolean castCancelled) {
+		this.castCancelled = castCancelled;
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -192,14 +192,13 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		LivingEntity target;
 
 		if (targeted) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			if (!targetList.canTarget(targetInfo.getTarget())) return noTarget(caster);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
+			if (!targetList.canTarget(info.target())) return noTarget(caster, args);
 
-			target = targetInfo.getTarget();
-			power = targetInfo.getPower();
-		}
-		else target = caster;
+			target = info.target();
+			power = info.power();
+		} else target = caster;
 
 		PostCastAction action = activate(caster, target, power, args, state == SpellCastState.NORMAL);
 		if (targeted && action == PostCastAction.HANDLE_NORMALLY) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
@@ -111,14 +111,18 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 			Player target = null;
 			if (requirePlayerTarget) {
 				TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-				if (targetInfo == null) {
-					sendMessage(strNoTarget, caster, args);
-					return PostCastAction.ALREADY_HANDLED;
-				}
-				target = targetInfo.getTarget();
+				if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+				target = targetInfo.target();
+				power = targetInfo.power();
 			}
+
 			process(caster, target, power, args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -82,10 +82,10 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			LivingEntity entTarget = null;
 			if (requireEntityTarget) {
 				TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
-				if (info != null) {
-					entTarget = info.getTarget();
-					power = info.getPower();
-				}
+				if (info.noTarget()) return noTarget(caster, args, info);
+
+				entTarget = info.target();
+				power = info.power();
 			} else if (pointBlank) {
 				locTarget = caster.getLocation();
 			} else {
@@ -100,20 +100,21 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 					DebugHandler.debugIllegalState(e);
 				}
 			}
-			if (locTarget == null && entTarget == null) return noTarget(caster);
+			if (locTarget == null && entTarget == null) return noTarget(caster, args);
 			if (locTarget != null) {
 				locTarget.setY(locTarget.getY() + yOffset.get(caster, null, power, args));
 				locTarget.setDirection(caster.getLocation().getDirection());
 			}
 			
 			boolean somethingWasDone = runSpells(caster, entTarget, locTarget, power, args);
-			if (!somethingWasDone) return noTarget(caster);
+			if (!somethingWasDone) return noTarget(caster, args);
 			
 			if (entTarget != null) {
 				sendMessages(caster, entTarget, args);
 				return PostCastAction.NO_MESSAGES;
 			}
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -125,9 +125,7 @@ public abstract class TargetedSpell extends InstantSpell {
 	protected TargetInfo<LivingEntity> getTargetedEntity(LivingEntity caster, float power, boolean forceTargetPlayers, ValidTargetChecker checker, String[] args) {
 		if (targetSelf || validTargetList.canTargetSelf()) {
 			SpellTargetEvent event = new SpellTargetEvent(this, caster, caster, power, args);
-			if (!event.callEvent()) return null;
-
-			return new TargetInfo<>(event.getTarget(), event.getPower());
+			return new TargetInfo<>(event.callEvent() ? event.getTarget() : null, event.getPower(), event.isCastCancelled());
 		}
 
 		return super.getTargetedEntity(caster, power, forceTargetPlayers, checker, args);
@@ -140,9 +138,43 @@ public abstract class TargetedSpell extends InstantSpell {
 	 * @return the appropriate PostCastAction value
 	 */
 	protected PostCastAction noTarget(LivingEntity livingEntity) {
-		return noTarget(livingEntity, strNoTarget);
+		return noTarget(livingEntity, strNoTarget, null, null);
 	}
-	
+
+	/**
+	 * This should be called if a target should not be found. It sends the no target message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param args arguments of spell
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, String[] args) {
+		return noTarget(livingEntity, strNoTarget, args, null);
+	}
+
+	/**
+	 * This should be called if a target should not be found. It sends the no target message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param info targeting info
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, TargetInfo<?> info) {
+		return noTarget(livingEntity, strNoTarget, null, info);
+	}
+
+	/**
+	 * This should be called if a target should not be found. It sends the no target message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param args arguments of spell
+	 * @param info targeting info
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, String[] args, TargetInfo<?> info) {
+		return noTarget(livingEntity, strNoTarget, args, info);
+	}
+
 	/**
 	 * This should be called if a target should not be found. It sends the provided message
 	 * and returns the appropriate return value.
@@ -151,10 +183,48 @@ public abstract class TargetedSpell extends InstantSpell {
 	 * @return the appropriate PostCastAction value
 	 */
 	protected PostCastAction noTarget(LivingEntity livingEntity, String message) {
+		return noTarget(livingEntity, message, null, null);
+	}
+
+	/**
+	 * This should be called if a target should not be found. It sends the provided message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param message the message to send
+	 * @param args arguments of spell
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, String message, String[] args) {
+		return noTarget(livingEntity, message, args, null);
+	}
+
+	/**
+	 * This should be called if a target should not be found. It sends the provided message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param message the message to send
+	 * @param info targeting info
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, String message, TargetInfo<?> info) {
+		return noTarget(livingEntity, message, null, info);
+	}
+
+	/**
+	 * This should be called if a target should not be found. It sends the provided message
+	 * and returns the appropriate return value.
+	 * @param livingEntity the casting living entity
+	 * @param message the message to send
+	 * @param args arguments of spell
+	 * @param info targeting info
+	 * @return the appropriate PostCastAction value
+	 */
+	protected PostCastAction noTarget(LivingEntity livingEntity, String message, String[] args, TargetInfo<?> info) {
+		if (info != null && info.cancelled()) return PostCastAction.ALREADY_HANDLED;
 		fizzle(livingEntity);
-		sendMessage(message, livingEntity, MagicSpells.NULL_ARGS);
+		sendMessage(message, livingEntity, args);
 		if (spellOnFail != null) spellOnFail.cast(livingEntity, 1.0F);
 		return alwaysActivate ? PostCastAction.NO_MESSAGES : PostCastAction.ALREADY_HANDLED;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
@@ -151,7 +151,7 @@ public class SeeHealthSpell extends BuffSpell {
 
 				CastData data = entry.getValue();
 				TargetInfo<LivingEntity> target = getTargetedEntity(player, data.power(), data.args());
-				if (target != null) showHealthBar(player, target.getTarget(), data);
+				if (!target.noTarget()) showHealthBar(player, target.target(), data);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -107,7 +107,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 				catch (IllegalStateException ignored) {}
 			}
 
-			if (loc == null) return noTarget(caster);
+			if (loc == null) return noTarget(caster, args);
 
 			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, loc, power, args);
 			EventUtil.call(event);
@@ -117,10 +117,10 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 				power = event.getPower();
 			}
 
-			if (loc == null) return noTarget(caster);
+			if (loc == null) return noTarget(caster, args);
 			
 			boolean done = doAoe(caster, loc, power, args);
-			if (!done) return noTarget(caster);
+			if (!done) return noTarget(caster, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
@@ -148,12 +148,12 @@ public class AreaScanSpell extends TargetedSpell implements TargetedLocationSpel
 			if (pointBlank) origin = caster.getLocation();
 			else {
 				Block target = getTargetedBlock(caster, power, args);
-				if (target == null) return noTarget(caster);
+				if (target == null) return noTarget(caster, args);
 
 				origin = target.getLocation();
 			}
 
-			if (!scan(caster, origin, power, args)) return noTarget(caster);
+			if (!scan(caster, origin, power, args)) return noTarget(caster, args);
 		}
 
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
@@ -54,7 +54,7 @@ public class BlinkSpell extends TargetedSpell implements TargetedLocationSpell {
 				}
 			}
 
-			if (found == null) return noTarget(caster, strCantBlink);
+			if (found == null) return noTarget(caster, strCantBlink, args);
 
 			Location loc = null;
 			if (!passThroughCeiling && found.getRelative(0, -1, 0).equals(prev)) {
@@ -78,7 +78,7 @@ public class BlinkSpell extends TargetedSpell implements TargetedLocationSpell {
 				else loc = event.getTargetLocation();
 			}
 
-			if (loc == null) return noTarget(caster, strCantBlink);
+			if (loc == null) return noTarget(caster, strCantBlink, args);
 
 			loc.setX(loc.getX() + 0.5);
 			loc.setZ(loc.getZ() + 0.5);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
@@ -78,12 +78,12 @@ public class BombSpell extends TargetedSpell implements TargetedLocationSpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			List<Block> blocks = getLastTwoTargetedBlocks(caster, power, args);
-			if (blocks.size() != 2) return noTarget(caster);
-			if (!blocks.get(1).getType().isSolid()) return noTarget(caster);
+			if (blocks.size() != 2) return noTarget(caster, args);
+			if (!blocks.get(1).getType().isSolid()) return noTarget(caster, args);
 
 			Block target = blocks.get(0);
 			boolean ok = bomb(caster, target.getLocation(), power, args);
-			if (!ok) return noTarget(caster);
+			if (!ok) return noTarget(caster, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -79,7 +79,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			int slot = this.slot.get(caster, null, power, args);
 			ItemStack item = player.getInventory().getItem(slot);
-			if (item == null || !isAllowed(item.getType())) return noTarget(player, strInvalidBlock);
+			if (item == null || !isAllowed(item.getType())) return noTarget(player, strInvalidBlock, args);
 
 			List<Block> lastBlocks;
 			try {
@@ -90,10 +90,10 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 
 			if (lastBlocks == null || lastBlocks.size() < 2 || BlockUtils.isAir(lastBlocks.get(1).getType()))
-				return noTarget(player, strCantBuild);
+				return noTarget(player, strCantBuild, args);
 
 			boolean built = build(player, lastBlocks.get(0), lastBlocks.get(1), item, slot, power, args);
-			if (!built) return noTarget(player, strCantBuild);
+			if (!built) return noTarget(player, strCantBuild, args);
 
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -101,7 +101,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 				if (b != null && b.getType() != Material.AIR) loc = b.getLocation();
 			}
 
-			if (loc == null) return noTarget(player);
+			if (loc == null) return noTarget(player, args);
 
 			layCarpet(player, loc, power, args);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -55,12 +55,16 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			chain(caster, caster.getLocation(), target.getTarget(), target.getPower(), args);
-			sendMessages(caster, target.getTarget(), args);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
+			LivingEntity target = info.target();
+
+			chain(caster, caster.getLocation(), target, info.power(), args);
+			sendMessages(caster, target, args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
@@ -191,12 +191,14 @@ public class CleanseSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, checker, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			cleanse(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			cleanse(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CollisionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CollisionSpell.java
@@ -7,42 +7,59 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.TargetBooleanState;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class CollisionSpell extends TargetedSpell implements TargetedEntitySpell {
-	
+
 	private TargetBooleanState targetBooleanState;
-	
+
 	public CollisionSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		targetBooleanState = TargetBooleanState.getFromName(getConfigString("target-state", "toggle"));
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args);
+			LivingEntity target = targetInfo.target();
 
 			target.setCollidable(targetBooleanState.getBooleanState(target.isCollidable()));
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
 		target.setCollidable(targetBooleanState.getBooleanState(target.isCollidable()));
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(target)) return false;
 		target.setCollidable(targetBooleanState.getBooleanState(target.isCollidable()));
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
-	
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		return castAtEntity(target, power, null);
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -51,13 +51,15 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			boolean combusted = combust(caster, target.getTarget(), target.getPower(), args);
-			if (!combusted) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			sendMessages(caster, target.getTarget(), args);
+			boolean combusted = combust(caster, target.target(), target.power(), args);
+			if (!combusted) return noTarget(caster, args);
+
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ConversationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ConversationSpell.java
@@ -10,12 +10,13 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.ConfigReaderUtil;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.util.prompt.ConversationContextUtil;
 
 public class ConversationSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	private ConversationFactory conversationFactory;
-	
+
 	public ConversationSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
@@ -26,31 +27,48 @@ public class ConversationSpell extends TargetedSpell implements TargetedEntitySp
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-			if (targetInfo == null || targetInfo.getTarget() == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
 
-			conversate(targetInfo.getTarget());
-			return PostCastAction.HANDLE_NORMALLY;
+			conversate(caster, targetInfo.target(), targetInfo.power(), args);
+			sendMessages(caster, targetInfo.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
+		if (!validTargetList.canTarget(caster, target) || !(target instanceof Player player)) return false;
+		conversate(caster, player, power, args);
+		return true;
+	}
+
+	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		conversate(target);
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
+		if (!validTargetList.canTarget(target) || !(target instanceof Player player)) return false;
+		conversate(null, player, power, args);
 		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		return false;
+		return castAtEntity(target, power, null);
 	}
 
-	private void conversate(LivingEntity target) {
-		if (!(target instanceof Player player)) return;
-		Conversation conversation = conversationFactory.buildConversation(player);
-		ConversationContextUtil.setConversable(conversation.getContext(), player);
+	private void conversate(LivingEntity caster, Player target, float power, String[] args) {
+		Conversation conversation = conversationFactory.buildConversation(target);
+		ConversationContextUtil.setConversable(conversation.getContext(), target);
 		conversation.begin();
+
+		if (caster != null) playSpellEffects(caster, target, power, args);
+		else playSpellEffects(EffectPosition.TARGET, target, power, args);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
@@ -39,12 +39,14 @@ public class CrippleSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 
-			cripple(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			cripple(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CustomNameVisibilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CustomNameVisibilitySpell.java
@@ -7,42 +7,59 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.TargetBooleanState;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class CustomNameVisibilitySpell extends TargetedSpell implements TargetedEntitySpell {
-	
+
 	private TargetBooleanState targetBooleanState;
-	
+
 	public CustomNameVisibilitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
 		targetBooleanState = TargetBooleanState.getFromName(getConfigString("target-state", "toggle"));
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			LivingEntity target = targetInfo.target();
 
 			target.setCustomNameVisible(targetBooleanState.getBooleanState(target.isCustomNameVisible()));
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
 		target.setCustomNameVisible(targetBooleanState.getBooleanState(target.isCustomNameVisible()));
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(target)) return false;
 		target.setCustomNameVisible(targetBooleanState.getBooleanState(target.isCustomNameVisible()));
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
-	
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		return castAtEntity(target, power, null);
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DataSpell.java
@@ -43,14 +43,17 @@ public class DataSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(player, power, args);
-			if (targetInfo == null) return noTarget(player);
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(player);
+			if (targetInfo.noTarget()) return noTarget(player, args, targetInfo);
+			LivingEntity target = targetInfo.target();
 
-			playSpellEffects(player, target, power, args);
+			playSpellEffects(player, target, targetInfo.power(), args);
 			String value = dataElement.apply(target);
 			MagicSpells.getVariableManager().set(variableName, player, value);
+
+			sendMessages(caster, target, args);
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
@@ -65,18 +65,21 @@ public class DisarmSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			
-			LivingEntity realTarget = target.getTarget();
-			
-			boolean disarmed = disarm(caster, realTarget, power, args);
-			if (!disarmed) return noTarget(caster, strInvalidItem);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-			playSpellEffects(caster, realTarget, power, args);
-			sendMessages(caster, realTarget, args);
+			LivingEntity target = info.target();
+			power = info.power();
+
+			boolean disarmed = disarm(caster, target, power, args);
+			if (!disarmed) return noTarget(caster, strInvalidItem, args);
+
+			playSpellEffects(caster, target, power, args);
+			sendMessages(caster, target, args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
@@ -76,9 +76,14 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell, Dama
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			applyDot(caster, targetInfo.getTarget(), targetInfo.getPower(), args);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			applyDot(caster, targetInfo.target(), targetInfo.power(), args);
+			sendMessages(caster, targetInfo.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -106,13 +106,15 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			boolean drained = drain(caster, target.getTarget(), target.getPower(), args);
-			if (!drained) return noTarget(caster);
-			sendMessages(caster, target.getTarget(), args);
+			boolean drained = drain(caster, target.target(), target.power(), args);
+			if (!drained) return noTarget(caster, args);
+
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
@@ -23,12 +23,14 @@ public class DummySpell extends TargetedSpell implements TargetedEntitySpell, Ta
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			playSpellEffects(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			playSpellEffects(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityEditSpell.java
@@ -34,13 +34,15 @@ public class EntityEditSpell extends TargetedSpell implements TargetedEntitySpel
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			applyAttributes(target.getTarget());
-			playSpellEffects(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			applyAttributes(target.target());
+			playSpellEffects(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySelectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySelectSpell.java
@@ -28,11 +28,15 @@ public class EntitySelectSpell extends TargetedSpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null || targetInfo.getTarget() == null) return noTarget(caster);
-			
-			targets.put(caster.getUniqueId(), new WeakReference<>(targetInfo.getTarget()));
-			sendMessages(caster, targetInfo.getTarget(), args);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			targets.put(caster.getUniqueId(), new WeakReference<>(targetInfo.target()));
+			playSpellEffects(caster, targetInfo.target(), targetInfo.power(), args);
+			sendMessages(caster, targetInfo.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntitySilenceSpell.java
@@ -7,6 +7,7 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.TargetBooleanState;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class EntitySilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 	
@@ -22,27 +23,43 @@ public class EntitySilenceSpell extends TargetedSpell implements TargetedEntityS
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			LivingEntity target = targetInfo.target();
 
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
 			target.setSilent(targetBooleanState.getBooleanState(target.isSilent()));
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 	
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
 		target.setSilent(targetBooleanState.getBooleanState(target.isSilent()));
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(target)) return false;
 		target.setSilent(targetBooleanState.getBooleanState(target.isSilent()));
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
-	
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		return castAtEntity(target, power, null);
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
@@ -72,23 +72,26 @@ public class EntombSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			power = targetInfo.getPower();
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			LivingEntity target = targetInfo.target();
+			power = targetInfo.power();
 			
 			createTomb(caster, target, power, args);
 			sendMessages(caster, target, args);
 			playSpellEffects(caster, target, power, args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 	
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
-		playSpellEffects(caster, target, power, args);
 		createTomb(caster, target, power, args);
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
@@ -85,9 +85,9 @@ public class ExplodeSpell extends TargetedSpell implements TargetedLocationSpell
 				}
 			}
 
-			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster);
+			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster, args);
 			boolean exploded = explode(caster, target.getLocation(), power, args);
-			if (!exploded && !ignoreCanceled) return noTarget(caster);
+			if (!exploded && !ignoreCanceled) return noTarget(caster, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FarmSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FarmSpell.java
@@ -74,12 +74,12 @@ public class FarmSpell extends TargetedSpell implements TargetedLocationSpell {
 
 			if (block != null) {
 				boolean farmed = farm(caster, block, power, args);
-				if (!farmed) return noTarget(caster);
+				if (!farmed) return noTarget(caster, args);
 
 				SpellData data = new SpellData(caster, power, args);
 				playSpellEffects(EffectPosition.CASTER, caster, data);
 				if (targeted) playSpellEffects(EffectPosition.TARGET, block.getLocation(), data);
-			} else return noTarget(caster);
+			} else return noTarget(caster, args);
 
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
@@ -8,6 +8,7 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.TargetBooleanState;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 	
@@ -23,27 +24,43 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			Player target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			Player target = targetInfo.target();
 
 			target.setFlying(targetBooleanState.getBooleanState(target.isFlying()));
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!(target instanceof Player player) || !validTargetList.canTarget(caster, target)) return false;
 		player.setFlying(targetBooleanState.getBooleanState(((Player) target).isFlying()));
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
-	
+
 	@Override
-	public boolean castAtEntity(LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!(target instanceof Player player) || !validTargetList.canTarget(target)) return false;
 		player.setFlying(targetBooleanState.getBooleanState(((Player) target).isFlying()));
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
-	
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power) {
+		return castAtEntity(target, power, null);
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcebombSpell.java
@@ -61,7 +61,7 @@ public class ForcebombSpell extends TargetedSpell implements TargetedLocationSpe
 				}
 			}
 
-			if (block == null || BlockUtils.isAir(block.getType())) return noTarget(caster);
+			if (block == null || BlockUtils.isAir(block.getType())) return noTarget(caster, args);
 			knockback(caster, block.getLocation().add(0.5, 0, 0.5), power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -47,12 +47,14 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
 
-			toss(caster, targetInfo.getTarget(), targetInfo.getPower(), args);
-			sendMessages(caster, targetInfo.getTarget(), args);
+			toss(caster, targetInfo.target(), targetInfo.power(), args);
+			sendMessages(caster, targetInfo.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GeyserSpell.java
@@ -64,13 +64,14 @@ public class GeyserSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			boolean ok = geyser(caster, target.getTarget(), target.getPower(), args);
-			if (!ok) return noTarget(caster);
+			boolean ok = geyser(caster, target.target(), target.power(), args);
+			if (!ok) return noTarget(caster, args);
 
-			playSpellEffects(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			playSpellEffects(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GlideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GlideSpell.java
@@ -22,12 +22,16 @@ public class GlideSpell extends TargetedSpell implements TargetedEntitySpell{
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			LivingEntity target = targetInfo.target();
 
-			if (target == null) return noTarget(caster);
 			target.setGliding(targetState.getBooleanState(target.isGliding()));
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/GripSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/GripSpell.java
@@ -42,11 +42,11 @@ public class GripSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			if (!grip(caster, target.getTarget(), caster.getLocation(), power, args))
-				return noTarget(caster, strCantGrip);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			sendMessages(caster, target.getTarget(), args);
+			if (!grip(caster, target.target(), caster.getLocation(), power, args)) return noTarget(caster, strCantGrip, args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
@@ -46,12 +46,17 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, checker, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			power = targetInfo.getPower();
-			if (cancelIfFull && target.getHealth() == Util.getMaxHealth(target)) return noTarget(caster, formatMessage(strMaxHealth, "%t", getTargetName(target)));
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			LivingEntity target = targetInfo.target();
+			power = targetInfo.power();
+
+			if (cancelIfFull && target.getHealth() == Util.getMaxHealth(target))
+				return noTarget(caster, formatMessage(strMaxHealth, "%t", getTargetName(target)), args);
+
 			boolean healed = heal(caster, target, power, args);
-			if (!healed) return noTarget(caster);
+			if (!healed) return noTarget(caster, args);
+
 			sendMessages(caster, target, args);
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
@@ -19,6 +19,8 @@ import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
+import org.checkerframework.checker.units.qual.C;
+
 public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
 	private ConfigData<Integer> resetTime;
@@ -72,13 +74,14 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 
 			if (targetEntity) {
 				TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-				if (target != null) data = new CastData(caster, target.getTarget(), target.getPower(), args);
-				else return noTarget(caster);
+				if (target.noTarget()) return noTarget(caster, args, target);
+
+				data = new CastData(caster, target.target(), target.power(), args);
 			} else if (targetLocation) {
 				Block block = getTargetedBlock(caster, power, args);
-				if (block != null && block.getType() != Material.AIR)
-					data = new CastData(caster, block.getLocation().add(0.5, 0.5, 0.5), power, args);
-				else return noTarget(caster);
+				if (block == null || block.getType().isAir()) return noTarget(caster, args);
+
+				data = new CastData(caster, block.getLocation().add(0.5, 0.5, 0.5), power, args);
 			} else data = new CastData(caster, power, args);
 
 			data.cast(caster);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -170,9 +170,11 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		if (state == SpellCastState.NORMAL) {
 			ValidTargetChecker checker = hitSpell != null ? hitSpell.getSpell().getValidTargetChecker() : null;
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, checker, args);
-			if (target == null) return noTarget(caster);
-			new MissileTracker(caster, target.getTarget(), target.getPower(), args);
-			sendMessages(caster, target.getTarget(), args);
+			if (target.noTarget()) return noTarget(caster, args, target);
+
+			new MissileTracker(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -171,9 +171,11 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			new HomingProjectileMonitor(caster, targetInfo.getTarget(), targetInfo.getPower(), args);
-			sendMessages(caster, targetInfo.getTarget(), args);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			new HomingProjectileMonitor(caster, targetInfo.target(), targetInfo.power(), args);
+			sendMessages(caster, targetInfo.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -93,10 +93,11 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 			return PostCastAction.ALREADY_HANDLED;
 		} else if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			levitate(caster, target.getTarget(), target.getPower(), args);
-			sendMessages(caster, target.getTarget(), args);
+			levitate(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -227,11 +227,10 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			if (targeted) {
 				if (requireEntityTarget) {
 					TargetInfo<LivingEntity> info = getTargetedEntity(caster, power);
+					if (info.noTarget()) return noTarget(caster, args, info);
 
-					if (info != null) {
-						entityTarget = info.getTarget();
-						power = info.getPower();
-					}
+					entityTarget = info.target();
+					power = info.power();
 				} else if (pointBlank) {
 					locationTarget = caster.getLocation();
 				} else {
@@ -242,14 +241,14 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 						locationTarget.add(0.5, yOffset + 0.5, 0.5);
 
 						SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, locationTarget, power, args);
-						if (!event.callEvent()) return noTarget(caster);
+						if (!event.callEvent()) return noTarget(caster, args);
 
 						locationTarget = event.getTargetLocation();
 						power = event.getPower();
 					}
 				}
 
-				if (entityTarget == null && locationTarget == null) return noTarget(caster);
+				if (entityTarget == null && locationTarget == null) return noTarget(caster, args);
 			}
 
 			initLoop(caster, entityTarget, locationTarget, power, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MagicBondSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MagicBondSpell.java
@@ -20,7 +20,6 @@ import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.events.SpellCastEvent;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class MagicBondSpell extends TargetedSpell implements TargetedEntitySpell {
 
@@ -52,9 +51,12 @@ public class MagicBondSpell extends TargetedSpell implements TargetedEntitySpell
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			bond(caster, target.getTarget(), target.getPower(), args);
+			bond(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -157,20 +157,20 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 				lastTwo = null;
 			}
 
-			if (lastTwo == null || lastTwo.size() != 2) return noTarget(player);
-			if (!BlockUtils.isAir(lastTwo.get(0).getType()) || BlockUtils.isAir(lastTwo.get(1).getType())) return noTarget(player);
+			if (lastTwo == null || lastTwo.size() != 2) return noTarget(player, args);
+			if (!BlockUtils.isAir(lastTwo.get(0).getType()) || BlockUtils.isAir(lastTwo.get(1).getType())) return noTarget(player, args);
 
 			Block block = lastTwo.get(0);
 			Block against = lastTwo.get(1);
 			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, player, block.getLocation(), power, args);
 			EventUtil.call(event);
-			if (event.isCancelled()) return noTarget(player, strFailed);
+			if (event.isCancelled()) return noTarget(player, strFailed, args);
 			block = event.getTargetLocation().getBlock();
 			power = event.getPower();
 
 			if (!hasMiddle) {
 				boolean done = materialize(player, block, against, power, args);
-				if (!done) return noTarget(player, strFailed);
+				if (!done) return noTarget(player, strFailed, args);
 				return PostCastAction.HANDLE_NORMALLY;
 			}
 
@@ -234,7 +234,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 
 						//As soon as a block can't be spawned, it will return an error.
 						boolean done = materialize(player, air, ground, power, args);
-						if (!done) return noTarget(player, strFailed);
+						if (!done) return noTarget(player, strFailed, args);
 
 						//Done with placing that one block? Move on to the next one.
 						spawnBlock.setX((ground.getX() + 1));

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ModifyCooldownSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ModifyCooldownSpell.java
@@ -44,10 +44,14 @@ public class ModifyCooldownSpell extends TargetedSpell implements TargetedEntity
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			modifyCooldowns(caster, target.getTarget(), target.getPower(), args);
+			modifyCooldowns(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
@@ -34,10 +34,13 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			LivingEntity target = targetInfo.target();
+
 			mount(caster, target, power, args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
 
 		return PostCastAction.HANDLE_NORMALLY;
@@ -109,7 +112,8 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 			LivingEntity finalTarget1 = target;
 			MagicSpells.scheduleDelayedTask(() -> finalTarget1.removePassenger(caster), duration);
 		}
-		sendMessages(caster, target, args);
+
+		playSpellEffects(caster, target, power, args);
 	}
 
 	@EventHandler

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -134,10 +134,12 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		if (state == SpellCastState.NORMAL) {
 			if (requireEntityTarget) {
 				TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-				if (target == null) return noTarget(caster);
-				new OrbitTracker(caster, target.getTarget(), target.getPower(), args);
-				playSpellEffects(caster, target.getTarget(), power, args);
-				sendMessages(caster, target.getTarget(), args);
+				if (target.noTarget()) return noTarget(caster, args, target);
+
+				new OrbitTracker(caster, target.target(), target.power(), args);
+				playSpellEffects(caster, target.target(), target.power(), args);
+				sendMessages(caster, target.target(), args);
+
 				return PostCastAction.NO_MESSAGES;
 			}
 
@@ -152,11 +154,12 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				}
 			}
 
-			if (block == null) return noTarget(caster);
+			if (block == null) return noTarget(caster, args);
 
 			new OrbitTracker(caster, block.getLocation().add(0.5, 0, 0.5), power, args);
 			return PostCastAction.HANDLE_NORMALLY;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
@@ -57,16 +57,17 @@ public class PainSpell extends TargetedSpell implements TargetedEntitySpell, Dam
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
 			boolean done;
-			if (caster instanceof Player) done = CompatBasics.exemptAction(() -> causePain(caster, target.getTarget(), target.getPower(), args), (Player) caster, CompatBasics.activeExemptionAssistant.getPainExemptions());
-			else done = causePain(caster, target.getTarget(), target.getPower(), args);
-			if (!done) return noTarget(caster);
+			if (caster instanceof Player) done = CompatBasics.exemptAction(() -> causePain(caster, target.target(), target.power(), args), (Player) caster, CompatBasics.activeExemptionAssistant.getPainExemptions());
+			else done = causePain(caster, target.target(), target.power(), args);
+			if (!done) return noTarget(caster, args);
 			
-			sendMessages(caster, target.getTarget(), args);
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParseSpell.java
@@ -83,13 +83,16 @@ public class ParseSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			Player target = targetInfo.getTarget();
-			if (target == null) return noTarget(caster);
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+			Player target = targetInfo.target();
 
 			parse(target);
-			playSpellEffects(caster, target, power, args);
+			playSpellEffects(caster, target, targetInfo.power(), args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
@@ -167,13 +167,12 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 
 			if (canTargetEntities) {
 				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-				if (targetInfo != null) {
-					target = targetInfo.getTarget();
+				if (targetInfo.cancelled()) return PostCastAction.ALREADY_HANDLED;
 
-					if (target != null) {
-						locToSpawn = targetInfo.getTarget().getLocation();
-						power = targetInfo.getPower();
-					}
+				if (!targetInfo.empty()) {
+					power = targetInfo.power();
+					target = targetInfo.target();
+					locToSpawn = target.getLocation();
 				}
 			}
 
@@ -182,13 +181,14 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 				if (targetBlock != null) locToSpawn = targetBlock.getLocation().add(0.5, 1, 0.5);
 			}
 
-			if (locToSpawn == null) return noTarget(caster);
+			if (locToSpawn == null) return noTarget(caster, args);
 
 			locToSpawn.setDirection(caster.getLocation().getDirection());
 
 			AreaEffectCloud cloud = spawnCloud(caster, target, locToSpawn, power, args);
 			cloud.setSource(caster);
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
@@ -90,10 +90,10 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			Block target = pasteAtCaster ? caster.getLocation().getBlock() : getTargetedBlock(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 			Location loc = target.getLocation();
 			boolean ok = castAtLocation(caster, loc, power, args);
-			if (!ok) return noTarget(caster);
+			if (!ok) return noTarget(caster, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PotionEffectSpell.java
@@ -164,13 +164,16 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 			LivingEntity target;
 			if (targeted) {
 				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-				if (targetInfo == null) return noTarget(caster);
+				if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
 
-				target = targetInfo.getTarget();
-				power = targetInfo.getPower();
+				target = targetInfo.target();
+				power = targetInfo.power();
 			} else {
 				SpellTargetEvent targetEvent = new SpellTargetEvent(this, caster, caster, power, args);
-				if (!targetEvent.callEvent()) return noTarget(caster);
+				targetEvent.callEvent();
+
+				if (targetEvent.isCastCancelled()) return PostCastAction.ALREADY_HANDLED;
+				else if (targetEvent.isCancelled()) return noTarget(caster, args);
 
 				target = targetEvent.getTarget();
 				power = targetEvent.getPower();
@@ -182,6 +185,7 @@ public class PotionEffectSpell extends TargetedSpell implements TargetedEntitySp
 
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
@@ -233,7 +233,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 					if (block != null && !BlockUtils.isAir(block.getType())) loc = block.getLocation();
 				} catch (IllegalStateException ignored) {}
 			}
-			if (loc == null) return noTarget(caster);
+			if (loc == null) return noTarget(caster, args);
 
 			modify(caster, loc, power, args);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -132,17 +132,17 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			Block target = null;
 
 			if (lastTwo != null && lastTwo.size() == 2) target = lastTwo.get(0);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 
 			int yOffset = this.yOffset.get(caster, null, power, args);
 			if (yOffset > 0) target = target.getRelative(BlockFace.UP, yOffset);
 			else if (yOffset < 0) target = target.getRelative(BlockFace.DOWN, yOffset);
-			if (!BlockUtils.isPathable(target)) return noTarget(caster);
+			if (!BlockUtils.isPathable(target)) return noTarget(caster, args);
 
 			if (target != null) {
 				SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, target.getLocation(), power, args);
 				EventUtil.call(event);
-				if (event.isCancelled()) return noTarget(caster);
+				if (event.isCancelled()) return noTarget(caster, args);
 				target = event.getTargetLocation().getBlock();
 				power = event.getPower();
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemoveMarksSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RemoveMarksSpell.java
@@ -63,7 +63,7 @@ public class RemoveMarksSpell extends TargetedSpell implements TargetedLocationS
 				Block b = getTargetedBlock(caster, power, args);
 				if (b != null && !BlockUtils.isAir(b.getType())) loc = b.getLocation();
 			}
-			if (loc == null) return noTarget(caster);
+			if (loc == null) return noTarget(caster, args);
 			removeMarks(caster, loc, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -130,7 +130,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			Block target = pointBlank ? caster.getLocation().getBlock() : getTargetedBlock(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 			replace(caster, target.getLocation(), power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -74,28 +74,26 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			if (targetSelf) new Rewinder(caster, caster, power, args);
-			else {
-				TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-				if (targetInfo == null) return noTarget(caster);
-				sendMessages(caster, targetInfo.getTarget(), args);
-				new Rewinder(caster, targetInfo.getTarget(), targetInfo.getPower(), args);
-			}
-			playSpellEffects(EffectPosition.CASTER, caster, power, args);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
+
+			LivingEntity target = info.target();
+			power = info.power();
+
+			new Rewinder(caster, target, power, args);
+			playSpellEffects(caster, target, power, args);
+			sendMessages(caster, target, args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float v, String[] args) {
-		new Rewinder(caster, target, v, args);
-		sendMessages(caster, target, args);
-
-		SpellData data = new SpellData(caster, target, v, args);
-		playSpellEffects(EffectPosition.CASTER, caster, data);
-		playSpellEffects(EffectPosition.TARGET, target, data);
-		playSpellEffectsTrail(caster.getLocation(), target.getLocation(), data);
-
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
+		new Rewinder(caster, target, power, args);
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
 
@@ -105,9 +103,9 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 	}
 
 	@Override
-	public boolean castAtEntity(LivingEntity target, float v, String[] args) {
-		new Rewinder(null, target, v, args);
-		playSpellEffects(EffectPosition.TARGET, target, v, args);
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
+		new Rewinder(null, target, power, args);
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RiptideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RiptideSpell.java
@@ -23,64 +23,51 @@ public class RiptideSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
-		if (state != SpellCastState.NORMAL) return PostCastAction.HANDLE_NORMALLY;
+		if (state == SpellCastState.NORMAL) {
+			TargetInfo<Player> info = getTargetedPlayer(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-		TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-		if (targetInfo == null) return noTarget(caster);
+			Player target = info.target();
+			power = info.power();
 
-		Player target = targetInfo.getTarget();
-		if (target == null) return noTarget(caster);
+			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target, duration.get(caster, target, power, args));
+			playSpellEffects(caster, target, power, args);
+			sendMessages(caster, target, args);
 
-		power = targetInfo.getPower();
-
-		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(target, duration.get(caster, target, power, args));
-		playSpellEffects(caster, target, power, args);
+			return PostCastAction.NO_MESSAGES;
+		}
 
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
-		if (target instanceof Player player && validTargetList.canTarget(caster, target)) {
-			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(caster, target, power, args));
-			playSpellEffects(caster, target, power, args);
-			return true;
-		}
+		if (!(target instanceof Player player) || !validTargetList.canTarget(caster, target)) return false;
 
-		return false;
+		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(caster, target, power, args));
+		playSpellEffects(caster, target, power, args);
+
+		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (target instanceof Player player && validTargetList.canTarget(caster, target)) {
-			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(caster, target, power, null));
-			playSpellEffects(caster, target, power, null);
-			return true;
-		}
-
-		return false;
+		return castAtEntity(caster, target, power, null);
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
-		if (target instanceof Player player && validTargetList.canTarget(target)) {
-			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(null, target, power, args));
-			playSpellEffects(EffectPosition.TARGET, target, power, args);
-			return true;
-		}
+		if (!(target instanceof Player player) || !validTargetList.canTarget(target)) return false;
 
-		return false;
+		MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(null, target, power, args));
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
+
+		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (target instanceof Player player && validTargetList.canTarget(target)) {
-			MagicSpells.getVolatileCodeHandler().startAutoSpinAttack(player, duration.get(null, target, power, null));
-			playSpellEffects(EffectPosition.TARGET, target, power, null);
-			return true;
-		}
-
-		return false;
+		return castAtEntity(target, power, null);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RotateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RotateSpell.java
@@ -40,19 +40,24 @@ public class RotateSpell extends TargetedSpell implements TargetedEntitySpell, T
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			spinFace(caster, target.getTarget(), power, args);
-			playSpellEffects(caster, target.getTarget(), power, args);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
+
+			spinFace(caster, info.target(), info.power(), args);
+			playSpellEffects(caster, info.target(), info.power(), args);
+			sendMessages(caster, info.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
-		playSpellEffects(caster, target, power, args);
 		spinFace(caster, target, power, args);
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
 
@@ -64,8 +69,8 @@ public class RotateSpell extends TargetedSpell implements TargetedEntitySpell, T
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(target)) return false;
-		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		spinTarget(null, target, power, args);
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
 
@@ -76,8 +81,8 @@ public class RotateSpell extends TargetedSpell implements TargetedEntitySpell, T
 
 	@Override
 	public boolean castAtLocation(LivingEntity caster, Location target, float power, String[] args) {
-		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		spin(caster, target);
+		playSpellEffects(caster, target, power, args);
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ScoreboardDataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ScoreboardDataSpell.java
@@ -51,18 +51,18 @@ public class ScoreboardDataSpell extends TargetedSpell implements TargetedEntity
 	}
 
 	@Override
-	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
-		if (state == SpellCastState.NORMAL && livingEntity instanceof Player player) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(player, power, args);
-			if (targetInfo == null) return noTarget(player);
+	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
+		if (state == SpellCastState.NORMAL && caster instanceof Player player) {
+			TargetInfo<LivingEntity> info = getTargetedEntity(player, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-			LivingEntity target = targetInfo.getTarget();
-			if (target == null) return noTarget(player);
+			setScore(player, info.target());
+			playSpellEffects(player, info.target(), info.power(), args);
+			sendMessages(caster, info.target(), args);
 
-			setScore(player, target);
-
-			playSpellEffects(player, target, power, args);
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
@@ -71,8 +71,8 @@ public class ScoreboardDataSpell extends TargetedSpell implements TargetedEntity
 		if (!(caster instanceof Player player) || !validTargetList.canTarget(caster, target)) return false;
 
 		setScore(player, target);
-
 		playSpellEffects(caster, target, power, args);
+
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShadowstepSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ShadowstepSpell.java
@@ -42,13 +42,15 @@ public class ShadowstepSpell extends TargetedSpell implements TargetedEntitySpel
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			boolean done = shadowstep(caster, target.getTarget(), target.getPower(), args);
-			if (!done) return noTarget(caster, strNoLandingSpot);
-			sendMessages(caster, target.getTarget(), args);
+			boolean done = shadowstep(caster, target.target(), target.power(), args);
+			if (!done) return noTarget(caster, strNoLandingSpot, args);
+
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -99,13 +99,15 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			silence(caster, target.getTarget(), target.getPower(), args);
-			playSpellEffects(caster, target.getTarget(), power, args);
-			sendMessages(caster, target.getTarget(), args);
+			silence(caster, target.target(), target.power(), args);
+			playSpellEffects(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
@@ -8,6 +8,7 @@ import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class SkinSpell extends TargetedSpell implements TargetedEntitySpell {
 	
@@ -24,26 +25,43 @@ public class SkinSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<Player> targetInfo = getTargetedPlayer(caster, power, args);
-			if (targetInfo == null || targetInfo.getTarget() == null) return noTarget(caster);
+			TargetInfo<Player> info = getTargetedPlayer(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args);
 
-			Util.setSkin(targetInfo.getTarget(), texture, signature);
+			Util.setSkin(info.target(), texture, signature);
+			playSpellEffects(caster, info.target(), info.power(), args);
+			sendMessages(caster, info.target(), args);
+
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!(target instanceof Player player) || !validTargetList.canTarget(caster, target)) return false;
 		Util.setSkin(player, texture, signature);
+		playSpellEffects(caster, target, power, args);
+		return true;
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null);
+	}
+
+	@Override
+	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
+		if (!(target instanceof Player player) || !validTargetList.canTarget(target)) return false;
+		Util.setSkin(player, texture, signature);
+		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!(target instanceof Player player) || !validTargetList.canTarget(target)) return false;
-		Util.setSkin(player, texture, signature);
-		return true;
+		return castAtEntity(target, power, null);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlimeSizeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SlimeSizeSpell.java
@@ -15,6 +15,8 @@ import com.nisovin.magicspells.util.config.ConfigData;
 
 public class SlimeSizeSpell extends TargetedSpell implements TargetedEntitySpell {
 
+	private static final ValidTargetChecker SLIME = entity -> entity instanceof Slime;
+
 	private VariableMod variableMod;
 
 	private String size;
@@ -43,40 +45,32 @@ public class SlimeSizeSpell extends TargetedSpell implements TargetedEntitySpell
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, SLIME, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-			setSize(caster, targetInfo.getTarget(), targetInfo.getPower(), args);
+			if (!setSize(caster, info.target(), info.power(), args)) return noTarget(caster, args);
+
+			sendMessages(caster, info.target(), args);
+			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
-		setSize(caster, target, power, args);
-		return true;
+		return setSize(caster, target, power, args);
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		setSize(caster, target, power, null);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
-		if (!validTargetList.canTarget(target)) return false;
-		setSize(null, target, power, args);
-		return true;
+		return castAtEntity(caster, target, power, null);
 	}
 
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!validTargetList.canTarget(target)) return false;
-		setSize(null, target, power, null);
-		return true;
+		return false;
 	}
 
 	@Override
@@ -84,9 +78,8 @@ public class SlimeSizeSpell extends TargetedSpell implements TargetedEntitySpell
 		return isSlimeChecker;
 	}
 
-	private void setSize(LivingEntity caster, LivingEntity target, float power, String[] args) {
-		if (!(target instanceof Slime slime)) return;
-		if (!(caster instanceof Player player)) return;
+	private boolean setSize(LivingEntity caster, LivingEntity target, float power, String[] args) {
+		if (!(target instanceof Slime slime) || !(caster instanceof Player player)) return false;
 
 		int minSize = this.minSize.get(caster, target, power, args);
 		int maxSize = this.maxSize.get(caster, target, power, args);
@@ -97,6 +90,10 @@ public class SlimeSizeSpell extends TargetedSpell implements TargetedEntitySpell
 		double rawOutputValue = variableMod.getValue(player, null, slime.getSize(), power, args);
 		int finalSize = Util.clampValue(minSize, maxSize, (int) rawOutputValue);
 		slime.setSize(finalSize);
+
+		playSpellEffects(caster, target, power, args);
+
+		return true;
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -237,10 +237,10 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			switch (location.toLowerCase()) {
 				case "focus" -> {
 					loc = getRandomLocationFrom(caster.getLocation(), 3);
-					TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-					if (targetInfo == null) return noTarget(caster);
-					target = targetInfo.getTarget();
-					power = targetInfo.getPower();
+					TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+					if (info.noTarget()) return noTarget(caster, args, info);
+					target = info.target();
+					power = info.power();
 				}
 				case "target" -> {
 					Block block = getTargetedBlock(caster, power, args);
@@ -259,7 +259,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				}
 			}
 
-			if (loc == null) return noTarget(caster);
+			if (loc == null) return noTarget(caster, args);
 			spawnMob(caster, caster.getLocation(), loc, target, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/StunSpell.java
@@ -72,14 +72,17 @@ public class StunSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster);
-			LivingEntity target = targetInfo.getTarget();
-			power = targetInfo.getPower();
+			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
+
+			LivingEntity target = targetInfo.target();
+			power = targetInfo.power();
 
 			stunLivingEntity(caster, target, power, args);
 			sendMessages(caster, target, args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -99,7 +99,7 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 					target = players.get(0);
 				}
 			}
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 
 			// Teleport player
 			String displayName = Util.getStringFromComponent(player.displayName());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchHealthSpell.java
@@ -24,12 +24,12 @@ public class SwitchHealthSpell extends TargetedSpell implements TargetedEntitySp
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			boolean ok = switchHealth(caster, target.getTarget(), power, args);
-			if (!ok) return noTarget(caster);
+			boolean ok = switchHealth(caster, target.target(), target.power(), args);
+			if (!ok) return noTarget(caster, args);
 
-			sendMessages(caster, target.getTarget(), args);
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SwitchSpell.java
@@ -24,13 +24,14 @@ public class SwitchSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target.noTarget()) return noTarget(caster, args, target);
 			
-			playSpellEffects(caster, target.getTarget(), power, args);
-			switchPlaces(caster, target.getTarget(), target.getPower(), args);
-			sendMessages(caster, target.getTarget(), args);
+			switchPlaces(caster, target.target(), target.power(), args);
+			sendMessages(caster, target.target(), args);
+
 			return PostCastAction.NO_MESSAGES;
 		}
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
@@ -59,6 +60,8 @@ public class SwitchSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		int switchBack = this.switchBack.get(caster, target, power, args);
 		if (switchBack <= 0) return;
+
+		playSpellEffects(caster, target, power, args);
 
 		MagicSpells.scheduleDelayedTask(() -> {
 			if (caster.isDead() || target.isDead()) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
@@ -42,16 +42,15 @@ public class TelekinesisSpell extends TargetedSpell implements TargetedLocationS
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL && caster instanceof Player) {
 			Block target = getTargetedBlock(caster, power, args);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 
 			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, target.getLocation(), power, args);
-			EventUtil.call(event);
-			if (event.isCancelled()) return noTarget(caster);
+			if (!event.callEvent()) return noTarget(caster, args);
 			
 			target = event.getTargetLocation().getBlock();
 
 			boolean activated = activate((Player) caster, target);
-			if (!activated) return noTarget(caster);
+			if (!activated) return noTarget(caster, args);
 
 			playSpellEffects(caster, target.getLocation(), power, args);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TeleportSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TeleportSpell.java
@@ -37,10 +37,11 @@ public class TeleportSpell extends TargetedSpell implements TargetedEntitySpell 
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster);
-			if (!teleport(caster, target.getTarget(), target.getPower(), args)) return noTarget(caster, strCantTeleport);
+			if (target.noTarget()) return noTarget(caster, args, target);
 
-			sendMessages(caster, target.getTarget(), args);
+			if (!teleport(caster, target.target(), target.power(), args)) return noTarget(caster, strCantTeleport, args);
+
+			sendMessages(caster, target.target(), args);
 			return PostCastAction.NO_MESSAGES;
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -204,18 +204,18 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			Block target = null;
 
 			if (lastTwo != null && lastTwo.size() == 2) target = lastTwo.get(0);
-			if (target == null) return noTarget(caster);
+			if (target == null) return noTarget(caster, args);
 
 			int yOffset = this.yOffset.get(caster, null, power, args);
 			if (yOffset > 0) target = target.getRelative(BlockFace.UP, yOffset);
 			else if (yOffset < 0) target = target.getRelative(BlockFace.DOWN, yOffset);
 			if (!BlockUtils.isAir(target.getType()) && target.getType() != Material.SNOW && target.getType() != Material.TALL_GRASS)
-				return noTarget(caster);
+				return noTarget(caster, args);
 
 			if (target != null) {
 				SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, target.getLocation(), power);
 				EventUtil.call(event);
-				if (event.isCancelled()) return noTarget(caster);
+				if (event.isCancelled()) return noTarget(caster, args);
 				target = event.getTargetLocation().getBlock();
 				power = event.getPower();
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TransmuteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TransmuteSpell.java
@@ -49,14 +49,14 @@ public class TransmuteSpell extends TargetedSpell implements TargetedLocationSpe
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			Block block = getTargetedBlock(caster, power, args);
-			if (block == null) return noTarget(caster);
+			if (block == null) return noTarget(caster, args);
 			
 			SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, caster, block.getLocation(), power);
 			EventUtil.call(event);
-			if (event.isCancelled()) return noTarget(caster);
+			if (event.isCancelled()) return noTarget(caster, args);
 			block = event.getTargetLocation().getBlock();
 			
-			if (!canTransmute(block)) return noTarget(caster);
+			if (!canTransmute(block)) return noTarget(caster, args);
 
 			block.setType(transmuteType);
 			playSpellEffects(caster, block.getLocation().add(0.5, 0.5, 0.5), power, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TreeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TreeSpell.java
@@ -54,10 +54,10 @@ public class TreeSpell extends TargetedSpell implements TargetedLocationSpell {
 				else target = event.getTargetLocation().getBlock();
 			}
 			
-			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster);
+			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster, args);
 			
 			boolean grown = growTree(caster, target, power, args);
-			if (!grown) return noTarget(caster);
+			if (!grown) return noTarget(caster, args);
 
 			playSpellEffects(caster, target.getLocation(), power, args);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
@@ -36,11 +36,11 @@ public class VinesSpell extends TargetedSpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			List<Block> target = getLastTwoTargetedBlocks(caster, power, args);
-			if (target == null || target.size() != 2) return noTarget(caster);
-			if (target.get(0).getType() != Material.AIR || !target.get(1).getType().isSolid()) return noTarget(caster);
+			if (target == null || target.size() != 2) return noTarget(caster, args);
+			if (target.get(0).getType() != Material.AIR || !target.get(1).getType().isSolid()) return noTarget(caster, args);
 
 			boolean success = growVines(caster, target.get(0), target.get(1), power, args);
-			if (!success) return noTarget(caster);
+			if (!success) return noTarget(caster, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -87,7 +87,7 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 			} catch (IllegalStateException e) {
 				target = null;
 			}
-			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster);
+			if (target == null || BlockUtils.isAir(target.getType())) return noTarget(caster, args);
 			volley(caster, null, caster.getLocation(), target.getLocation(), power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
@@ -84,11 +84,11 @@ public class ZapSpell extends TargetedSpell implements TargetedLocationSpell {
 				if (event.isCancelled()) target = null;
 				else target = event.getTargetLocation().getBlock();
 			}
-			if (target == null) return noTarget(caster, strCantZap);
+			if (target == null) return noTarget(caster, strCantZap, args);
 
-			if (!canZap(target)) return noTarget(caster, strCantZap);
+			if (!canZap(target)) return noTarget(caster, strCantZap, args);
 			boolean ok = zap(target, (Player) caster, power, args);
-			if (!ok) return noTarget(caster, strCantZap);
+			if (!ok) return noTarget(caster, strCantZap, args);
 
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
@@ -11,11 +11,11 @@ import org.bukkit.inventory.ItemStack;
 
 public class MobUtil {
 
-	static Map<String, EntityType> entityTypeMap = new HashMap<>();
+	private static final Map<EntityType, Material> entityToEggMaterial = new HashMap<>();
+	private static final Map<String, EntityType> entityTypeMap = new HashMap<>();
 
 	static {
 		for (EntityType type : EntityType.values()) {
-			if (type == null) continue;
 			if (type == EntityType.UNKNOWN) continue;
 
 			entityTypeMap.put(type.name().toLowerCase(), type);
@@ -23,6 +23,9 @@ public class MobUtil {
 
 			entityTypeMap.put(type.getKey().getKey(), type);
 			entityTypeMap.put(type.getKey().getKey().replace("_", ""), type);
+
+			Material material = Util.getMaterial(type.getKey().getKey() + "_SPAWN_EGG");
+			if (material != null) entityToEggMaterial.put(type, material);
 		}
 
 		Map<String, EntityType> types = new HashMap<>();
@@ -38,10 +41,14 @@ public class MobUtil {
 	}
 
 	public static ItemStack getEggItemForEntityType(EntityType type) {
-		Material eggMaterial = Util.getMaterial(type.getKey().getKey() + "_SPAWN_EGG");
+		Material eggMaterial = entityToEggMaterial.get(type);
 		if (eggMaterial == null) return null;
 
 		return new ItemStack(eggMaterial);
+	}
+
+	public static boolean hasEggMaterialForEntityType(EntityType type) {
+		return entityToEggMaterial.containsKey(type);
 	}
 
 	public static void setTarget(LivingEntity mob, LivingEntity target) {

--- a/core/src/main/java/com/nisovin/magicspells/util/TargetInfo.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TargetInfo.java
@@ -2,22 +2,14 @@ package com.nisovin.magicspells.util;
 
 import org.bukkit.entity.Entity;
 
-public class TargetInfo<E extends Entity> {
+public record TargetInfo<E extends Entity>(E target, float power, boolean cancelled) {
 
-	private E target;
-	private float power;
-	
-	public TargetInfo(E target, float power) {
-		this.target = target;
-		this.power = power;
+	public boolean empty() {
+		return target == null;
 	}
-	
-	public E getTarget() {
-		return target;
+
+	public boolean noTarget() {
+		return cancelled || target == null;
 	}
-	
-	public float getPower() {
-		return power;
-	}
-	
+
 }


### PR DESCRIPTION
Bugfixes:
- All entities that do not pass a spell's valid target checker are now filtered before, not after, targeting events are fired.
- Various spells now no longer target entity types that the spell cannot be applied to. This is not related to the spell's `can-target`. Examples include:
	+ All spells that only target players will now no longer attempt to target or fire targeting events for non-player entities, such as `PlayerMenuSpell` and `CloseMenuSpell`.
	+ `AgeSpell` now only targets entities that implement `Ageable`.
	+ `CaptureSpell` now only targets entities that have a corresponding mob egg.
	+ `RegrowSpell` now only targets sheep.
	+ `ShearSpell` now only targets sheep.
	+ `SlimeSizeSpell` now only targets slimes.
- Using a `castinstead` within `target-modifiers` now properly cancels a spell cast.
- Many targeted entitiy spells will now properly send targeted messages.
- Many targeted entitiy spells will now properly play spell effects.
- `str-no-target` and other messages sent when a target is not found will now properly support argument substitution.
- `ResourcePackSpell` will now properly set the target's resource pack, rather than the caster.

Changes:
- Replaced usages of `StringBuffer` with `StringBuilder`.

Additions:
- `PlayerMenuSpell` now plays effects in position `DISABLED` when the menu is closed.
- `ResourcePackSpell` can now be casted as a targeted entity subspell.
- `TagEntitySpell` now supports targeted variable replacement and argument substitution for `tag`.