### PR TITLE
Magic item additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/DurabilityHandler.java
@@ -28,7 +28,6 @@ public class DurabilityHandler {
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof Damageable damageableMeta)) return;
-		if (!damageableMeta.hasDamage()) return;
 		data.setAttribute(DURABILITY, damageableMeta.getDamage());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -34,6 +34,7 @@ public class MagicItemData {
     private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
 
     private boolean strictEnchantLevel = true;
+    private boolean strictDurability = true;
     private boolean strictEnchants = true;
 
     public Object getAttribute(MagicItemAttribute attr) {
@@ -69,6 +70,14 @@ public class MagicItemData {
 
     public void setStrictEnchantLevel(boolean strictEnchantLevel) {
         this.strictEnchantLevel = strictEnchantLevel;
+    }
+
+    public boolean isStrictDurability() {
+        return strictDurability;
+    }
+
+    public void setStrictDurability(boolean strictDurability) {
+        this.strictDurability = strictDurability;
     }
 
     public boolean isStrictEnchants() {
@@ -144,6 +153,13 @@ public class MagicItemData {
                 case ATTRIBUTES -> {
                     if (!hasEqualAttributes(data)) return false;
                 }
+                case DURABILITY -> {
+                    Integer durabilitySelf = (Integer) itemAttributes.get(attr);
+                    Integer durabilityOther = (Integer) data.itemAttributes.get(attr);
+
+                    int compare = durabilitySelf.compareTo(durabilityOther);
+                    if (strictDurability ? compare != 0 : compare < 0) return false;
+                }
                 case ENCHANTS -> {
                     if (strictEnchants && strictEnchantLevel) {
                         if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
@@ -164,7 +180,7 @@ public class MagicItemData {
                         Integer levelOther = enchantsOther.get(enchant);
 
                         int compare = levelSelf.compareTo(levelOther);
-                        if ((strictEnchantLevel && compare != 0) || (!strictEnchantLevel && compare > 0)) return false;
+                        if (strictEnchantLevel ? compare != 0 : compare > 0) return false;
                     }
                 }
                 default -> {
@@ -752,6 +768,14 @@ public class MagicItemData {
             else output.append('{');
 
             output.append("\"strict-enchants\": false");
+            previous = true;
+        }
+
+        if (!strictDurability) {
+            if (previous) output.append(',');
+            else output.append('{');
+
+            output.append("\"strict-durability\": false");
             previous = true;
         }
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -60,7 +60,7 @@ public class MagicItemDataParser {
 		String[] args = str.split("\\{", 2);
 		// check if it contains additional data
 		if (args.length < 2) {
-			// it doesnt, check if its a material type
+			// it doesn't, check if it's a material type
 			Material type = Util.getMaterial(str.trim());
 			if (type == null) return null;
 
@@ -431,6 +431,11 @@ public class MagicItemDataParser {
 						case "strict-enchants":
 						case "strict_enchants":
 							data.setStrictEnchants(value.getAsBoolean());
+							break;
+						case "strictdurability":
+						case "strict-durability":
+						case "strict_durability":
+							data.setStrictDurability(value.getAsBoolean());
 							break;
 						case "strictenchantlevel":
 						case "strict-enchant-level":

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -70,20 +70,27 @@ public class MagicItemDataParser {
 			return magicItemData;
 		}
 
+		String base = args[0].trim();
 		args[1] = "{" + args[1];
 
-		Material type;
+		MagicItemData data;
 
-		type = Util.getMaterial(args[0].trim());
-		if (type == null) return null;
+		Material type = Util.getMaterial(base);
+		if (type != null) {
+			data = new MagicItemData();
+			data.setAttribute(TYPE, type);
+
+			if (type.isAir()) return data;
+		} else {
+			MagicItem magicItem = MagicItems.getMagicItems().get(base);
+			if (magicItem == null) return null;
+			data = magicItem.getMagicItemData().clone();
+
+			if (data.hasAttribute(TYPE) && ((Material) data.getAttribute(TYPE)).isAir()) return data;
+		}
 
 		JsonReader jsonReader = new JsonReader(new StringReader(args[1]));
 		jsonReader.setLenient(true);
-
-		MagicItemData data = new MagicItemData();
-		data.setAttribute(TYPE, type);
-
-		if (type.isAir()) return data;
 
 		try {
 			while (jsonReader.peek() != JsonToken.END_DOCUMENT) {

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -325,6 +325,9 @@ public class MagicItems {
 				if (section.isBoolean("strict-enchants"))
 					magicItem.getMagicItemData().setStrictEnchants(section.getBoolean("strict-enchants"));
 
+				if (section.isBoolean("strict-durability"))
+					magicItem.getMagicItemData().setStrictDurability(section.getBoolean("strict-durability"));
+
 				if (section.isBoolean("strict-enchant-level"))
 					magicItem.getMagicItemData().setStrictEnchantLevel(section.getBoolean("strict-enchant-level"));
 
@@ -523,6 +526,9 @@ public class MagicItems {
 
 			if (section.isBoolean("strict-enchants"))
 				itemData.setStrictEnchants(section.getBoolean("strict-enchants"));
+
+			if (section.isBoolean("strict-durability"))
+				itemData.setStrictDurability(section.getBoolean("strict-durability"));
 
 			if (section.isBoolean("strict-enchant-level"))
 				itemData.setStrictEnchantLevel(section.getBoolean("strict-enchant-level"));


### PR DESCRIPTION
- Added `strict-durability` option. When `strict-durability: false`, magic items being matched instead only have to have at most the same durability damage as configured, instead of exactly the same.
- When parsing a magic item using the string format, a pre-existing magic item can now be used in place of the material type to use it as base reference for options.