### PR TITLE
Changes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -23,6 +23,7 @@ import org.bukkit.util.BlockIterator;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventPriority;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -803,6 +804,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	protected <T extends Enum<T>> ConfigData<T> getConfigDataEnum(String key, Class<T> type, T def) {
 		return ConfigDataUtil.getEnum(config.getMainConfig(), "spells." + internalName + '.' + key, type, def);
+	}
+
+	protected ConfigData<BlockData> getConfigDataBlockData(String key, BlockData def) {
+		return ConfigDataUtil.getBlockData(config.getMainConfig(), "spells." + internalName + '.' + key, def);
 	}
 
 	protected boolean isConfigString(String key) {

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemCooldownEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemCooldownEffect.java
@@ -19,7 +19,7 @@ public class ItemCooldownEffect extends SpellEffect {
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		duration = ConfigDataUtil.getInteger(config, "duration", TimeUtil.TICKS_PER_SECOND);
-		type = ConfigDataUtil.getEnum(config, "item", Material.class, Material.STONE);
+		type = ConfigDataUtil.getMaterial(config, "item", Material.STONE);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemSprayEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemSprayEffect.java
@@ -31,7 +31,7 @@ public class ItemSprayEffect extends SpellEffect {
 
 	@Override
 	public void loadFromConfig(ConfigurationSection config) {
-		material = ConfigDataUtil.getEnum(config, "type", Material.class, null);
+		material = ConfigDataUtil.getMaterial(config, "type", null);
 
 		force = ConfigDataUtil.getDouble(config, "force", 1);
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesEffect.java
@@ -55,7 +55,7 @@ public class ParticlesEffect extends SpellEffect {
 	public void loadFromConfig(ConfigurationSection config) {
 		particle = ConfigDataUtil.getParticle(config, "particle-name", Particle.EXPLOSION_NORMAL);
 
-		material = ConfigDataUtil.getEnum(config, "material", Material.class, null);
+		material = ConfigDataUtil.getMaterial(config, "material", null);
 		blockData = ConfigDataUtil.getBlockData(config, "material", null);
 		dustOptions = ConfigDataUtil.getDustOptions(config, "color", "size", new DustOptions(Color.RED, 1));
 		dustTransition = ConfigDataUtil.getDustTransition(config, "color", "to-color", "size", new DustTransition(Color.RED, Color.BLACK, 1));

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -73,9 +73,7 @@ public class Util {
 	}
 
 	public static Material getMaterial(String name) {
-		Material m = Material.getMaterial(name.toUpperCase());
-		if (m == null) m = Material.matchMaterial(name.toUpperCase());
-		return m;
+		return Material.matchMaterial(name);
 	}
 
 	// - <potionEffectType> (level) (duration) (ambient)

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -8,21 +8,22 @@ import java.util.regex.Pattern;
 
 import de.slikey.exp4j.Expression;
 
-import org.bukkit.Bukkit;
 import org.bukkit.Color;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.Particle;
-import org.bukkit.Particle.DustTransition;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.Particle.DustOptions;
-import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.Particle.DustTransition;
 import org.bukkit.potion.PotionEffectType;
+import org.bukkit.configuration.ConfigurationSection;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.ColorUtil;
 import com.nisovin.magicspells.util.ParticleUtil;
-import com.nisovin.magicspells.util.Util;
 
 public class ConfigDataUtil {
 
@@ -387,6 +388,35 @@ public class ConfigDataUtil {
 
 			};
 		}
+	}
+
+	public static ConfigData<Material> getMaterial(@NotNull ConfigurationSection config, @NotNull String path, @Nullable Material def) {
+		String value = config.getString(path);
+		if (value == null) return (caster, target, power, args) -> def;
+
+		Material val = Util.getMaterial(value);
+		if (val != null) return (caster, target, power, args) -> val;
+
+		ConfigData<String> supplier = getString(value);
+		if (supplier.isConstant()) return (caster, target, power, args) -> def;
+
+		return new ConfigData<>() {
+
+			@Override
+			public Material get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+				String val = supplier.get(caster, target, power, args);
+				if (val == null) return def;
+
+				Material material = Util.getMaterial(val);
+				return material == null ? def : material;
+			}
+
+			@Override
+			public boolean isConstant() {
+				return false;
+			}
+
+		};
 	}
 
 	@NotNull

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -366,6 +366,7 @@ public class ConfigDataUtil {
 			return (caster, target, power, args) -> val;
 		} catch (IllegalArgumentException e) {
 			ConfigData<String> supplier = getString(value);
+			if (supplier.isConstant()) return (caster, target, power, args) -> def;
 
 			return new ConfigData<>() {
 
@@ -383,7 +384,7 @@ public class ConfigDataUtil {
 
 				@Override
 				public boolean isConstant() {
-					return supplier.isConstant();
+					return false;
 				}
 
 			};
@@ -428,6 +429,8 @@ public class ConfigDataUtil {
 		if (type != null) return (caster, target, power, args) -> type;
 
 		ConfigData<String> supplier = getString(value);
+		if (supplier.isConstant()) return (caster, target, power, args) -> def;
+
 		return new ConfigData<>() {
 
 			@Override
@@ -441,7 +444,7 @@ public class ConfigDataUtil {
 
 			@Override
 			public boolean isConstant() {
-				return supplier.isConstant();
+				return false;
 			}
 
 		};
@@ -456,6 +459,8 @@ public class ConfigDataUtil {
 		if (val != null) return (caster, target, power, args) -> val;
 
 		ConfigData<String> supplier = getString(value);
+		if (supplier.isConstant()) return (caster, target, power, args) -> def;
+
 		return new ConfigData<>() {
 
 			@Override
@@ -469,7 +474,7 @@ public class ConfigDataUtil {
 
 			@Override
 			public boolean isConstant() {
-				return supplier.isConstant();
+				return false;
 			}
 
 		};
@@ -485,6 +490,7 @@ public class ConfigDataUtil {
 			return (caster, target, power, args) -> val;
 		} catch (IllegalArgumentException e) {
 			ConfigData<String> supplier = getString(value);
+			if (supplier.isConstant()) return (caster, target, power, args) -> def;
 
 			return new ConfigData<>() {
 
@@ -502,7 +508,7 @@ public class ConfigDataUtil {
 
 				@Override
 				public boolean isConstant() {
-					return supplier.isConstant();
+					return false;
 				}
 
 			};


### PR DESCRIPTION
- Change `Util#getMaterial` to only call `Material#matchMaterial`, instead of falling back to it after calling `Material#getMaterial`.
- Modify spell effects that support variable replacement for `Material` to use new `ConfigDataUtil` method that calls `Util#getMaterial`.
- Modify `ConfigDataUtil` methods that use a `ConfigData<String>` to check if their suppliers are constant, and returning the default value earlier if so.
- Support `BlockData` for `GeyserSpell`.