### PR TITLE
Spawnentity nameplates now hidden when unused

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells;
 import java.util.*;
 
 import net.kyori.adventure.text.Component;
+import net.kyori.adventure.text.format.NamedTextColor;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
@@ -162,23 +163,14 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	}
 
 	private ItemStack createItem(String path, String defaultName) {
-		ItemStack item = null;
-		MagicItem magicItem = null;
+		MagicItem magicItem = MagicItems.getMagicItemFromString(getConfigString(path, null));
+		if (magicItem != null) return magicItem.getItemStack().clone();
 
-		if (MagicItems.getMagicItemFromString(getConfigString(path, "")) != null) {
-			magicItem = MagicItems.getMagicItemFromString(getConfigString(path, "")).clone();
-		}
+		ItemStack item = new ItemStack(Material.GREEN_WOOL);
+		ItemMeta meta = item.getItemMeta();
 
-		if (magicItem == null) {
-			item = new ItemStack(Material.GREEN_WOOL);
-
-			ItemMeta itemMeta = item.getItemMeta();
-			itemMeta.displayName(Util.getMiniMessage("&6" + defaultName));
-
-			item.setItemMeta(itemMeta);
-		} else {
-			item = magicItem.getItemStack();
-		}
+		meta.displayName(Component.text(defaultName).color(NamedTextColor.GOLD));
+		item.setItemMeta(meta);
 
 		return item;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -163,22 +163,23 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 	private ItemStack createItem(String path, String defaultName) {
 		ItemStack item = null;
-		if (isConfigSection(path)) {
-			MagicItem magicItem = MagicItems.getMagicItemFromSection(getConfigSection(path));
-			if (magicItem != null) item = magicItem.getItemStack();
-		} else {
-			MagicItem magicItem = MagicItems.getMagicItemFromString(getConfigString(path, ""));
+		MagicItem magicItem = null;
 
-			if (magicItem == null) {
-				item = new ItemStack(Material.GREEN_WOOL);
-				ItemMeta itemMeta = item.getItemMeta();
-
-				itemMeta.setDisplayName("§6§t" + defaultName);
-				item.setItemMeta(itemMeta);
-			} else {
-				item = magicItem.getItemStack();
-			}
+		if (MagicItems.getMagicItemFromString(getConfigString(path, "")) != null) {
+			magicItem = MagicItems.getMagicItemFromString(getConfigString(path, "")).clone();
 		}
+
+		if (magicItem == null) {
+			item = new ItemStack(Material.GREEN_WOOL);
+
+			ItemMeta itemMeta = item.getItemMeta();
+			itemMeta.displayName(Util.getMiniMessage("&6" + defaultName));
+
+			item.setItemMeta(itemMeta);
+		} else {
+			item = magicItem.getItemStack();
+		}
+
 		return item;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -1,7 +1,5 @@
 package com.nisovin.magicspells.spells;
 
-import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.NAME;
-
 import java.util.*;
 
 import net.kyori.adventure.text.Component;
@@ -21,15 +19,13 @@ import org.bukkit.event.player.PlayerQuitEvent;
 import org.bukkit.event.inventory.InventoryClickEvent;
 
 import com.nisovin.magicspells.Subspell;
-import com.nisovin.magicspells.util.Util;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
-import com.nisovin.magicspells.util.magicitems.MagicItemData;
-import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.SpellData;
-import com.nisovin.magicspells.util.MenuData;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 
@@ -220,7 +216,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		int size = (int) Math.ceil(Math.min((players.size()+1), 54) / 9.0) * 9;
 		Inventory inv = Bukkit.createInventory(opener, size, Component.text(internalName));
 
-		for (int i = (page * 50); i < Math.min(players.size(), (page + 1) * 50); i++) {
+		for (int i = (page * 52); i < Math.min(players.size(), (page + 1) * 52); i++) {
 			ItemStack head = new ItemStack(Material.PLAYER_HEAD);
 			ItemMeta itemMeta = head.getItemMeta();
 			SkullMeta skullMeta = (SkullMeta) itemMeta;
@@ -235,14 +231,14 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 				itemMeta.lore(lore);
 			}
 			head.setItemMeta(skullMeta);
-			inv.setItem(i%50, head);
+			inv.setItem(i%52, head);
 		}
 
 		if (page > 0) {
 			inv.setItem(52, previousPageItem);
 		}
 
-		if (players.size() > ((page + 1) * 50)) {
+		if (players.size() > ((page + 1) * 52)) {
 			inv.setItem(53, nextPageItem);
 		}
 
@@ -327,5 +323,9 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 			menuData.remove(player.getUniqueId());
 			playSpellEffects(EffectPosition.DISABLED, player, spellData);
 		}
+	}
+
+	public record MenuData(SpellData spellData, int page) {
+
 	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -165,7 +165,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		retargetRange = getConfigDataDouble("retarget-range", 50);
 
 		location = getConfigString("location", "target");
-		nameplateText = Util.getMiniMessage(getConfigString("nameplate-text", ""));
+		nameplateText = Util.getMiniMessage(getConfigString("nameplate-text", null));
 
 		noAI = getConfigBoolean("no-ai", false);
 		gravity = getConfigBoolean("gravity", true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -501,7 +501,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			this.target = target;
 			this.power = power;
 			this.args = args;
-			this.attackSpellCancelsDefaultAttack = SpawnEntitySpell.this.attackSpellCancelsDefaultAttack.get(caster, null, power, args);;
+			this.attackSpellCancelsDefaultAttack = SpawnEntitySpell.this.attackSpellCancelsDefaultAttack.get(caster, null, power, args);
 		}
 
 		@EventHandler(ignoreCancelled = true)
@@ -531,7 +531,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 
 		@EventHandler
 		private void onTarget(EntityTargetEvent event) {
-			if (event.getEntity() == monster && event.getTarget() == caster) event.setCancelled(true);
+			if (event.getEntity() == monster && !validTargetList.canTarget(caster, event.getTarget())) event.setCancelled(true);
 			else if (event.getTarget() == null) retarget(null);
 			else if (target != null && event.getTarget() != target) event.setTarget(target);
 		}
@@ -552,7 +552,6 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			for (Entity e : monster.getNearbyEntities(retargetRange, retargetRange, retargetRange)) {
 				if (!(e instanceof LivingEntity)) continue;
 				if (!validTargetList.canTarget(caster, e)) continue;
-				if (e == caster) continue;
 				if (e == ignore) continue;
 
 				if (e instanceof Player p) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -87,6 +87,8 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 	private boolean addLookAtPlayerAI;
 	private boolean allowSpawnInMidair;
 	private boolean nameplateFormatting;
+	private ConfigData<Boolean> attackSpellCancelsDefaultAttack;
+
 
 	private Subspell attackSpell;
 	private String attackSpellName;
@@ -174,6 +176,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		useCasterName = getConfigBoolean("use-caster-name", false);
 		addLookAtPlayerAI = getConfigBoolean("add-look-at-player-ai", false);
 		allowSpawnInMidair = getConfigBoolean("allow-spawn-in-midair", false);
+		attackSpellCancelsDefaultAttack = getConfigDataBoolean("attack-spell-cancels-default-attack", true);
 
 		attackSpellName = getConfigString("attack-spell", "");
 
@@ -488,6 +491,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		private final LivingEntity monster;
 		private final String[] args;
 		private final float power;
+		private final Boolean attackSpellCancelsDefaultAttack;
 
 		private LivingEntity target;
 
@@ -497,6 +501,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			this.target = target;
 			this.power = power;
 			this.args = args;
+			this.attackSpellCancelsDefaultAttack = SpawnEntitySpell.this.attackSpellCancelsDefaultAttack.get(caster, null, power, args);;
 		}
 
 		@EventHandler(ignoreCancelled = true)
@@ -520,7 +525,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				} else {
 					attackSpell.cast(caster, power);
 				}
-				event.setCancelled(true);
+				event.setCancelled(this.attackSpellCancelsDefaultAttack);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -89,7 +89,6 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 	private boolean nameplateFormatting;
 	private boolean cancelAttack;
 
-
 	private Subspell attackSpell;
 	private String attackSpellName;
 
@@ -491,7 +490,6 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		private final LivingEntity monster;
 		private final String[] args;
 		private final float power;
-		private final boolean cancelAttack;
 
 		private LivingEntity target;
 
@@ -501,7 +499,6 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			this.target = target;
 			this.power = power;
 			this.args = args;
-			this.cancelAttack = SpawnEntitySpell.this.cancelAttack;
 		}
 
 		@EventHandler(ignoreCancelled = true)
@@ -525,7 +522,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				} else {
 					attackSpell.cast(caster, power);
 				}
-				event.setCancelled(this.cancelAttack);
+				event.setCancelled(SpawnEntitySpell.this.cancelAttack);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -87,7 +87,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 	private boolean addLookAtPlayerAI;
 	private boolean allowSpawnInMidair;
 	private boolean nameplateFormatting;
-	private ConfigData<Boolean> attackSpellCancelsDefaultAttack;
+	private boolean cancelAttack;
 
 
 	private Subspell attackSpell;
@@ -176,7 +176,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		useCasterName = getConfigBoolean("use-caster-name", false);
 		addLookAtPlayerAI = getConfigBoolean("add-look-at-player-ai", false);
 		allowSpawnInMidair = getConfigBoolean("allow-spawn-in-midair", false);
-		attackSpellCancelsDefaultAttack = getConfigDataBoolean("attack-spell-cancels-default-attack", true);
+		cancelAttack = getConfigBoolean("cancel-attack", true);
 
 		attackSpellName = getConfigString("attack-spell", "");
 
@@ -491,7 +491,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		private final LivingEntity monster;
 		private final String[] args;
 		private final float power;
-		private final Boolean attackSpellCancelsDefaultAttack;
+		private final boolean cancelAttack;
 
 		private LivingEntity target;
 
@@ -501,7 +501,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			this.target = target;
 			this.power = power;
 			this.args = args;
-			this.attackSpellCancelsDefaultAttack = SpawnEntitySpell.this.attackSpellCancelsDefaultAttack.get(caster, null, power, args);
+			this.cancelAttack = SpawnEntitySpell.this.cancelAttack;
 		}
 
 		@EventHandler(ignoreCancelled = true)
@@ -525,7 +525,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				} else {
 					attackSpell.cast(caster, power);
 				}
-				event.setCancelled(this.attackSpellCancelsDefaultAttack);
+				event.setCancelled(this.cancelAttack);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/MenuData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MenuData.java
@@ -1,7 +1,0 @@
-package com.nisovin.magicspells.util;
-
-import org.bukkit.entity.LivingEntity;
-
-public record MenuData(SpellData spellData, int page) {
-
-}

--- a/core/src/main/java/com/nisovin/magicspells/util/MenuData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MenuData.java
@@ -1,0 +1,7 @@
+package com.nisovin.magicspells.util;
+
+import org.bukkit.entity.LivingEntity;
+
+public record MenuData(SpellData spellData, int page) {
+
+}


### PR DESCRIPTION
SpawnEntitySpells were spawning in mobs with empty nametags, instead of no nametag at all. Fixed it by defaulting to null instead of "".

PlayerMenuSpells didn't work in games with more than 54 players in it. Changed the spell so that if the player count is over 50 it adds "next tab" and "previous tab" buttons

Added a config to SpawnEntitySpells to customize whether the default attack damage is canceled when using an AttackSpell (old behavior was always true)

Changed spawned entity behavior to obey the ValidTargetList when picking targets (old behavior was always ignore caster)