### PR TITLE
Add `follow-yaw` option to OrbitSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -61,7 +61,7 @@ import net.kyori.adventure.text.Component;
 
 public abstract class Spell implements Comparable<Spell>, Listener {
 
-	protected Random random = ThreadLocalRandom.current();
+	protected static final Random random = ThreadLocalRandom.current();
 
 	protected MagicConfig config;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -39,7 +39,6 @@ import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
-	private final static ThreadLocalRandom random = ThreadLocalRandom.current();
 	private static boolean deathRegistered;
 
 	private final Multimap<UUID, Loop> activeLoops = HashMultimap.create();

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -406,7 +406,7 @@ public class Util {
 		return false;
 	}
 
-	public static void rotateVector(Vector v, float degrees) {
+	public static void rotateVector(Vector v, double degrees) {
 		double rad = FastMath.toRadians(degrees);
 		double sin = FastMath.sin(rad);
 		double cos = FastMath.cos(rad);


### PR DESCRIPTION
- Added `follow-yaw` option to OrbitSpell. When `true`, the orbit rotates to match the change in the target's yaw.