### PR TITLE
Effect bugfix, CreatureTargetSpell refactor

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1446,20 +1446,33 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		playSpellEffectsTrail(caster.getLocation(), target, data);
 	}
 
-	@Deprecated
-	protected void playSpellEffects(Location startLoc, Entity target) {
-		playSpellEffects(startLoc, target, null);
+	protected void playSpellEffects(Entity caster, Location from, Entity target, float power, String[] args) {
+		SpellData data = new SpellData(caster instanceof LivingEntity le ? le : null, target instanceof LivingEntity le ? le : null, power, args);
+		playSpellEffects(caster, from, target, data);
 	}
 
-	protected void playSpellEffects(Location startLoc, Entity target, float power, String[] args) {
-		SpellData data = new SpellData(null, target instanceof LivingEntity le ? le : null, power, args);
-		playSpellEffects(startLoc, target, data);
-	}
-
-	protected void playSpellEffects(Location startLoc, Entity target, SpellData data) {
-		playSpellEffects(EffectPosition.START_POSITION, startLoc, data);
+	protected void playSpellEffects(Entity caster, Location from, Entity target, SpellData data) {
+		playSpellEffects(EffectPosition.CASTER, caster, data);
 		playSpellEffects(EffectPosition.TARGET, target, data);
-		playSpellEffectsTrail(startLoc, target.getLocation(), data);
+		playSpellEffects(EffectPosition.START_POSITION, from, data);
+		playSpellEffects(EffectPosition.END_POSITION, target, data);
+		playSpellEffectsTrail(from, target.getLocation(), data);
+	}
+
+	@Deprecated
+	protected void playSpellEffects(Location from, Entity target) {
+		playSpellEffects(from, target, null);
+	}
+
+	protected void playSpellEffects(Location from, Entity target, float power, String[] args) {
+		SpellData data = new SpellData(null, target instanceof LivingEntity le ? le : null, power, args);
+		playSpellEffects(from, target, data);
+	}
+
+	protected void playSpellEffects(Location from, Entity target, SpellData data) {
+		playSpellEffects(EffectPosition.START_POSITION, from, data);
+		playSpellEffects(EffectPosition.TARGET, target, data);
+		playSpellEffectsTrail(from, target.getLocation(), data);
 	}
 
 	@Deprecated

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1471,6 +1471,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	protected void playSpellEffects(Location from, Entity target, SpellData data) {
 		playSpellEffects(EffectPosition.START_POSITION, from, data);
+		playSpellEffects(EffectPosition.END_POSITION, target, data);
 		playSpellEffects(EffectPosition.TARGET, target, data);
 		playSpellEffectsTrail(from, target.getLocation(), data);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -382,7 +382,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		ParticleProjectileTracker tracker = new ParticleProjectileTracker(caster, power, args);
 		setupTracker(tracker, caster, target, power, args);
 		tracker.startTarget(from, target);
-		playSpellEffects(from, target, tracker.getSpellData());
+		playSpellEffects(caster, from, target, tracker.getSpellData());
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
@@ -1,18 +1,14 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import org.bukkit.Location;
 import org.bukkit.entity.Creature;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.spelleffects.EffectPosition;
-import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
+import com.nisovin.magicspells.spells.InstantSpell;
 
-public class CreatureTargetSpell extends TargetedSpell implements TargetedEntitySpell, TargetedEntityFromLocationSpell {
+public class CreatureTargetSpell extends InstantSpell {
 
 	private String targetSpellName;
 	private Subspell targetSpell;
@@ -42,68 +38,14 @@ public class CreatureTargetSpell extends TargetedSpell implements TargetedEntity
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
-	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		castSpells(caster, power, args);
-		return true;
-	}
+	private void castSpells(LivingEntity caster, float power, String[] args) {
+		if (!(caster instanceof Creature creature)) return;
 
-	@Override
-	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		castSpells(caster, power, null);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
-		if (!validTargetList.canTarget(target)) return false;
-		playSpellEffects(EffectPosition.TARGET, target, power, args);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntity(LivingEntity target, float power) {
-		if (!validTargetList.canTarget(target)) return false;
-		playSpellEffects(EffectPosition.TARGET, target, power, null);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power, String[] args) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		castSpells(caster, power, args);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power) {
-		if (!validTargetList.canTarget(caster, target)) return false;
-		castSpells(caster, power, null);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntityFromLocation(Location from, LivingEntity target, float power, String[] args) {
-		if (!validTargetList.canTarget(target)) return false;
-		playSpellEffects(from, target, power, args);
-		return true;
-	}
-
-	@Override
-	public boolean castAtEntityFromLocation(Location from, LivingEntity target, float power) {
-		if (!validTargetList.canTarget(target)) return false;
-		playSpellEffects(from, target, power, null);
-		return true;
-	}
-
-	private void castSpells(LivingEntity livingEntity, float power, String[] args) {
-		if (!(livingEntity instanceof Creature caster)) return;
-		LivingEntity target = caster.getTarget();
+		LivingEntity target = creature.getTarget();
 		if (target == null || !target.isValid()) return;
 
 		playSpellEffects(caster, target, power, args);
+
 		if (targetSpell == null) return;
 		if (targetSpell.isTargetedEntityFromLocationSpell()) targetSpell.castAtEntityFromLocation(caster, caster.getLocation(), target, power);
 		else if (targetSpell.isTargetedLocationSpell()) targetSpell.castAtLocation(caster, target.getLocation(), power);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DestroySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DestroySpell.java
@@ -152,7 +152,7 @@ public class DestroySpell extends TargetedSpell implements TargetedLocationSpell
 	@Override
 	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power, String[] args) {
 		doIt(caster, target, from, target.getLocation(), power, args);
-		playSpellEffects(from, target, new SpellData(caster, target, power, args));
+		playSpellEffects(caster, from, target, new SpellData(caster, target, power, args));
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DummySpell.java
@@ -89,14 +89,14 @@ public class DummySpell extends TargetedSpell implements TargetedEntitySpell, Ta
 	@Override
 	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power, String[] args) {
 		if (!validTargetList.canTarget(caster, target)) return false;
-		playSpellEffects(from, target, new SpellData(caster, target, power, args));
+		playSpellEffects(caster, from, target, new SpellData(caster, target, power, args));
 		return true;
 	}
 
 	@Override
 	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power) {
 		if (!validTargetList.canTarget(caster, target)) return false;
-		playSpellEffects(from, target, new SpellData(caster, target, power, null));
+		playSpellEffects(caster, from, target, new SpellData(caster, target, power, null));
 		return true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -418,7 +418,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			MagicSpells.scheduleDelayedTask(() -> HandlerList.unregisterAll(monitor), duration > 0 ? duration : 12000);
 		}
 
-		if (caster != null) playSpellEffects(caster, entity, power, args);
+		if (caster != null) playSpellEffects(caster, source, entity, power, args);
 		else playSpellEffects(source, entity, power, args);
 
 		entities.add(entity);


### PR DESCRIPTION
- Fixed an issue where `EffectPosition.CASTER` would not be played in certain instances where a spell was casted at an entity from a location. Note: effects played in `EffectPosition.CASTER` now play at the caster's location, not the `from` location as was in older versions.
- Refactored `CreatureTargetSpell` to be an instant spell, as the spell does not use a target. Still located in the `targeted` package to maintain compatibility.