### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SplashPotionEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SplashPotionEffect.java
@@ -20,7 +20,7 @@ public class SplashPotionEffect extends SpellEffect {
 
 	@Override
 	public Runnable playEffectLocation(Location location, SpellData data) {
-		location.getWorld().playEffect(location, Effect.POTION_BREAK, pot.get(data));
+		location.getWorld().playEffect(location, Effect.POTION_BREAK, (int) pot.get(data));
 		return null;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
@@ -22,20 +22,14 @@ import org.bukkit.entity.LivingEntity;
 import me.clip.placeholderapi.PlaceholderAPI;
 
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.variables.Variable;
 import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
 public class FunctionData<T extends Number> implements ConfigData<T> {
 
-	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("""
-		%(?:\
-		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
-		(playervar:([a-zA-Z0-9_]{3,16}):(\\w+)(?::(\\d+))?)|\
-		(arg:(\\d+):(\\w+))|\
-		((papi|casterpapi|targetpapi):([^%]+))|\
-		(playerpapi:([a-zA-Z0-9_]{3,16}):([^%]+))\
-		)%""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("%(?:((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|(playervar:([a-zA-Z0-9_]{3,16}):(\\w+)(?::(\\d+))?)|(arg:(\\d+):(" + RegexUtil.DOUBLE_PATTERN + "))|((papi|casterpapi|targetpapi):([^%]+))|(playerpapi:([a-zA-Z0-9_]{3,16}):([^%]+)))%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	private final Map<String, ConfigData<Double>> variables;
 	private final Function<Double, T> converter;


### PR DESCRIPTION
- Added an explicit conversion to primitive in other to play the potion break effect with the correct overload of `World#playEffect`.
- Fixed an issue with the argument placeholder regex in `FunctionData` that prevented inputting most double values as a default.
- Added more general support for subeffects in EffectLib effects.