### PR TITLE
PlaceholderAPI support, ChainSpell bugfix

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/CustomNameCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/CustomNameCondition.java
@@ -1,51 +1,45 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
-import com.nisovin.magicspells.util.Util;
 
-import net.kyori.adventure.text.Component;
+import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 
 import com.nisovin.magicspells.castmodifiers.Condition;
 
 public class CustomNameCondition extends Condition {
 
-	private Component name;
-	private boolean isVar;
+	private boolean requireReplacement;
+	private String name;
 
 	@Override
 	public boolean initialize(String var) {
 		if (var == null || var.isEmpty()) return false;
-		if (var.contains("%var:") || var.contains("%playervar")) isVar = true;
 
-		name = Util.getMiniMessage(var);
+		requireReplacement = MagicSpells.requireReplacement(var);
+		name = var.replace("__", " ");
+
 		return true;
 	}
 
 	@Override
-	public boolean check(LivingEntity livingEntity) {
+	public boolean check(LivingEntity caster) {
 		return false;
 	}
 
 	@Override
-	public boolean check(LivingEntity livingEntity, LivingEntity target) {
-		return checkName(livingEntity, target);
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return checkName(caster, target);
 	}
 
 	@Override
-	public boolean check(LivingEntity livingEntity, Location location) {
+	public boolean check(LivingEntity caster, Location location) {
 		return false;
 	}
 
-	private boolean checkName(LivingEntity livingEntity, LivingEntity target) {
-		if (!(livingEntity instanceof Player pl)) return false;
-
-		String checkedName = Util.getStringFromComponent(name);
-
-		if (isVar) checkedName = Util.doVarReplacement(pl, checkedName);
-		else checkedName = checkedName.replace("__", " ");
-
+	private boolean checkName(LivingEntity caster, LivingEntity target) {
+		String checkedName = requireReplacement ? MagicSpells.doReplacements(name, caster, target) : name;
 		return target.customName() != null && Util.getMiniMessage(checkedName).equals(target.customName());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasScoreboardTagCondition.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -9,12 +8,16 @@ import com.nisovin.magicspells.castmodifiers.Condition;
 
 public class HasScoreboardTagCondition extends Condition {
 
+    private boolean doReplacement;
     private String tag;
 
     @Override
     public boolean initialize(String var) {
         if (var == null || var.isEmpty()) return false;
+
+        doReplacement = MagicSpells.requireReplacement(var);
         tag = var;
+
         return true;
     }
 
@@ -33,10 +36,8 @@ public class HasScoreboardTagCondition extends Condition {
         return false;
     }
 
-    // TODO: Add functionality to check both caster and target variables
     private boolean checkTags(LivingEntity caster, LivingEntity target) {
-        String localTag = tag;
-        if (caster instanceof Player && localTag.contains("%")) localTag = MagicSpells.doVariableReplacements((Player) caster, localTag);
+        String localTag = doReplacement ? MagicSpells.doReplacements(tag, caster, target) : tag;
         return target.getScoreboardTags().contains(localTag);
     }
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/customdata/CustomDataFloat.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/customdata/CustomDataFloat.java
@@ -1,15 +1,15 @@
 package com.nisovin.magicspells.castmodifiers.customdata;
 
-import org.apache.commons.math3.util.Pair;
-
 import org.bukkit.entity.LivingEntity;
 
-import de.slikey.exp4j.Expression;
-
-import com.nisovin.magicspells.events.*;
 import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.events.SpellCastEvent;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.events.ManaChangeEvent;
+import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.util.config.FunctionData;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
+import com.nisovin.magicspells.events.MagicSpellsGenericPlayerEvent;
 
 public class CustomDataFloat extends CustomData {
 
@@ -23,13 +23,17 @@ public class CustomDataFloat extends CustomData {
 			return;
 		}
 
-		Expression expression = FunctionData.buildExpression(data);
-		if (expression == null) {
-			invalidText = "Number or function is invalid.";
-			return;
+		try {
+			float value = Float.parseFloat(data);
+			customData = (caster, target, power, args) -> value;
+		} catch (NumberFormatException e) {
+			customData = FunctionData.build(data, Double::floatValue, 0f);
+			if (customData == null) {
+				invalidText = "Number or function is invalid.";
+				return;
+			}
 		}
 
-		customData = new FunctionData.FloatData(expression, 0f);
 		isValid = true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/TitleEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/TitleEffect.java
@@ -24,7 +24,7 @@ public class TitleEffect extends SpellEffect {
 	private static Duration milisOfTicks(int ticks) {
 		return Duration.ofMillis(TimeUtil.MILLISECONDS_PER_SECOND * (ticks / TimeUtil.TICKS_PER_SECOND));
 	}
-	
+
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
 		title = config.getString("title", "");
@@ -33,11 +33,11 @@ public class TitleEffect extends SpellEffect {
 		int fadeIn = config.getInt("fade-in", 10);
 		int stay = config.getInt("stay", 40);
 		int fadeOut = config.getInt("fade-out", 10);
-		times = Title.Times.of(milisOfTicks(fadeIn), milisOfTicks(stay), milisOfTicks(fadeOut));
+		times = Title.Times.times(milisOfTicks(fadeIn), milisOfTicks(stay), milisOfTicks(fadeOut));
 
 		broadcast = config.getBoolean("broadcast", false);
 	}
-	
+
 	@Override
 	protected Runnable playEffectEntity(Entity entity, SpellData data) {
 		String[] args = data == null ? null : data.args();

--- a/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/ExternalCommandSpell.java
@@ -166,13 +166,18 @@ public class ExternalCommandSpell extends TargetedSpell implements TargetedEntit
 				}
 				
 				int delay = 0;
-				Player varOwner;
-				if (!useTargetVariablesInstead) varOwner = sender instanceof Player player ? player : null;
-				else varOwner = target;
+				LivingEntity varOwner, varTarget;
+				if (useTargetVariablesInstead) {
+					varOwner = target;
+					varTarget = sender instanceof Player player ? player : null;
+				} else {
+					varOwner = sender instanceof Player player ? player : null;
+					varTarget = target;
+				}
 
 				for (String comm : commandToExecute) {
 					if (comm == null || comm.isEmpty()) continue;
-					if (doVariableReplacement) comm = MagicSpells.doArgumentAndVariableSubstitution(comm, varOwner, args);
+					if (doVariableReplacement) comm = MagicSpells.doReplacements(comm, varOwner, varTarget, args);
 					if (args != null && args.length > 0) {
 						for (int i = 0; i < args.length; i++) {
 							comm = comm.replace("%" + (i + 1), args[i]);

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -335,7 +335,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 	private Component translateRawComponent(Component component, Player player, String[] args) {
 		String text = Util.getStringFromComponent(component);
-		text = MagicSpells.doArgumentAndVariableSubstitution(text, player, args);
+		text = MagicSpells.doReplacements(text, player, args);
 		return Util.getMiniMessage(text);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -1,7 +1,5 @@
 package com.nisovin.magicspells.spells;
 
-import java.util.regex.Pattern;
-
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -11,14 +9,10 @@ import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.util.ValidTargetChecker;
 
 public abstract class TargetedSpell extends InstantSpell {
-
-	private static final Pattern chatVarCasterMatchPattern = Pattern.compile("%castervar:[A-Za-z0-9_]+(:[0-9]+)?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-	private static final Pattern chatVarTargetMatchPattern = chatVarCasterMatchPattern;
 
 	protected boolean targetSelf;
 	protected boolean alwaysActivate;
@@ -63,31 +57,11 @@ public abstract class TargetedSpell extends InstantSpell {
 	
 	public void sendMessages(LivingEntity caster, LivingEntity target, String[] args) {
 		String casterName = getTargetName(caster);
-		Player playerCaster = null;
-		if (caster instanceof Player player) playerCaster = player;
-
 		String targetName = getTargetName(target);
-		Player playerTarget = null;
-		if (target instanceof Player player) playerTarget = player;
 
-		if (playerCaster != null)
-			sendMessage(prepareMessage(strCastSelf, playerCaster, playerTarget), caster, args,
-				"%a", casterName, "%t", targetName);
-
-		if (playerTarget != null)
-			sendMessage(prepareMessage(strCastTarget, playerCaster, playerTarget), target, args,
-				"%a", casterName, "%t", targetName);
-
-		sendMessageNear(caster, playerTarget, prepareMessage(strCastOthers, playerCaster, playerTarget), broadcastRange, args,
-			"%a", casterName, "%t", targetName);
-	}
-
-	protected String prepareMessage(String message, Player caster, Player playerTarget) {
-		if (message == null || message.isEmpty()) return message;
-
-		message = MagicSpells.doTargetedVariableReplacements(caster, playerTarget, message);
-
-		return message;
+		sendMessage(strCastSelf, caster, caster, target, args, "%a", casterName, "%t", targetName);
+		sendMessage(strCastTarget, target, caster, target, args, "%a", casterName, "%t", targetName);
+		sendMessageNear(caster, target, strCastOthers, args, "%a", casterName, "%t", targetName);
 	}
 
 	protected String getTargetName(LivingEntity target) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureBookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ConjureBookSpell.java
@@ -116,11 +116,11 @@ public class ConjureBookSpell extends InstantSpell implements TargetedLocationSp
 		return castAtLocation(null, target, power, null);
 	}
 
-	private static Component createComponent(String raw, Player player, String displayName) {
+	private static Component createComponent(String raw, Player player, String displayName, String[] args) {
 		if (player != null) {
 			raw = RegexUtil.replaceAll(NAME_VARIABLE_PATTERN, raw, player.getName());
 			if (displayName != null) raw = RegexUtil.replaceAll(DISPLAY_NAME_VARIABLE_PATTERN, raw, displayName);
-			raw = MagicSpells.doVariableReplacements(player, raw);
+			raw = MagicSpells.doReplacements(raw, player, args);
 		}
 		return Util.getMiniMessage(raw);
 	}
@@ -149,17 +149,17 @@ public class ConjureBookSpell extends InstantSpell implements TargetedLocationSp
 
 		List<Component> pagesRaw = new ArrayList<>();
 		for (String page : pages) {
-			pagesRaw.add(createComponent(page, player, playerDisplayName));
+			pagesRaw.add(createComponent(page, player, playerDisplayName, args));
 		}
 		List<Component> loreRaw = new ArrayList<>();
 		for (String line : lore) {
-			loreRaw.add(createComponent(line, player, playerDisplayName));
+			loreRaw.add(createComponent(line, player, playerDisplayName, args));
 		}
 
 		ItemStack item = new ItemStack(Material.WRITTEN_BOOK);
 		BookMeta meta = (BookMeta) ((BookMeta) item.getItemMeta())
-				.title(createComponent(title, player, playerDisplayName))
-				.author(createComponent(author, player, playerDisplayName))
+				.title(createComponent(title, player, playerDisplayName, args))
+				.author(createComponent(author, player, playerDisplayName, args))
 				.pages(pagesRaw);
 		meta.lore(loreRaw);
 		item.setItemMeta(meta);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/DowseSpell.java
@@ -174,7 +174,7 @@ public class DowseSpell extends InstantSpell {
 			playSpellEffects(EffectPosition.CASTER, player, power, args);
 			if (getDistance) {
 				sendMessage(strCastSelf, player, args, "%d", distance + "");
-				sendMessageNear(player, strCastOthers);
+				sendMessageNear(player, strCastOthers, args, "%d", String.valueOf(distance));
 				return PostCastAction.NO_MESSAGES;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -4,8 +4,6 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 
-import org.apache.commons.math3.util.Pair;
-
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -20,8 +18,6 @@ import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.EntityChangeBlockEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
-
-import de.slikey.exp4j.Expression;
 
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.util.Util;
@@ -81,10 +77,8 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				int fuse = Integer.parseInt(split[1]);
 				tntFuse = (caster, target, power, args) -> fuse;
 			} catch (NumberFormatException e) {
-				Expression ex = FunctionData.buildExpression(split[1]);
-
-				tntFuse = ex == null ? null : new FunctionData.IntegerData(ex, 0);
-				if (ex == null) MagicSpells.error("Invalid tnt fuse '" + split[1] + "' for ThrowBlockSpell '" + internalName + "'.");
+				tntFuse = FunctionData.build(split[1], Double::intValue, 0);
+				if (tntFuse == null) MagicSpells.error("Invalid tnt fuse '" + split[1] + "' for ThrowBlockSpell '" + internalName + "'.");
 			}
 		} else {
 			material = Util.getMaterial(materialName);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -184,15 +184,12 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		} else new ChainBouncer(caster, start, targets, targetPowers, interval, args);
 	}
 
-	private boolean castSpellAt(LivingEntity caster, Location from, LivingEntity target, float power) {
+	private void castSpellAt(LivingEntity caster, Location from, LivingEntity target, float power) {
 		if (spellToCast.isTargetedEntityFromLocationSpell() && from != null)
-			return spellToCast.castAtEntityFromLocation(caster, from, target, power);
-		if (spellToCast.isTargetedEntitySpell())
-			return spellToCast.castAtEntity(caster, target, power);
-		if (spellToCast.isTargetedLocationSpell())
-			return spellToCast.castAtLocation(caster, target.getLocation(), power);
-
-		return true;
+			spellToCast.castAtEntityFromLocation(caster, from, target, power);
+		if (spellToCast.isTargetedEntitySpell()) spellToCast.castAtEntity(caster, target, power);
+		if (spellToCast.isTargetedLocationSpell()) spellToCast.castAtLocation(caster, target.getLocation(), power);
+		else spellToCast.cast(caster, power);
 	}
 
 	private class ChainBouncer implements Runnable {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -139,23 +139,25 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		int attempts = 0;
 		while (targets.size() < bounces && attempts++ < bounces << 1) {
 			List<Entity> entities = current.getNearbyEntities(bounceRange, bounceRange, bounceRange);
-			for (Entity e : entities) {
-				if (!(e instanceof LivingEntity)) continue;
-				if (targets.contains(e)) continue;
+			for (Entity entity : entities) {
+				if (!(entity instanceof LivingEntity livingEntity)) continue;
+				if (targets.contains(livingEntity)) continue;
 
-				if (!validTargetList.canTarget(caster, target)) continue;
+				if (!validTargetList.canTarget(caster, livingEntity)) continue;
 
-				float thisPower = power;
+				float subPower = power;
 				if (caster != null) {
-					SpellTargetEvent event = new SpellTargetEvent(this, caster, (LivingEntity) e, thisPower, args);
-					EventUtil.call(event);
-					if (event.isCancelled()) continue;
-					thisPower = event.getPower();
+					SpellTargetEvent event = new SpellTargetEvent(this, caster, livingEntity, subPower, args);
+					if (!event.callEvent()) continue;
+
+					livingEntity = event.getTarget();
+					subPower = event.getPower();
 				}
 
-				targets.add((LivingEntity) e);
-				targetPowers.add(thisPower);
-				current = (LivingEntity) e;
+				targets.add(livingEntity);
+				targetPowers.add(subPower);
+				current = livingEntity;
+
 				break;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.UUID;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.collect.Multimap;
 import com.google.common.collect.HashMultimap;
@@ -519,19 +518,11 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			else if (caster != null) playSpellEffects(EffectPosition.DELAYED, caster, data);
 
 			if (caster != null || targetEntity != null) {
-				Player playerCaster = caster instanceof Player p ? p : null;
-				Player playerTarget = targetEntity instanceof Player p ? p : null;
-
 				String casterName = caster != null ? getTargetName(caster) : "";
 				String targetName = targetEntity != null ? getTargetName(targetEntity) : "";
 
-				if (playerCaster != null)
-					sendMessage(prepareMessage(strFadeSelf, playerCaster, playerTarget), playerCaster, data.args(),
-						"%a", casterName, "%t", targetName);
-
-				if (playerTarget != null)
-					sendMessage(prepareMessage(strFadeTarget, playerCaster, playerTarget), playerTarget, data.args(),
-						"%a", casterName, "%t", targetName);
+				sendMessage(strFadeSelf, caster, caster, targetEntity, data.args(), "%a", casterName, "%t", targetName);
+				sendMessage(strFadeTarget, targetEntity, caster, targetEntity, data.args(), "%a", casterName, "%t", targetName);
 			}
 
 			if (spellOnEnd != null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TagEntitySpell.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.Set;
 import java.util.HashSet;
 
-import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TargetInfo;
@@ -17,12 +16,15 @@ public class TagEntitySpell extends TargetedSpell implements TargetedEntitySpell
 	private final String operation;
 	private final String tag;
 
+	private final boolean doReplacements;
+
 	public TagEntitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
 		tag = getConfigString("tag", null);
 		operation = getConfigString("operation", "add");
 
+		doReplacements = MagicSpells.requireReplacement(tag);
 	}
 
 	@Override
@@ -68,14 +70,7 @@ public class TagEntitySpell extends TargetedSpell implements TargetedEntitySpell
 	}
 
 	private void tag(LivingEntity caster, LivingEntity target, String[] args) {
-		String varTag = tag;
-		if (varTag.contains("%")) {
-			varTag = MagicSpells.doTargetedVariableReplacements(
-				caster instanceof Player player ? player : null,
-				target instanceof Player player ? player : null,
-				MagicSpells.doArgumentSubstitution(tag, args)
-			);
-		}
+		String varTag = doReplacements ? MagicSpells.doReplacements(tag, caster, target, args) : tag;
 
 		switch (operation) {
 			case "add", "insert" -> target.addScoreboardTag(varTag);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -345,8 +345,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			loc.setYaw(caster.getLocation().getYaw());
 			armorStand = (ArmorStand) loc.getWorld().spawnEntity(loc, EntityType.ARMOR_STAND);
 			if (!totemName.isEmpty()) {
-				if (caster instanceof Player pl) armorStand.customName(Util.getMiniMessage(MagicSpells.doArgumentAndVariableSubstitution(totemName, pl, null)));
-				else armorStand.customName(Util.getMiniMessage(totemName));
+				armorStand.customName(Util.getMiniMessage(MagicSpells.doReplacements(totemName, caster, args)));
 				armorStand.setCustomNameVisible(totemNameVisible);
 			}
 			EntityEquipment totemEquipment = armorStand.getEquipment();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/PlaceholderAPIDataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/PlaceholderAPIDataSpell.java
@@ -58,8 +58,7 @@ public class PlaceholderAPIDataSpell extends TargetedSpell implements TargetedEn
 			if (targetInfo.noTarget()) return noTarget(player, args, null);
 			Player target = targetInfo.target();
 
-			String value = MagicSpells.doArgumentSubstitution(placeholderAPITemplate, args);
-			setPlaceholders(player, target, value, targetInfo.power(), args);
+			setPlaceholders(player, target, targetInfo.power(), args);
 			sendMessages(caster, target, args);
 
 			return PostCastAction.NO_MESSAGES;
@@ -72,7 +71,7 @@ public class PlaceholderAPIDataSpell extends TargetedSpell implements TargetedEn
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!(caster instanceof Player casterPlayer) || !(target instanceof Player targetPlayer)) return false;
 		if (!validTargetList.canTarget(caster, target)) return false;
-		setPlaceholders(casterPlayer, targetPlayer, placeholderAPITemplate, power, args);
+		setPlaceholders(casterPlayer, targetPlayer, power, args);
 		return true;
 	}
 
@@ -86,10 +85,22 @@ public class PlaceholderAPIDataSpell extends TargetedSpell implements TargetedEn
 		return false;
 	}
 
-	private void setPlaceholders(Player caster, Player target, String value, float power, String[] args) {
-		value = MagicSpells.doVariableReplacements(useTargetVariables ? target : caster, value);
+	private void setPlaceholders(Player caster, Player target, float power, String[] args) {
+		String value = MagicSpells.doArgumentSubstitution(placeholderAPITemplate, args);
+
+		Player variableCaster, variableTarget;
+		if (useTargetVariables) {
+			variableCaster = target;
+			variableTarget = caster;
+		} else {
+			variableCaster = caster;
+			variableTarget = target;
+		}
+
+		value = MagicSpells.doVariableReplacements(value, variableCaster, variableTarget);
 		value = PlaceholderAPI.setBracketPlaceholders(setTargetPlaceholders ? target : caster, value);
 		value = PlaceholderAPI.setPlaceholders(setTargetPlaceholders ? target : caster, value);
+
 		MagicSpells.getVariableManager().set(variableName, setTargetVariable ? target : caster, value);
 		playSpellEffects(caster, target, power, args);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -707,12 +707,12 @@ public class Util {
 
 	public static Component getMiniMessageWithVars(Player player, String input) {
 		if (input.isEmpty()) return Component.text("");
-		return getMiniMessage(MagicSpells.doVariableReplacements(player, input));
+		return getMiniMessage(MagicSpells.doReplacements(input, player));
 	}
 
 	public static Component getMiniMessageWithArgsAndVars(Player player, String input, String[] args) {
 		if (input.isEmpty()) return Component.text("");
-		return getMiniMessage(MagicSpells.doArgumentAndVariableSubstitution(input, player, args));
+		return getMiniMessage(MagicSpells.doReplacements(input, player, args));
 	}
 
 	public static String getStringFromComponent(Component component) {
@@ -743,13 +743,11 @@ public class Util {
 	}
 
 	public static String doVarReplacementAndColorize(Player player, String string) {
-		if (string.isEmpty()) return "";
-		return colorize(MagicSpells.doVariableReplacements(player, string));
+		return colorize(MagicSpells.doReplacements(string, player));
 	}
 
 	public static String doVarReplacement(Player player, String string) {
-		if (string.isEmpty()) return "";
-		return MagicSpells.doVariableReplacements(player, string);
+		return MagicSpells.doReplacements(string, player);
 	}
 
 	public static void setInventoryTitle(Player player, String title) {

--- a/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
@@ -120,13 +120,11 @@ public class VariableMod {
 	}
 
 	public String getStringValue(Player caster, Player target) {
-		String ret = MagicSpells.doTargetedVariableReplacements(caster, target, value);
-		return MagicSpells.doVariableReplacements(caster, ret);
+		return MagicSpells.doReplacements(value, caster, target);
 	}
 
 	public String getStringValue(Player caster, Player target, String[] args) {
-		String ret = MagicSpells.doTargetedVariableReplacements(caster, target, value);
-		return MagicSpells.doArgumentAndVariableSubstitution(ret, caster, args);
+		return MagicSpells.doReplacements(value, caster, target, args);
 	}
 
 	public String getValue() {

--- a/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/VariableMod.java
@@ -2,12 +2,11 @@ package com.nisovin.magicspells.util;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Function;
 import java.util.function.BinaryOperator;
 import java.util.concurrent.ThreadLocalRandom;
 
-import de.slikey.exp4j.Expression;
 import org.apache.commons.math3.util.FastMath;
-import org.apache.commons.math3.util.Pair;
 
 import org.bukkit.entity.Player;
 
@@ -91,12 +90,7 @@ public class VariableMod {
 				if (owner != null && owner.equalsIgnoreCase("target:")) variableOwner = VariableOwner.TARGET;
 
 				modifyingVariableName = matcher.group(2);
-			} else {
-				Expression ex = FunctionData.buildExpression(data, true);
-				if (ex == null) return;
-
-				functionModifier = new FunctionData.DoubleData(ex, 0d);
-			}
+			} else functionModifier = FunctionData.build(data, Function.identity(), 0d, true);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -4,8 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.List;
-
-import de.slikey.exp4j.Expression;
+import java.util.function.Function;
 
 import org.bukkit.Color;
 import org.bukkit.Bukkit;
@@ -32,10 +31,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Integer> data = FunctionData.build(config.getString(path), Double::intValue, def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.IntegerData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -49,10 +48,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return def;
+			FunctionData<Integer> data = FunctionData.build(config.getString(path), Double::intValue, def);
+			if (data == null) return def;
 
-			return new FunctionData.IntegerData(ex, def);
+			return data;
 		}
 
 		return def;
@@ -66,10 +65,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Long> data = FunctionData.build(config.getString(path), Double::longValue, def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.LongData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -83,10 +82,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return def;
+			FunctionData<Long> data = FunctionData.build(config.getString(path), Double::longValue, def);
+			if (data == null) return def;
 
-			return new FunctionData.LongData(ex, def);
+			return data;
 		}
 
 		return def;
@@ -100,10 +99,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Short> data = FunctionData.build(config.getString(path), Double::shortValue, def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.ShortData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -117,10 +116,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return def;
+			FunctionData<Short> data = FunctionData.build(config.getString(path), Double::shortValue, def);
+			if (data == null) return def;
 
-			return new FunctionData.ShortData(ex, def);
+			return data;
 		}
 
 		return def;
@@ -134,10 +133,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Byte> data = FunctionData.build(config.getString(path), Double::byteValue, def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.ByteData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -151,10 +150,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return def;
+			FunctionData<Byte> data = FunctionData.build(config.getString(path), Double::byteValue, def);
+			if (data == null) return def;
 
-			return new FunctionData.ByteData(ex, def);
+			return data;
 		}
 
 		return def;
@@ -168,10 +167,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Double> data = FunctionData.build(config.getString(path), Function.identity(), def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.DoubleData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -185,10 +184,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return def;
+			FunctionData<Double> data = FunctionData.build(config.getString(path), Function.identity(), def);
+			if (data == null) return def;
 
-			return new FunctionData.DoubleData(ex, def);
+			return data;
 		}
 
 		return def;
@@ -202,10 +201,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path));
-			if (ex == null) return (caster, target, power, args) -> def;
+			FunctionData<Float> data = FunctionData.build(config.getString(path), Double::floatValue, def);
+			if (data == null) return (caster, target, power, args) -> def;
 
-			return new FunctionData.FloatData(ex, def);
+			return data;
 		}
 
 		return (caster, target, power, args) -> def;
@@ -219,10 +218,10 @@ public class ConfigDataUtil {
 		}
 
 		if (config.isString(path)) {
-			Expression ex = FunctionData.buildExpression(config.getString(path, ""));
-			if (ex == null) return def;
+			FunctionData<Float> data = FunctionData.build(config.getString(path), Double::floatValue, def);
+			if (data == null) return def;
 
-			return new FunctionData.FloatData(ex, def);
+			return data;
 		}
 
 		return def;

--- a/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
@@ -2,72 +2,108 @@ package com.nisovin.magicspells.util.config;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Set;
-import java.util.HashSet;
+import java.util.Map;
+import java.util.HashMap;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.function.Function;
+
+import org.apache.commons.math3.util.Precision;
 
 import de.slikey.exp4j.Expression;
 import de.slikey.exp4j.ValidationResult;
 import de.slikey.exp4j.ExpressionBuilder;
+import org.jetbrains.annotations.Nullable;
 
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
+import me.clip.placeholderapi.PlaceholderAPI;
+
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.RegexUtil;
-import com.nisovin.magicspells.util.managers.VariableManager;
+import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
+import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
-public abstract class FunctionData<T> implements ConfigData<T> {
+public class FunctionData<T extends Number> implements ConfigData<T> {
 
-	private static final Pattern ARGUMENT_PATTERN = Pattern.compile("%arg:(\\d+):(" + RegexUtil.DOUBLE_PATTERN + ")%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
-	private static final Pattern VARIABLE_PATTERN = Pattern.compile("%(var|castervar|targetvar):(\\w+)%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("""
+		%(?:\
+		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
+		(playervar:([a-zA-Z0-9_]{3,16}):(\\w+)(?::(\\d+))?)|\
+		(arg:(\\d+):(\\w+))|\
+		((papi|casterpapi|targetpapi):([^%]+))|\
+		(playerpapi:([a-zA-Z0-9_]{3,16}):([^%]+))\
+		)%""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
+	private final Map<String, ConfigData<Double>> variables;
+	private final Function<Double, T> converter;
 	private final Expression expression;
+	private final ConfigData<T> dataDef;
+	private final T def;
 
-	protected final ConfigData<T> dataDef;
-	protected final T def;
-
-	public FunctionData(@NotNull Expression expression, @NotNull T def) {
+	public FunctionData(@NotNull Expression expression, @NotNull Map<String, ConfigData<Double>> variables, @NotNull Function<Double, T> converter, @NotNull T def) {
 		this.expression = expression;
+		this.variables = variables;
+		this.converter = converter;
 		this.dataDef = null;
 		this.def = def;
 	}
 
-	public FunctionData(@NotNull Expression expression, @NotNull ConfigData<T> def) {
+	public FunctionData(@NotNull Expression expression, @NotNull Map<String, ConfigData<Double>> variables, @NotNull Function<Double, T> converter, @NotNull ConfigData<T> def) {
 		this.expression = expression;
+		this.variables = variables;
+		this.converter = converter;
 		this.dataDef = def;
 		this.def = null;
 	}
 
-	public static Expression buildExpression(String expressionString) {
-		return buildExpression(expressionString, false);
+	@Nullable
+	public static <T extends Number> FunctionData<T> build(@Nullable String expressionString, @NotNull Function<Double, T> converter, @NotNull T def) {
+		return build(expressionString, converter, def, false);
 	}
 
-	public static Expression buildExpression(String expressionString, boolean silent) {
+	@Nullable
+	public static <T extends Number> FunctionData<T> build(@Nullable String expressionString, @NotNull Function<Double, T> converter, @NotNull T def, boolean silent) {
+		Map<String, ConfigData<Double>> variables = new HashMap<>();
+
+		Expression expression = buildExpression(expressionString, variables, silent);
+		if (expression == null) return null;
+
+		return new FunctionData<>(expression, variables, converter, def);
+	}
+
+	@Nullable
+	public static <T extends Number> FunctionData<T> build(@Nullable String expressionString, @NotNull Function<Double, T> converter, @NotNull ConfigData<T> def) {
+		return build(expressionString, converter, def, false);
+	}
+
+	@Nullable
+	public static <T extends Number> FunctionData<T> build(@Nullable String expressionString, @NotNull Function<Double, T> converter, @NotNull ConfigData<T> def, boolean silent) {
+		Map<String, ConfigData<Double>> variables = new HashMap<>();
+
+		Expression expression = buildExpression(expressionString, variables, silent);
+		if (expression == null) return null;
+
+		return new FunctionData<>(expression, variables, converter, def);
+	}
+
+	@Nullable
+	public static Expression buildExpression(@Nullable String expressionString, @NotNull Map<String, ConfigData<Double>> variables, boolean silent) {
 		if (expressionString == null || expressionString.isEmpty()) return null;
 
-		Set<String> variables = new HashSet<>();
-		variables.add("power");
-
-		Matcher matcher = VARIABLE_PATTERN.matcher(expressionString);
+		Matcher matcher = PLACEHOLDER_PATTERN.matcher(expressionString);
 		StringBuilder builder = new StringBuilder();
+		int count = 0;
 
 		while (matcher.find()) {
-			String variable = matcher.group(2);
-			if (matcher.group(1).equals("targetvar")) variable = "target." + variable;
+			String variable = "var" + count;
+			count++;
 
-			variables.add(variable);
-			matcher.appendReplacement(builder, variable);
-		}
-		matcher.appendTail(builder);
+			ConfigData<Double> data = createData(matcher);
+			variables.put(variable, data);
 
-		matcher = ARGUMENT_PATTERN.matcher(builder.toString());
-		builder = new StringBuilder();
-		while (matcher.find()) {
-			String variable = "arg." + matcher.group(1) + "." + matcher.group(2);
-
-			variables.add(variable);
 			matcher.appendReplacement(builder, variable);
 		}
 		matcher.appendTail(builder);
@@ -75,13 +111,14 @@ public abstract class FunctionData<T> implements ConfigData<T> {
 		Expression expression;
 		try {
 			expression = new ExpressionBuilder(builder.toString())
-				.variables(variables)
+				.variables(variables.keySet())
+				.variable("power")
 				.build();
 
 			ValidationResult result = expression.validate(false);
 			if (!result.isValid()) {
 				if (!silent)
-					MagicSpells.error("Invalid equation '" + expressionString + "': [" + String.join(", ", result.getErrors()) + "]");
+					MagicSpells.error("Invalid expression '" + expressionString + "': [" + String.join(", ", result.getErrors()) + "]");
 				return null;
 			}
 
@@ -96,42 +133,87 @@ public abstract class FunctionData<T> implements ConfigData<T> {
 		}
 	}
 
-	protected Double getValue(LivingEntity caster, LivingEntity target, float power, String[] args) {
-		Set<String> variables = expression.getVariableNames();
+	private static ConfigData<Double> createData(Matcher matcher) {
+		if (matcher.group(1) != null) {
+			String owner = matcher.group(2);
+			String variable = matcher.group(3);
+			String placesString = matcher.group(4);
 
-		Player playerCaster = caster instanceof Player ? (Player) caster : null;
-		Player playerTarget = target instanceof Player ? (Player) target : null;
+			int places = -1;
+			if (placesString != null) {
+				try {
+					places = Integer.parseInt(placesString);
+				} catch (NumberFormatException e) {
+					return (caster, target, power, args) -> 0d;
+				}
+			}
 
-		VariableManager variableManager = MagicSpells.getVariableManager();
-
-		for (String variable : variables) {
-			if (variable.startsWith("arg.")) {
-				String[] split = variable.split("\\.");
-
-				int index = Integer.parseInt(split[1]) - 1;
-				double value;
-
-				if (args != null && index < args.length) {
-					try {
-						value = Double.parseDouble(args[index]);
-					} catch (NumberFormatException ignored) {
-						value = Double.parseDouble(split[2]);
-					}
-				} else value = Double.parseDouble(split[2]);
-
-				expression.setVariable(variable, value);
-			} else if (variable.startsWith("target."))
-				expression.setVariable(variable, variableManager.getValue(variable.substring(7), playerTarget));
-			else
-				expression.setVariable(variable, variableManager.getValue(variable, playerCaster));
+			return owner.equalsIgnoreCase("targetvar") ?
+				new TargetVariableData(variable, places) :
+				new CasterVariableData(variable, places);
 		}
+
+		if (matcher.group(5) != null) {
+			String player = matcher.group(6);
+			String variable = matcher.group(7);
+			String placesString = matcher.group(8);
+
+			int places = -1;
+			if (placesString != null) {
+				try {
+					places = Integer.parseInt(placesString);
+				} catch (NumberFormatException e) {
+					return (caster, target, power, args) -> 0d;
+				}
+			}
+
+			return new PlayerVariableData(variable, player, places);
+		}
+
+		if (matcher.group(9) != null) {
+			String def = matcher.group(11);
+
+			int index;
+			try {
+				index = Integer.parseInt(matcher.group(10));
+			} catch (NumberFormatException e) {
+				return (caster, target, power, args) -> 0d;
+			}
+			if (index == 0) return (caster, target, power, args) -> 0d;
+
+			return new ArgumentData(index - 1, def);
+		}
+
+		if (matcher.group(12) != null) {
+			String owner = matcher.group(13);
+			String papiPlaceholder = '%' + matcher.group(14) + '%';
+
+			return owner.equalsIgnoreCase("targetpapi") ?
+				new TargetPAPIData(papiPlaceholder) :
+				new CasterPAPIData(papiPlaceholder);
+		}
+
+		if (matcher.group(15) != null) {
+			String player = matcher.group(16);
+			String papiPlaceholder = '%' + matcher.group(17) + '%';
+
+			return new PlayerPAPIData(papiPlaceholder, player);
+		}
+
+		return (caster, target, power, args) -> 0d;
+	}
+
+	@Override
+	public T get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+		for (Map.Entry<String, ConfigData<Double>> entry : variables.entrySet())
+			expression.setVariable(entry.getKey(), entry.getValue().get(caster, target, power, args));
 
 		expression.setVariable("power", power);
 
 		try {
-			return expression.evaluate();
+			return converter.apply(expression.evaluate());
 		} catch (Exception e) {
-			return null;
+			return dataDef != null ? dataDef.get(caster, target, power, args) : def;
 		}
 	}
 
@@ -140,146 +222,234 @@ public abstract class FunctionData<T> implements ConfigData<T> {
 		return false;
 	}
 
-	public static class DoubleData extends FunctionData<Double> {
+	public static class ArgumentData implements ConfigData<Double> {
 
-		public DoubleData(@NotNull Expression expression, @NotNull Double def) {
-			super(expression, def);
-		}
+		private final double def;
+		private final int index;
 
-		public DoubleData(@NotNull Expression expression, @NotNull ConfigData<Double> def) {
-			super(expression, def);
+		public ArgumentData(int index, String def) {
+			this.index = index;
+
+			double d;
+			try {
+				d = Double.parseDouble(def);
+			} catch (NumberFormatException e) {
+				d = 0;
+			}
+
+			this.def = d;
 		}
 
 		@Override
 		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double ret = getValue(caster, target, power, args);
+			if (args != null && args.length > index) {
+				try {
+					return Double.parseDouble(args[index]);
+				} catch (NumberFormatException e) {
+					return def;
+				}
+			} else return def;
+		}
 
-			if (ret == null) {
-				if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-				else ret = def;
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class CasterVariableData implements ConfigData<Double> {
+
+		private final String variable;
+		private final int places;
+
+		public CasterVariableData(String variable, int places) {
+			this.variable = variable;
+			this.places = places;
+		}
+
+		@Override
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!(caster instanceof Player player)) return 0d;
+
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return 0d;
+
+			double value;
+			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
+				try {
+					value = Double.parseDouble(var.getStringValue(player));
+				} catch (NumberFormatException e) {
+					return 0d;
+				}
+			} else value = var.getValue(player);
+
+			return places >= 0 ? Precision.round(value, places) : value;
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class TargetVariableData implements ConfigData<Double> {
+
+		private final String variable;
+		private final int places;
+
+		public TargetVariableData(String variable, int places) {
+			this.variable = variable;
+			this.places = places;
+		}
+
+		@Override
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!(target instanceof Player player)) return 0d;
+
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return 0d;
+
+			double value;
+			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
+				try {
+					value = Double.parseDouble(var.getStringValue(player));
+				} catch (NumberFormatException e) {
+					return 0d;
+				}
+			} else value = var.getValue(player);
+
+			return places >= 0 ? Precision.round(value, places) : value;
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class PlayerVariableData implements ConfigData<Double> {
+
+		private final String variable;
+		private final String player;
+		private final int places;
+
+		public PlayerVariableData(String variable, String player, int places) {
+			this.variable = variable;
+			this.player = player;
+			this.places = places;
+		}
+
+		@Override
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return 0d;
+
+			double value;
+			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
+				try {
+					value = Double.parseDouble(var.getStringValue(player));
+				} catch (NumberFormatException e) {
+					return 0d;
+				}
+			} else value = var.getValue(player);
+
+			return places >= 0 ? Precision.round(value, places) : value;
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class CasterPAPIData implements ConfigData<Double> {
+
+		private final String papiPlaceholder;
+
+		public CasterPAPIData(String papiPlaceholder) {
+			this.papiPlaceholder = papiPlaceholder;
+		}
+
+		@Override
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(caster instanceof Player player))
+				return 0d;
+
+			String value = PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+
+			try {
+				return Double.parseDouble(value);
+			} catch (NumberFormatException e) {
+				return 0d;
 			}
+		}
 
-			return ret;
+		@Override
+		public boolean isConstant() {
+			return false;
 		}
 
 	}
 
-	public static class FloatData extends FunctionData<Float> {
+	public static class TargetPAPIData implements ConfigData<Double> {
 
-		public FloatData(@NotNull Expression expression, @NotNull Float def) {
-			super(expression, def);
-		}
+		private final String placeholder;
 
-		public FloatData(@NotNull Expression expression, @NotNull ConfigData<Float> def) {
-			super(expression, def);
+		public TargetPAPIData(String placeholder) {
+			this.placeholder = placeholder;
 		}
 
 		@Override
-		public Float get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double value = getValue(caster, target, power, args);
-			Float ret;
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(target instanceof Player player))
+				return 0d;
 
-			if (value != null) ret = value.floatValue();
-			else if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-			else ret = def;
+			String value = PlaceholderAPI.setPlaceholders(player, placeholder);
 
-			return ret;
+			try {
+				return Double.parseDouble(value);
+			} catch (NumberFormatException e) {
+				return 0d;
+			}
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
 		}
 
 	}
 
-	public static class IntegerData extends FunctionData<Integer> {
+	public static class PlayerPAPIData implements ConfigData<Double> {
 
-		public IntegerData(@NotNull Expression expression, @NotNull Integer def) {
-			super(expression, def);
-		}
+		private final String placeholder;
+		private final String player;
 
-		public IntegerData(@NotNull Expression expression, @NotNull ConfigData<Integer> def) {
-			super(expression, def);
-		}
-
-		@Override
-		public Integer get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double value = getValue(caster, target, power, args);
-			Integer ret;
-
-			if (value != null) ret = value.intValue();
-			else if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-			else ret = def;
-
-			return ret;
-		}
-
-	}
-
-	public static class ShortData extends FunctionData<Short> {
-
-		public ShortData(@NotNull Expression expression, @NotNull Short def) {
-			super(expression, def);
-		}
-
-		public ShortData(@NotNull Expression expression, @NotNull ConfigData<Short> def) {
-			super(expression, def);
+		public PlayerPAPIData(String placeholder, String player) {
+			this.placeholder = placeholder;
+			this.player = player;
 		}
 
 		@Override
-		public Short get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double value = getValue(caster, target, power, args);
-			Short ret;
+		public Double get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return 0d;
 
-			if (value != null) ret = value.shortValue();
-			else if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-			else ret = def;
+			String value = PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(player), placeholder);
 
-			return ret;
-		}
-
-	}
-
-	public static class ByteData extends FunctionData<Byte> {
-
-		public ByteData(@NotNull Expression expression, @NotNull Byte def) {
-			super(expression, def);
-		}
-
-		public ByteData(@NotNull Expression expression, @NotNull ConfigData<Byte> def) {
-			super(expression, def);
+			try {
+				return Double.parseDouble(value);
+			} catch (NumberFormatException e) {
+				return 0d;
+			}
 		}
 
 		@Override
-		public Byte get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double value = getValue(caster, target, power, args);
-			Byte ret;
-
-			if (value != null) ret = value.byteValue();
-			else if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-			else ret = def;
-
-			return ret;
-		}
-
-	}
-
-	public static class LongData extends FunctionData<Long> {
-
-		public LongData(@NotNull Expression expression, @NotNull Long def) {
-			super(expression, def);
-		}
-
-		public LongData(@NotNull Expression expression, @NotNull ConfigData<Long> def) {
-			super(expression, def);
-		}
-
-		@Override
-		public Long get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-			Double value = getValue(caster, target, power, args);
-			Long ret;
-
-			if (value != null) ret = value.longValue();
-			else if (dataDef != null) ret = dataDef.get(caster, target, power, args);
-			else ret = def;
-
-			return ret;
+		public boolean isConstant() {
+			return false;
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -1,43 +1,350 @@
 package com.nisovin.magicspells.util.config;
 
-import com.nisovin.magicspells.MagicSpells;
-import org.bukkit.entity.LivingEntity;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
+import me.clip.placeholderapi.PlaceholderAPI;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.TxtUtil;
+import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
+import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
 public class StringData implements ConfigData<String> {
 
-	private final boolean targetedReplacement;
-	private final boolean varReplacement;
-	private final boolean argReplacement;
+	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("""
+		%(?:\
+		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
+		(playervar:([a-zA-Z0-9_]{3,16}):(\\w+)(?::(\\d+))?)|\
+		(arg:(\\d+):(\\w+))|\
+		((papi|casterpapi|targetpapi):([^%]+))|\
+		(playerpapi:([a-zA-Z0-9_]{3,16}):([^%]+))\
+		)%""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
-	private final String value;
+	private final List<ConfigData<String>> values;
+	private final List<String> fragments;
 
-	public StringData(String value, boolean varReplacement, boolean targetedReplacement, boolean argReplacement) {
-		this.targetedReplacement = targetedReplacement;
-		this.varReplacement = varReplacement;
-		this.argReplacement = argReplacement;
+	public StringData(String value) {
+		List<ConfigData<String>> values = new ArrayList<>();
+		List<String> fragments = new ArrayList<>();
 
-		this.value = value;
+		Matcher matcher = PLACEHOLDER_PATTERN.matcher(value);
+		int end = 0;
+		while (matcher.find()) {
+			ConfigData<String> data = createData(matcher);
+			if (data == null) continue;
+
+			fragments.add(value.substring(end, matcher.start()));
+			values.add(data);
+
+			end = matcher.end();
+		}
+
+		fragments.add(value.substring(end));
+
+		this.fragments = Collections.unmodifiableList(fragments);
+		this.values = Collections.unmodifiableList(values);
+	}
+
+	private static ConfigData<String> createData(Matcher matcher) {
+		String placeholder = matcher.group(1);
+		if (placeholder != null) {
+			String owner = matcher.group(2);
+			String variable = matcher.group(3);
+			String placesString = matcher.group(4);
+
+			int places = -1;
+			if (placesString != null) {
+				try {
+					places = Integer.parseInt(placesString);
+				} catch (NumberFormatException e) {
+					return null;
+				}
+			}
+
+			return owner.equalsIgnoreCase("targetvar") ?
+				new TargetVariableData(placeholder, variable, places) :
+				new CasterVariableData(placeholder, variable, places);
+		}
+
+		placeholder = matcher.group(5);
+		if (placeholder != null) {
+			String player = matcher.group(6);
+			String variable = matcher.group(7);
+			String placesString = matcher.group(8);
+
+			int places = -1;
+			if (placesString != null) {
+				try {
+					places = Integer.parseInt(placesString);
+				} catch (NumberFormatException e) {
+					return null;
+				}
+			}
+
+			return new PlayerVariableData(placeholder, variable, player, places);
+		}
+
+		placeholder = matcher.group(9);
+		if (placeholder != null) {
+			String def = matcher.group(11);
+
+			int index;
+			try {
+				index = Integer.parseInt(matcher.group(10));
+			} catch (NumberFormatException e) {
+				return null;
+			}
+			if (index == 0) return null;
+
+			return new ArgumentData(index - 1, def);
+		}
+
+		placeholder = matcher.group(12);
+		if (placeholder != null) {
+			String owner = matcher.group(13);
+			String papiPlaceholder = '%' + matcher.group(14) + '%';
+
+			return owner.equalsIgnoreCase("targetpapi") ?
+				new TargetPAPIData(placeholder, papiPlaceholder) :
+				new CasterPAPIData(placeholder, papiPlaceholder);
+		}
+
+		placeholder = matcher.group(15);
+		if (placeholder != null) {
+			String player = matcher.group(16);
+			String papiPlaceholder = '%' + matcher.group(17) + '%';
+
+			return new PlayerPAPIData(placeholder, papiPlaceholder, player);
+		}
+
+		return null;
 	}
 
 	@Override
 	public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
-		String ret = value;
+		if (values.isEmpty()) return fragments.get(0);
 
-		if (argReplacement) ret = MagicSpells.doArgumentSubstitution(ret, args);
+		StringBuilder builder = new StringBuilder();
+		for (int i = 0; i < fragments.size() - 1; i++) {
+			builder.append(fragments.get(i));
+			builder.append(values.get(i).get(caster, target, power, args));
+		}
+		builder.append(fragments.get(fragments.size() - 1));
 
-		Player playerCaster = caster instanceof Player p ? p : null;
-		Player playerTarget = target instanceof Player p ? p : null;
+		return builder.toString();
+	}
 
-		if (varReplacement) ret = MagicSpells.doVariableReplacements(playerCaster, ret);
-		if (targetedReplacement) ret = MagicSpells.doTargetedVariableReplacements(playerCaster, playerTarget, ret);
+	public List<ConfigData<String>> getValues() {
+		return values;
+	}
 
-		return ret;
+	public List<String> getFragments() {
+		return fragments;
+	}
+
+	public static abstract class PlaceholderData implements ConfigData<String> {
+
+		protected final String placeholder;
+
+		public PlaceholderData(String placeholder) {
+			this.placeholder = '%' + placeholder + '%';
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class ArgumentData implements ConfigData<String> {
+
+		private final String def;
+		private final int index;
+
+		public ArgumentData(int index, String def) {
+			this.index = index;
+			this.def = def;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (args != null && args.length > index) return args[index];
+			else return def;
+		}
+
+		@Override
+		public boolean isConstant() {
+			return false;
+		}
+
+	}
+
+	public static class CasterVariableData extends PlaceholderData {
+
+		private final String variable;
+		private final int places;
+
+		public CasterVariableData(String placeholder, String variable, int places) {
+			super(placeholder);
+
+			this.variable = variable;
+			this.places = places;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!(caster instanceof Player player)) return placeholder;
+
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return placeholder;
+
+			if (places >= 0) {
+				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
+					return TxtUtil.getStringNumber(var.getStringValue(player), places);
+
+				return TxtUtil.getStringNumber(var.getValue(player), places);
+			}
+
+			return var.getStringValue(player);
+		}
+
+	}
+
+	public static class TargetVariableData extends PlaceholderData {
+
+		private final String variable;
+		private final int places;
+
+		public TargetVariableData(String placeholder, String variable, int places) {
+			super(placeholder);
+
+			this.variable = variable;
+			this.places = places;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!(target instanceof Player player)) return placeholder;
+
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return placeholder;
+
+			if (places >= 0) {
+				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
+					return TxtUtil.getStringNumber(var.getStringValue(player), places);
+
+				return TxtUtil.getStringNumber(var.getValue(player), places);
+			}
+
+			return var.getStringValue(player);
+		}
+
+	}
+
+	public static class PlayerVariableData extends PlaceholderData {
+
+		private final String variable;
+		private final String player;
+		private final int places;
+
+		public PlayerVariableData(String placeholder, String variable, String player, int places) {
+			super(placeholder);
+
+			this.variable = variable;
+			this.player = player;
+			this.places = places;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			Variable var = MagicSpells.getVariableManager().getVariable(variable);
+			if (var == null) return placeholder;
+
+			if (places >= 0) {
+				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
+					return TxtUtil.getStringNumber(var.getStringValue(player), places);
+
+				return TxtUtil.getStringNumber(var.getValue(player), places);
+			}
+
+			return var.getStringValue(player);
+		}
+
+	}
+
+	public static class CasterPAPIData extends PlaceholderData {
+
+		private final String papiPlaceholder;
+
+		public CasterPAPIData(String placeholder, String papiPlaceholder) {
+			super(placeholder);
+
+			this.papiPlaceholder = papiPlaceholder;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(caster instanceof Player player))
+				return placeholder;
+
+			return PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+		}
+
+	}
+
+	public static class TargetPAPIData extends PlaceholderData {
+
+		private final String papiPlaceholder;
+
+		public TargetPAPIData(String placeholder, String papiPlaceholder) {
+			super(placeholder);
+
+			this.papiPlaceholder = papiPlaceholder;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(target instanceof Player player))
+				return placeholder;
+
+			return PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+		}
+
+	}
+
+	public static class PlayerPAPIData extends PlaceholderData {
+
+		private final String papiPlaceholder;
+		private final String player;
+
+		public PlayerPAPIData(String placeholder, String papiPlaceholder, String player) {
+			super(placeholder);
+
+			this.papiPlaceholder = papiPlaceholder;
+			this.player = player;
+		}
+
+		@Override
+		public String get(LivingEntity caster, LivingEntity target, float power, String[] args) {
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return placeholder;
+			return PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(player), papiPlaceholder);
+		}
+
 	}
 
 	@Override
 	public boolean isConstant() {
-		return !argReplacement && !varReplacement && !targetedReplacement;
+		return values.isEmpty();
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -55,8 +55,7 @@ public class StringData implements ConfigData<String> {
 	}
 
 	private static ConfigData<String> createData(Matcher matcher) {
-		String placeholder = matcher.group(1);
-		if (placeholder != null) {
+		if (matcher.group(1) != null) {
 			String owner = matcher.group(2);
 			String variable = matcher.group(3);
 			String placesString = matcher.group(4);
@@ -71,12 +70,11 @@ public class StringData implements ConfigData<String> {
 			}
 
 			return owner.equalsIgnoreCase("targetvar") ?
-				new TargetVariableData(placeholder, variable, places) :
-				new CasterVariableData(placeholder, variable, places);
+				new TargetVariableData(matcher.group(), variable, places) :
+				new CasterVariableData(matcher.group(), variable, places);
 		}
 
-		placeholder = matcher.group(5);
-		if (placeholder != null) {
+		if (matcher.group(5) != null) {
 			String player = matcher.group(6);
 			String variable = matcher.group(7);
 			String placesString = matcher.group(8);
@@ -90,11 +88,10 @@ public class StringData implements ConfigData<String> {
 				}
 			}
 
-			return new PlayerVariableData(placeholder, variable, player, places);
+			return new PlayerVariableData(matcher.group(), variable, player, places);
 		}
 
-		placeholder = matcher.group(9);
-		if (placeholder != null) {
+		if (matcher.group(9) != null) {
 			String def = matcher.group(11);
 
 			int index;
@@ -108,22 +105,20 @@ public class StringData implements ConfigData<String> {
 			return new ArgumentData(index - 1, def);
 		}
 
-		placeholder = matcher.group(12);
-		if (placeholder != null) {
+		if (matcher.group(12) != null) {
 			String owner = matcher.group(13);
 			String papiPlaceholder = '%' + matcher.group(14) + '%';
 
 			return owner.equalsIgnoreCase("targetpapi") ?
-				new TargetPAPIData(placeholder, papiPlaceholder) :
-				new CasterPAPIData(placeholder, papiPlaceholder);
+				new TargetPAPIData(matcher.group(), papiPlaceholder) :
+				new CasterPAPIData(matcher.group(), papiPlaceholder);
 		}
 
-		placeholder = matcher.group(15);
-		if (placeholder != null) {
+		if (matcher.group(15) != null) {
 			String player = matcher.group(16);
 			String papiPlaceholder = '%' + matcher.group(17) + '%';
 
-			return new PlayerPAPIData(placeholder, papiPlaceholder, player);
+			return new PlayerPAPIData(matcher.group(), papiPlaceholder, player);
 		}
 
 		return null;
@@ -143,6 +138,11 @@ public class StringData implements ConfigData<String> {
 		return builder.toString();
 	}
 
+	@Override
+	public boolean isConstant() {
+		return values.isEmpty();
+	}
+
 	public List<ConfigData<String>> getValues() {
 		return values;
 	}
@@ -156,7 +156,7 @@ public class StringData implements ConfigData<String> {
 		protected final String placeholder;
 
 		public PlaceholderData(String placeholder) {
-			this.placeholder = '%' + placeholder + '%';
+			this.placeholder = placeholder;
 		}
 
 		@Override
@@ -340,11 +340,6 @@ public class StringData implements ConfigData<String> {
 			return PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(player), papiPlaceholder);
 		}
 
-	}
-
-	@Override
-	public boolean isConstant() {
-		return values.isEmpty();
 	}
 
 }


### PR DESCRIPTION
- Introduces support for PlaceholderAPI in replacement supporting options.
- Fixes an issue where the `can-target` of `ChainSpell` was improperly checking the original target instead of the chained target.
- Allow casting a non-targeted `spell` in `ChainSpell`.