### PR TITLE
Cleanup, apply attributes before spawning entity

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
@@ -57,20 +57,19 @@ public class ArmorStandEffect extends SpellEffect {
 
 	@Override
 	protected ArmorStand playArmorStandEffectLocation(Location location, SpellData data) {
-		if (!entityData.isVisible()) location.setY(450);
+		return (ArmorStand) entityData.spawn(location, entity -> {
+			ArmorStand armorStand = (ArmorStand) entity;
 
-		ArmorStand armorStand = (ArmorStand) entityData.spawn(location);
-		armorStand.addScoreboardTag(ENTITY_TAG);
-		armorStand.setGravity(gravity);
-		armorStand.setSilent(true);
-		armorStand.setCustomName(customName);
-		armorStand.setCustomNameVisible(customNameVisible);
+			armorStand.addScoreboardTag(ENTITY_TAG);
+			armorStand.setGravity(gravity);
+			armorStand.setSilent(true);
+			armorStand.setCustomName(customName);
+			armorStand.setCustomNameVisible(customNameVisible);
 
-		if (headItem != null) armorStand.setItem(EquipmentSlot.HEAD, headItem);
-		if (mainhandItem != null) armorStand.setItem(EquipmentSlot.HAND, mainhandItem);
-		if (offhandItem != null) armorStand.setItem(EquipmentSlot.OFF_HAND, offhandItem);
-
-		return armorStand;
+			if (headItem != null) armorStand.setItem(EquipmentSlot.HEAD, headItem);
+			if (mainhandItem != null) armorStand.setItem(EquipmentSlot.HAND, mainhandItem);
+			if (offhandItem != null) armorStand.setItem(EquipmentSlot.OFF_HAND, offhandItem);
+		});
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -33,12 +33,13 @@ public class EntityEffect extends SpellEffect {
 
 	@Override
 	protected Entity playEntityEffectLocation(Location location, SpellData data) {
-		Entity entity = entityData.spawn(location);
-		entity.addScoreboardTag(ENTITY_TAG);
-		entity.setGravity(gravity);
-		entity.setSilent(silent);
-		if (entity instanceof LivingEntity) ((LivingEntity) entity).setAI(enableAI);
-		return entity;
+		return entityData.spawn(location, entity -> {
+			entity.addScoreboardTag(ENTITY_TAG);
+			entity.setGravity(gravity);
+			entity.setSilent(silent);
+
+			if (entity instanceof LivingEntity livingEntity) livingEntity.setAI(enableAI);
+		});
 	}
 
 }


### PR DESCRIPTION
- Fixed an issue where `main-gene` was used instead of `hidden-gene` for setting a panda's hidden gene.
- Attributes/options of entities spawned with `EntityData` are now applied before the entity is spawned.