### PR TITLE
Fix effect rotations for `line/trail` effect position.

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EffectLibLineEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EffectLibLineEffect.java
@@ -21,9 +21,9 @@ public class EffectLibLineEffect extends EffectLibEffect {
 	}
 	
 	@Override
-	public Runnable playEffect(Location location1, Location location2, SpellData data) {
+	public Runnable playEffect(Location startLoc, Location endLoc, SpellData data) {
 		if (!initialize()) return null;
-		manager.start(className, getParameters(data), new DynamicLocation(location1), new DynamicLocation(location2), (ConfigurationSection) null, null);
+		manager.start(className, getParameters(data), new DynamicLocation(startLoc), new DynamicLocation(endLoc), (ConfigurationSection) null, null);
 		return null;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeTrailEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeTrailEffect.java
@@ -24,8 +24,8 @@ public class SmokeTrailEffect extends SpellEffect {
 	}
 
 	@Override
-	public Runnable playEffect(Location location1, Location location2, SpellData data) {
-		SmokeStreamEffect effect = new SmokeStreamEffect(location1, location2);
+	public Runnable playEffect(Location startLoc, Location endLoc, SpellData data) {
+		SmokeStreamEffect effect = new SmokeStreamEffect(startLoc, endLoc);
 
 		int interval = this.interval.get(data);
 		if (interval > 0) effect.start(interval);


### PR DESCRIPTION
Add `start-location-height-offset` and `end-location-height-offset` for `line/trail` effect position Refactored `max-distance` option for `line/trail` effect to cut the effect after the defined distance was reached instead of stopping it entirely.