### PR TITLE
`cast-on-animate` improvements

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -15,6 +15,7 @@ import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.entity.EntityShootBowEvent;
 import org.bukkit.event.player.PlayerAnimationType;
+import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerAnimationEvent;
@@ -164,7 +165,13 @@ public class CastListener implements Listener {
 
 		castSpell(player);
 	}
-	
+
+	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
+	public void onPlayerDrop(PlayerDropItemEvent event) {
+		if (!MagicSpells.isCastingOnAnimate()) return;
+		noCastUntil.put(event.getPlayer().getName(), System.currentTimeMillis() + 150);
+	}
+
 	@EventHandler
 	public void onPlayerShootBow(EntityShootBowEvent event) {
 		if (!(event.getEntity() instanceof Player player)) return;

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -14,6 +14,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.entity.EntityShootBowEvent;
+import org.bukkit.event.player.PlayerAnimationType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerAnimationEvent;
@@ -149,19 +150,19 @@ public class CastListener implements Listener {
 
 	@EventHandler(priority=EventPriority.MONITOR, ignoreCancelled = true)
 	public void onPlayerAnimation(PlayerAnimationEvent event) {
-		if (MagicSpells.isCastingOnAnimate()) {
-			Player player = event.getPlayer();
+		if (!MagicSpells.isCastingOnAnimate() || event.getAnimationType() != PlayerAnimationType.ARM_SWING) return;
 
-			InventoryType type = player.getOpenInventory().getType();
-			if (type != InventoryType.CRAFTING && type != InventoryType.CREATIVE) return;
+		Player player = event.getPlayer();
 
-			if (MagicSpells.areBowCycleButtonsReversed()) {
-				ItemStack inHand = player.getInventory().getItemInMainHand();
-				if (isBow(inHand.getType())) return;
-			}
+		InventoryType type = player.getOpenInventory().getType();
+		if (type != InventoryType.CRAFTING && type != InventoryType.CREATIVE) return;
 
-			castSpell(player);
+		if (MagicSpells.areBowCycleButtonsReversed()) {
+			ItemStack inHand = player.getInventory().getItemInMainHand();
+			if (isBow(inHand.getType())) return;
 		}
+
+		castSpell(player);
 	}
 	
 	@EventHandler


### PR DESCRIPTION
- Check if the hand animating is the main hand if `cast-on-animate: true`.
- Apply global cooldown after a player drops an item to prevent casting when `cast-on-animate: true`.