### PR TITLE
Changes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1504,6 +1504,11 @@ public class MagicSpells extends JavaPlugin {
 		return doVariableReplacements(player, doArgumentSubstitution(string, args));
 	}
 
+	public static String doReplacements(String message, SpellData data) {
+		if (data == null) return doReplacements(message, null, null, null, (String[]) null);
+		return doReplacements(message, data.caster(), data.target(), data.args(), (String[]) null);
+	}
+
 	public static String doReplacements(String message, LivingEntity caster) {
 		return doReplacements(message, caster, null, null, (String[]) null);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
@@ -7,6 +7,8 @@ import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.configuration.ConfigurationSection;
 
+import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.EntityData;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
@@ -34,7 +36,7 @@ public class ArmorStandEffect extends SpellEffect {
 		if (section == null) return;
 
 		entityData = new EntityData(section);
-		entityData.setEntityType(EntityType.ARMOR_STAND);
+		entityData.setEntityType((caster, target, power, args) -> EntityType.ARMOR_STAND);
 
 		gravity = section.getBoolean("gravity", false);
 
@@ -57,18 +59,18 @@ public class ArmorStandEffect extends SpellEffect {
 
 	@Override
 	protected ArmorStand playArmorStandEffectLocation(Location location, SpellData data) {
-		return (ArmorStand) entityData.spawn(location, entity -> {
+		return (ArmorStand) entityData.spawn(location, data, entity -> {
 			ArmorStand armorStand = (ArmorStand) entity;
 
 			armorStand.addScoreboardTag(ENTITY_TAG);
 			armorStand.setGravity(gravity);
 			armorStand.setSilent(true);
-			armorStand.setCustomName(customName);
+			armorStand.customName(Util.getMiniMessage(MagicSpells.doReplacements(customName, data)));
 			armorStand.setCustomNameVisible(customNameVisible);
 
-			if (headItem != null) armorStand.setItem(EquipmentSlot.HEAD, headItem);
-			if (mainhandItem != null) armorStand.setItem(EquipmentSlot.HAND, mainhandItem);
-			if (offhandItem != null) armorStand.setItem(EquipmentSlot.OFF_HAND, offhandItem);
+			armorStand.setItem(EquipmentSlot.HEAD, headItem);
+			armorStand.setItem(EquipmentSlot.HAND, mainhandItem);
+			armorStand.setItem(EquipmentSlot.OFF_HAND, offhandItem);
 		});
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -33,7 +33,7 @@ public class EntityEffect extends SpellEffect {
 
 	@Override
 	protected Entity playEntityEffectLocation(Location location, SpellData data) {
-		return entityData.spawn(location, entity -> {
+		return entityData.spawn(location, data, entity -> {
 			entity.addScoreboardTag(ENTITY_TAG);
 			entity.setGravity(gravity);
 			entity.setSilent(silent);

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -1,773 +1,456 @@
 package com.nisovin.magicspells.util;
 
-// this should probably be kept as a star import for version safety
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.Collection;
+import java.util.function.BiConsumer;
+
+import com.google.common.collect.Multimap;
+import com.google.common.collect.MultimapBuilder;
+
 import org.bukkit.entity.*;
+import org.bukkit.Location;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
-import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.util.Consumer;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.configuration.ConfigurationSection;
 
-import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
 
 public class EntityData {
 
-	private Vector relativeOffset;
+	private final Multimap<EntityType, Transformer<?, ?>> options = MultimapBuilder.enumKeys(EntityType.class).arrayListValues().build();
 
-	private EntityType entityType;
+	private ConfigData<EntityType> entityType;
 
-	private Material material;
-	private DyeColor dyeColor;
-	private DyeColor patternDyeColor;
+	private final ConfigData<BlockData> fallingBlockData;
+	private final ConfigData<Material> dropItemMaterial;
+	private final ConfigData<Vector> relativeOffset;
 
-	private Cat.Type catType;
-	private Fox.Type foxType;
-	private Panda.Gene mainGene;
-	private Panda.Gene hiddenGene;
-	private Horse.Color horseColor;
-	private Horse.Style horseStyle;
-	private Rabbit.Type rabbitType;
-	private Llama.Color llamaColor;
-	private Parrot.Variant parrotVariant;
-	private Villager.Profession profession;
-	private MushroomCow.Variant cowVariant;
-	private Axolotl.Variant axolotlVariant;
-	private Frog.Variant frogVariant;
-	private TropicalFish.Pattern fishPattern;
+	// Legacy support for DisguiseSpell section format
 
-	private EulerAngle headAngle;
-	private EulerAngle bodyAngle;
-	private EulerAngle leftArmAngle;
-	private EulerAngle rightArmAngle;
-	private EulerAngle leftLegAngle;
-	private EulerAngle rightLegAngle;
+	// Ageable
+	private final ConfigData<Boolean> baby;
 
-	private boolean baby;
-	private boolean tamed;
-	private boolean angry;
-	private boolean small;
-	private boolean marker;
-	private boolean visible;
-	private boolean hasArms;
-	private boolean powered;
-	private boolean chested;
-	private boolean saddled;
-	private boolean sheared;
-	private boolean hasBasePlate;
+	// AbstractHorse & Pig
+	private final ConfigData<Boolean> saddled;
 
-	private int size;
+	// ChestedHorse
+	private final ConfigData<Boolean> chested;
 
-	private boolean isMob = false;
-	private boolean isMisc = false;
-	private boolean isPlayer = false;
+	// Creeper
+	private final ConfigData<Boolean> powered;
 
-	public EntityData(ConfigurationSection section) {
-		if (section == null) throw new NullPointerException("section");
+	// Enderman
+	private final ConfigData<BlockData> carriedBlockData;
 
-		relativeOffset = Util.getVector(section.getString("relative-offset", "0,0,0"));
+	// Horse
+	private final ConfigData<Horse.Color> horseColor;
+	private final ConfigData<Horse.Style> horseStyle;
 
-		size = section.getInt("size", 0);
+	// Llama
+	private final ConfigData<Llama.Color> llamaColor;
 
-		baby = section.getBoolean("baby", false);
-		tamed = section.getBoolean("tamed", false);
-		angry = section.getBoolean("angry", false);
-		small = section.getBoolean("small", false);
-		marker = section.getBoolean("marker", false);
-		visible = section.getBoolean("visible", true);
-		hasArms = section.getBoolean("has-arms", true);
-		chested = section.getBoolean("chested", false);
-		powered = section.getBoolean("powered", false);
-		saddled = section.getBoolean("saddled", false);
-		sheared = section.getBoolean("sheared", false);
-		hasBasePlate = section.getBoolean("has-base-plate", true);
+	// Parrot
+	private final ConfigData<Parrot.Variant> parrotVariant;
 
-		Vector head = Util.getVector(section.getString("head-angle", "0,0,0"));
-		Vector body = Util.getVector(section.getString("body-angle", "0,0,0"));
-		Vector leftArm = Util.getVector(section.getString("left-arm-angle", "0,0,0"));
-		Vector rightArm = Util.getVector(section.getString("right-arm-angle", "0,0,0"));
-		Vector leftLeg = Util.getVector(section.getString("left-leg-angle", "0,0,0"));
-		Vector rightLeg = Util.getVector(section.getString("right-leg-angle", "0,0,0"));
+	// Puffer Fish & Slime
+	private final ConfigData<Integer> size;
 
-		headAngle = new EulerAngle(head.getX(), head.getY(), head.getZ());
-		bodyAngle = new EulerAngle(body.getX(), body.getY(), body.getZ());
-		leftArmAngle = new EulerAngle(leftArm.getX(), leftArm.getY(), leftArm.getZ());
-		rightArmAngle = new EulerAngle(rightArm.getX(), rightArm.getY(), rightArm.getZ());
-		leftLegAngle = new EulerAngle(leftLeg.getX(), leftLeg.getY(), leftLeg.getZ());
-		rightLegAngle = new EulerAngle(rightLeg.getX(), rightLeg.getY(), rightLeg.getZ());
+	// Sheep
+	private final ConfigData<Boolean> sheared;
 
-		String mat = section.getString("material", "");
-		String type = section.getString("type", "");
-		String color = section.getString("color", "");
-		String patternColor = section.getString("pattern-color", "");
-		String style = section.getString("style", "");
-		String entity = section.getString("entity", "");
-		String mainGeneType = section.getString("main-gene", "");
-		String hiddenGeneType = section.getString("hidden-gene", "");
-		switch (entity.toLowerCase()) {
-			case "player" -> {
-				entityType = EntityType.PLAYER;
-				isPlayer = true;
-			}
-			case "pillager" -> {
-				entityType = EntityType.PILLAGER;
-				isMob = true;
-			}
-			case "ravager" -> {
-				entityType = EntityType.RAVAGER;
-				isMob = true;
-			}
-			case "trader_llama" -> {
-				entityType = EntityType.TRADER_LLAMA;
-				isMob = true;
-			}
-			case "wandering_trader" -> {
-				entityType = EntityType.WANDERING_TRADER;
-				isMob = true;
-			}
-			case "hoglin" -> {
-				entityType = EntityType.HOGLIN;
-				isMob = true;
-			}
-			case "piglin" -> {
-				entityType = EntityType.PIGLIN;
-				isMob = true;
-			}
-			case "piglin_brute" -> {
-				entityType = EntityType.PIGLIN_BRUTE;
-				isMob = true;
-			}
-			case "zoglin" -> {
-				entityType = EntityType.ZOGLIN;
-				isMob = true;
-			}
-			case "strider" -> {
-				entityType = EntityType.STRIDER;
-				isMob = true;
-			}
-			case "bee" -> {
-				entityType = EntityType.BEE;
-				isMob = true;
-			}
-			case "wither_skeleton" -> {
-				entityType = EntityType.WITHER_SKELETON;
-				isMob = true;
-			}
-			case "zombie_villager" -> {
-				entityType = EntityType.ZOMBIE_VILLAGER;
-				isMob = true;
-			}
-			case "creeper" -> {
-				entityType = EntityType.CREEPER;
-				isMob = true;
-			}
-			case "panda" -> {
-				entityType = EntityType.PANDA;
-				isMob = true;
-				try {
-					mainGene = Panda.Gene.valueOf(mainGeneType.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid panda main gene: " + mainGeneType);
-					mainGene = null;
-				}
-				try {
-					hiddenGene = Panda.Gene.valueOf(hiddenGeneType.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid panda hidden gene: " + hiddenGeneType);
-					hiddenGene = null;
-				}
-			}
-			case "villager" -> {
-				entityType = EntityType.VILLAGER;
-				isMob = true;
-				try {
-					profession = Villager.Profession.valueOf(type.toUpperCase());
-				} catch (Exception e) {
-					MagicSpells.error("Invalid villager profession: " + type);
-					profession = null;
-				}
-			}
-			case "sheep" -> {
-				entityType = EntityType.SHEEP;
-				isMob = true;
-				try {
-					dyeColor = DyeColor.valueOf(color.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid sheep color: " + color);
-					dyeColor = null;
-				}
-			}
-			case "rabbit" -> {
-				entityType = EntityType.RABBIT;
-				isMob = true;
-				try {
-					rabbitType = Rabbit.Type.valueOf(type.toUpperCase());
-				} catch (Exception e) {
-					MagicSpells.error("Invalid rabbit type: " + type);
-					rabbitType = null;
-				}
-			}
-			case "wolf" -> {
-				entityType = EntityType.WOLF;
-				isMob = true;
-				try {
-					dyeColor = DyeColor.valueOf(color.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid wolf collar color: " + color);
-					dyeColor = null;
-				}
-			}
-			case "fox" -> {
-				entityType = EntityType.FOX;
-				isMob = true;
-				try {
-					foxType = Fox.Type.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid fox type: " + type);
-					foxType = null;
-				}
-			}
-			case "cat" -> {
-				entityType = EntityType.CAT;
-				isMob = true;
-				try {
-					catType = Cat.Type.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid cat type: " + type);
-					catType = null;
-				}
-			}
-			case "goat" -> {
-				entityType = EntityType.GOAT;
-				isMob = true;
-			}
-			case "glow_squid" -> {
-				entityType = EntityType.GLOW_SQUID;
-				isMob = true;
-			}
-			case "allay" -> {
-				entityType = EntityType.ALLAY;
-				isMob = true;
-			}
-			case "axolotl" -> {
-				entityType = EntityType.AXOLOTL;
-				isMob = true;
-				try {
-					axolotlVariant = Axolotl.Variant.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid axolotl variant: " + type);
-					axolotlVariant = null;
-				}
-			}
-			case "frog" -> {
-				entityType = EntityType.FROG;
-				isMob = true;
-				try {
-					frogVariant = Frog.Variant.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid frog variant: " + type);
-					frogVariant = null;
-				}
-			}
-			case "tadpole" -> {
-				entityType = EntityType.TADPOLE;
-				isMob = true;
-			}
-			case "warden" -> {
-				entityType = EntityType.WARDEN;
-				isMob = true;
-			}
-			case "pig" -> {
-				entityType = EntityType.PIG;
-				isMob = true;
-			}
-			case "iron_golem" -> {
-				entityType = EntityType.IRON_GOLEM;
-				isMob = true;
-			}
-			case "mooshroom" -> {
-				entityType = EntityType.MUSHROOM_COW;
-				isMob = true;
-				try {
-					cowVariant = MushroomCow.Variant.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid mooshroom type: " + type);
-					cowVariant = null;
-				}
-			}
-			case "magma_cube" -> {
-				entityType = EntityType.MAGMA_CUBE;
-				isMob = true;
-			}
-			case "ocelot" -> {
-				entityType = EntityType.OCELOT;
-				isMob = true;
-			}
-			case "snow_golem" -> {
-				entityType = EntityType.SNOWMAN;
-				isMob = true;
-			}
-			case "wither" -> {
-				entityType = EntityType.WITHER;
-				isMob = true;
-			}
-			case "ender_dragon" -> {
-				entityType = EntityType.ENDER_DRAGON;
-				isMob = true;
-			}
-			case "horse" -> {
-				entityType = EntityType.HORSE;
-				isMob = true;
-				try {
-					horseColor = Horse.Color.valueOf(color.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid horse color: " + color);
-					horseColor = null;
-				}
-				try {
-					horseStyle = Horse.Style.valueOf(style.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid horse style: " + style);
-					horseStyle = null;
-				}
-			}
-			case "skeleton_horse" -> {
-				entityType = EntityType.SKELETON_HORSE;
-				isMob = true;
-			}
-			case "zombie_horse" -> {
-				entityType = EntityType.ZOMBIE_HORSE;
-				isMob = true;
-			}
-			case "mule" -> {
-				entityType = EntityType.MULE;
-				isMob = true;
-			}
-			case "donkey" -> {
-				entityType = EntityType.DONKEY;
-				isMob = true;
-			}
-			case "elder_guardian" -> {
-				entityType = EntityType.ELDER_GUARDIAN;
-				isMob = true;
-			}
-			case "slime" -> {
-				entityType = EntityType.SLIME;
-				isMob = true;
-			}
-			case "cod" -> {
-				entityType = EntityType.COD;
-				isMob = true;
-			}
-			case "salmon" -> {
-				entityType = EntityType.SALMON;
-				isMob = true;
-			}
-			case "pufferfish" -> {
-				entityType = EntityType.PUFFERFISH;
-				isMob = true;
-			}
-			case "tropical_fish" -> {
-				entityType = EntityType.TROPICAL_FISH;
-				isMob = true;
-				try {
-					fishPattern = TropicalFish.Pattern.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid fish pattern: " + type);
-					fishPattern = null;
-				}
-				try {
-					dyeColor = DyeColor.valueOf(color.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid fish body color: " + color);
-					dyeColor = null;
-				}
-				try {
-					patternDyeColor = DyeColor.valueOf(patternColor.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid fish pattern color: " + patternColor);
-					patternDyeColor = null;
-				}
-			}
-			case "llama" -> {
-				entityType = EntityType.LLAMA;
-				isMob = true;
-				try {
-					llamaColor = Llama.Color.valueOf(color.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid llama color: " + color);
-					llamaColor = null;
-				}
-				material = Util.getMaterial(mat);
-				if (material == null) {
-					MagicSpells.error("Invalid llama material: " + mat);
-					material = null;
-				}
-			}
-			case "polar_bear" -> {
-				entityType = EntityType.POLAR_BEAR;
-				isMob = true;
-			}
-			case "armor_stand" -> {
-				entityType = EntityType.ARMOR_STAND;
-				isMisc = true;
-			}
-			case "bat" -> {
-				entityType = EntityType.BAT;
-				isMob = true;
-			}
-			case "blaze" -> {
-				entityType = EntityType.BLAZE;
-				isMob = true;
-			}
-			case "dolphin" -> {
-				entityType = EntityType.DOLPHIN;
-				isMob = true;
-			}
-			case "enderman" -> {
-				entityType = EntityType.ENDERMAN;
-				isMob = true;
-				material = Util.getMaterial(mat);
-				if (material == null) {
-					MagicSpells.error("Invalid enderman material: " + mat);
-					material = null;
-				}
-			}
-			case "ghast" -> {
-				entityType = EntityType.GHAST;
-				isMob = true;
-			}
-			case "guardian" -> {
-				entityType = EntityType.GUARDIAN;
-				isMob = true;
-			}
-			case "illusioner" -> {
-				entityType = EntityType.ILLUSIONER;
-				isMob = true;
-			}
-			case "vindicator" -> {
-				entityType = EntityType.VINDICATOR;
-				isMob = true;
-			}
-			case "evoker" -> {
-				entityType = EntityType.EVOKER;
-				isMob = true;
-			}
-			case "skeleton" -> {
-				entityType = EntityType.SKELETON;
-				isMob = true;
-			}
-			case "spider" -> {
-				entityType = EntityType.SPIDER;
-				isMob = true;
-			}
-			case "cave_spider" -> {
-				entityType = EntityType.CAVE_SPIDER;
-				isMob = true;
-			}
-			case "giant" -> {
-				entityType = EntityType.GIANT;
-				isMob = true;
-			}
-			case "zombie" -> {
-				entityType = EntityType.ZOMBIE;
-				isMob = true;
-			}
-			case "zombie_pigman", "zombified_piglin" -> {
-				entityType = MobUtil.getPigZombieEntityType();
-				isMob = true;
-			}
-			case "silverfish" -> {
-				entityType = EntityType.SILVERFISH;
-				isMob = true;
-			}
-			case "witch" -> {
-				entityType = EntityType.WITCH;
-				isMob = true;
-			}
-			case "endermite" -> {
-				entityType = EntityType.ENDERMITE;
-				isMob = true;
-			}
-			case "shulker" -> {
-				entityType = EntityType.SHULKER;
-				isMob = true;
-			}
-			case "cow" -> {
-				entityType = EntityType.COW;
-				isMob = true;
-			}
-			case "chicken" -> {
-				entityType = EntityType.CHICKEN;
-				isMob = true;
-			}
-			case "squid" -> {
-				entityType = EntityType.SQUID;
-				isMob = true;
-			}
-			case "parrot" -> {
-				entityType = EntityType.PARROT;
-				isMob = true;
-				try {
-					parrotVariant = Parrot.Variant.valueOf(type.toUpperCase());
-				} catch (Exception exception) {
-					MagicSpells.error("Invalid parrot variant: " + type);
-					parrotVariant = null;
-				}
-			}
-			case "turtle" -> {
-				entityType = EntityType.TURTLE;
-				isMob = true;
-			}
-			case "phantom" -> {
-				entityType = EntityType.PHANTOM;
-				isMob = true;
-			}
-			case "drowned" -> {
-				entityType = EntityType.DROWNED;
-				isMob = true;
-			}
-			case "falling_block" -> {
-				entityType = EntityType.FALLING_BLOCK;
-				isMisc = true;
-				material = Util.getMaterial(mat);
-				if (material == null || !material.isBlock()) {
-					MagicSpells.error("Invalid falling block material: " + mat);
-					material = null;
-				}
-			}
-			case "item" -> {
-				entityType = EntityType.DROPPED_ITEM;
-				isMisc = true;
-				material = Util.getMaterial(mat);
-				if (material == null) MagicSpells.error("Invalid item material: " + mat);
-			}
+	// Sheep & Tropical Fish & Wolf
+	private final ConfigData<DyeColor> color;
+
+	// Tameable
+	private final ConfigData<Boolean> tamed;
+
+	// Tropical Fish
+	private final ConfigData<TropicalFish.Pattern> tropicalFishPattern;
+	private final ConfigData<DyeColor> tropicalFishPatternColor;
+
+	// Villager
+	private final ConfigData<Villager.Profession> profession;
+
+	public EntityData(ConfigurationSection config) {
+		entityType = ConfigDataUtil.getEnum(config, "entity", EntityType.class, null);
+
+		relativeOffset = ConfigDataUtil.getVector(config, "relative-offset", new Vector(0, 0, 0));
+
+		Multimap<Class<?>, Transformer<?, ?>> transformers = MultimapBuilder.linkedHashKeys().arrayListValues().build();
+
+		// Ageable
+		baby = addBoolean(transformers, config, "baby", false, Ageable.class, (ageable, baby) -> {
+			if (baby) ageable.setBaby();
+			else ageable.setAdult();
+		});
+
+		if (config.contains("age"))
+			addInteger(transformers, config, "age", 0, Ageable.class, Ageable::setAge);
+
+		// Tameable
+		tamed = addBoolean(transformers, config, "tamed", false, Tameable.class, Tameable::setTamed);
+
+		// AbstractHorse
+		saddled = addBoolean(transformers, config, "saddled", false, AbstractHorse.class, (horse, saddled) -> {
+			if (saddled) horse.getInventory().setSaddle(new ItemStack(Material.SADDLE));
+		});
+
+		// Armor Stand
+		addBoolean(transformers, config, "small", false, ArmorStand.class, ArmorStand::setSmall);
+		addBoolean(transformers, config, "marker", false, ArmorStand.class, ArmorStand::setMarker);
+		addBoolean(transformers, config, "visible", true, ArmorStand.class, ArmorStand::setVisible);
+		addBoolean(transformers, config, "has-arms", true, ArmorStand.class, ArmorStand::setArms);
+		addBoolean(transformers, config, "has-base-plate", true, ArmorStand.class, ArmorStand::setBasePlate);
+
+		EulerAngle def = new EulerAngle(0, 0, 0);
+		addEulerAngle(transformers, config, "head-angle", def, ArmorStand.class, ArmorStand::setHeadPose);
+		addEulerAngle(transformers, config, "body-angle", def, ArmorStand.class, ArmorStand::setBodyPose);
+		addEulerAngle(transformers, config, "left-arm-angle", def, ArmorStand.class, ArmorStand::setLeftArmPose);
+		addEulerAngle(transformers, config, "right-arm-angle", def, ArmorStand.class, ArmorStand::setRightArmPose);
+		addEulerAngle(transformers, config, "left-leg-angle", def, ArmorStand.class, ArmorStand::setLeftLegPose);
+		addEulerAngle(transformers, config, "right-leg-angle", def, ArmorStand.class, ArmorStand::setRightLegPose);
+
+		// Axolotl
+		addEnum(transformers, config, "type", null, Axolotl.class, Axolotl.Variant.class, (axolotl, variant) -> {
+			if (variant != null) axolotl.setVariant(variant);
+		});
+
+		// Cat
+		addEnum(transformers, config, "type", null, Cat.class, Cat.Type.class, (cat, type) -> {
+			if (type != null) cat.setCatType(type);
+		});
+
+		// ChestedHorse
+		chested = addBoolean(transformers, config, "chested", false, ChestedHorse.class, ChestedHorse::setCarryingChest);
+
+		// Creeper
+		powered = addBoolean(transformers, config, "powered", false, Creeper.class, Creeper::setPowered);
+
+		// Dropped Item
+		dropItemMaterial = ConfigDataUtil.getMaterial(config, "material", null);
+
+		// Enderman
+		carriedBlockData = addBlockData(transformers, config, "material", null, Enderman.class, Enderman::setCarriedBlock);
+
+		// Falling Block
+		fallingBlockData = ConfigDataUtil.getBlockData(config, "material", null);
+
+		// Fox
+		addEnum(transformers, config, "type", null, Fox.class, Fox.Type.class, (fox, type) -> {
+			if (type != null) fox.setFoxType(type);
+		});
+
+		// Frog
+		addEnum(transformers, config, "type", null, Frog.class, Frog.Variant.class, (frog, variant) -> {
+			if (variant != null) frog.setVariant(variant);
+		});
+
+		// Horse
+		horseColor = addEnum(transformers, config, "color", null, Horse.class, Horse.Color.class, (horse, color) -> {
+			if (color != null) horse.setColor(color);
+		});
+		horseStyle = addEnum(transformers, config, "style", null, Horse.class, Horse.Style.class, (horse, style) -> {
+			if (style != null) horse.setStyle(style);
+		});
+
+		// Llama
+		llamaColor = addEnum(transformers, config, "color", null, Llama.class, Llama.Color.class, (llama, color) -> {
+			if (color != null) llama.setColor(color);
+		});
+		addMaterial(transformers, config, "material", null, Llama.class, (llama, material) -> {
+			if (material != null) llama.getInventory().setDecor(new ItemStack(material));
+		});
+
+		// Mushroom Cow
+		addEnum(transformers, config, "type", null, MushroomCow.class, MushroomCow.Variant.class, (mushroomCow, variant) -> {
+			if (variant != null) mushroomCow.setVariant(variant);
+		});
+
+		// Panda
+		addEnum(transformers, config, "main-gene", null, Panda.class, Panda.Gene.class, (panda, gene) -> {
+			if (gene != null) panda.setMainGene(gene);
+		});
+		addEnum(transformers, config, "hidden-gene", null, Panda.class, Panda.Gene.class, (panda, gene) -> {
+			if (gene != null) panda.setHiddenGene(gene);
+		});
+
+		// Parrot
+		parrotVariant = addEnum(transformers, config, "type", null, Parrot.class, Parrot.Variant.class, (parrot, variant) -> {
+			if (variant != null) parrot.setVariant(variant);
+		});
+
+		// Phantom
+		addInteger(transformers, config, "size", 0, Phantom.class, Phantom::setSize);
+
+		// Puffer Fish
+		size = addInteger(transformers, config, "size", 0, PufferFish.class, PufferFish::setPuffState);
+
+		// Rabbit
+		addEnum(transformers, config, "type", null, Rabbit.class, Rabbit.Type.class, (rabbit, type) -> {
+			if (type != null) rabbit.setRabbitType(type);
+		});
+
+		// Sheep
+		sheared = addBoolean(transformers, config, "sheared", false, Sheep.class, Sheep::setSheared);
+		color = addEnum(transformers, config, "color", null, Sheep.class, DyeColor.class, (sheep, color) -> {
+			if (color != null) sheep.setColor(color);
+		});
+
+		// Slime
+		addInteger(transformers, config, "size", 0, Slime.class, Slime::setSize);
+
+		// Steerable
+		addBoolean(transformers, config, "saddled", false, Steerable.class, Steerable::setSaddle);
+
+		// Tropical Fish
+		addEnum(transformers, config, "color", null, TropicalFish.class, DyeColor.class, (tropicalFish, color) -> {
+			if (color != null) tropicalFish.setBodyColor(color);
+		});
+		tropicalFishPatternColor = addEnum(transformers, config, "pattern-color", null, TropicalFish.class, DyeColor.class, (tropicalFish, color) -> {
+			if (color != null) tropicalFish.setPatternColor(color);
+		});
+		tropicalFishPattern = addEnum(transformers, config, "type", null, TropicalFish.class, TropicalFish.Pattern.class, (tropicalFish, pattern) -> {
+			if (pattern != null) tropicalFish.setPattern(pattern);
+		});
+
+		// Villager
+		profession = addEnum(transformers, config, "type", null, Villager.class, Villager.Profession.class, (villager, profession) -> {
+			if (profession != null) villager.setProfession(profession);
+		});
+
+		// Wolf
+		addBoolean(transformers, config, "angry", false, Wolf.class, Wolf::setAngry);
+		addEnum(transformers, config, "color", null, Wolf.class, DyeColor.class, (wolf, color) -> {
+			if (color != null) wolf.setCollarColor(color);
+		});
+
+		for (EntityType entityType : EntityType.values()) {
+			Class<? extends Entity> entityClass = entityType.getEntityClass();
+			if (entityClass == null) continue;
+
+			for (Class<?> transformerType : transformers.keys())
+				if (transformerType.isAssignableFrom(entityClass))
+					options.putAll(entityType, transformers.get(transformerType));
 		}
 	}
 
-	public EntityType getEntityType() {
-		return entityType;
+	@Nullable
+	public Entity spawn(@NotNull Location location) {
+		return spawn(location, null, null);
 	}
 
-	public void setEntityType(EntityType entityType) {
-		this.entityType = entityType;
+	@Nullable
+	public Entity spawn(@NotNull Location location, @Nullable Consumer<Entity> consumer) {
+		return spawn(location, null, consumer);
 	}
 
-	public boolean isVisible() {
-		return visible;
-	}
-
-	public void setVisible(boolean visible) {
-		this.visible = visible;
-	}
-
-	public Material getMaterial() {
-		return material;
-	}
-
-	public boolean isPlayer() {
-		return isPlayer;
-	}
-
-	public boolean isMob() {
-		return isMob;
-	}
-
-	public boolean isMisc() {
-		return isMisc;
-	}
-
-	public boolean isBaby() {
-		return baby;
-	}
-
-	public boolean isTamed() {
-		return tamed;
-	}
-
-	public boolean isAngry() {
-		return angry;
-	}
-
-	public boolean isPowered() {
-		return powered;
-	}
-
-	public boolean isChested() {
-		return chested;
-	}
-
-	public boolean isSaddled() {
-		return saddled;
-	}
-
-	public boolean isSheared() {
-		return sheared;
-	}
-
-	public int getSize() {
-		return size;
-	}
-
-	public Fox.Type getFoxType() {
-		return foxType;
-	}
-
-	public Villager.Profession getProfession() {
-		return profession;
-	}
-
-	public Horse.Color getHorseColor() {
-		return horseColor;
-	}
-
-	public Horse.Style getHorseStyle() {
-		return horseStyle;
-	}
-
-	public DyeColor getDyeColor() {
-		return dyeColor;
-	}
-
-	public DyeColor getPatternDyeColor() {
-		return patternDyeColor;
-	}
-
-	public TropicalFish.Pattern getFishPattern() {
-		return fishPattern;
-	}
-
-	public Llama.Color getLlamaColor() {
-		return llamaColor;
-	}
-
-	public Parrot.Variant getParrotVariant() {
-		return parrotVariant;
-	}
-
-	public Frog.Variant getFrogVariant() {
-		return frogVariant;
-	}
-
-	public Axolotl.Variant getAxolotlVariant() {
-		return axolotlVariant;
-	}
-
-	public Rabbit.Type getRabbitType() {
-		return rabbitType;
-	}
-
-	public Cat.Type getCatType() {
-		return catType;
-	}
-
-	public MushroomCow.Variant getCowVariant() {
-		return cowVariant;
-	}
-
-	public Panda.Gene getMainGene() {
-		return mainGene;
-	}
-
-	public Panda.Gene getHiddenGene() {
-		return hiddenGene;
-	}
-
-	public Entity spawn(Location location) {
-		return spawn(location, null);
-	}
-
-	public Entity spawn(Location location, Consumer<Entity> consumer) {
-		if (location == null) throw new NullPointerException("location");
-
+	@Nullable
+	public Entity spawn(@NotNull Location location, @Nullable SpellData data, @Nullable Consumer<Entity> consumer) {
 		Location startLoc = location.clone();
 		Vector dir = startLoc.getDirection().normalize();
+		Vector relativeOffset = this.relativeOffset.get(data);
 
 		Vector horizOffset = new Vector(-dir.getZ(), 0, dir.getX()).normalize();
 		startLoc.add(horizOffset.multiply(relativeOffset.getZ())).getBlock().getLocation();
 		startLoc.add(startLoc.getDirection().clone().multiply(relativeOffset.getX()));
 		startLoc.setY(startLoc.getY() + relativeOffset.getY());
 
+		EntityType entityType = this.entityType.get(data);
+		if (entityType == null || (!entityType.isSpawnable() && entityType != EntityType.FALLING_BLOCK && entityType != EntityType.DROPPED_ITEM))
+			return null;
+
 		return switch (entityType) {
-			case FALLING_BLOCK -> startLoc.getWorld().spawnFallingBlock(startLoc, material.createBlockData());
-			case DROPPED_ITEM -> startLoc.getWorld().dropItem(startLoc, new ItemStack(material));
-			default -> startLoc.getWorld().spawn(startLoc, (Class<Entity>) entityType.getEntityClass(), entity -> {
-				if (entity instanceof Ageable ageable) {
-					if (baby) ageable.setBaby();
-					else ageable.setAdult();
-				}
+			case FALLING_BLOCK -> {
+				BlockData blockData = fallingBlockData.get(data);
+				if (blockData == null) yield null;
 
-				if (entity instanceof AbstractHorse horse && isSaddled())
-					horse.getInventory().setSaddle(new ItemStack(Material.SADDLE));
-
-				if (entity instanceof ChestedHorse horse)
-					horse.setCarryingChest(isChested());
-
-				if (entity instanceof Slime slime)
-					slime.setSize(getSize());
-
-				if (entity instanceof Phantom phantom)
-					phantom.setSize(getSize());
-
-				switch (entityType) {
-					case ARMOR_STAND -> {
-						((ArmorStand) entity).setSmall(small);
-						((ArmorStand) entity).setArms(hasArms);
-						((ArmorStand) entity).setMarker(marker);
-						((ArmorStand) entity).setVisible(visible);
-						((ArmorStand) entity).setBasePlate(hasBasePlate);
-						((ArmorStand) entity).setHeadPose(headAngle);
-						((ArmorStand) entity).setBodyPose(bodyAngle);
-						((ArmorStand) entity).setLeftArmPose(leftArmAngle);
-						((ArmorStand) entity).setRightArmPose(rightArmAngle);
-						((ArmorStand) entity).setLeftLegPose(leftLegAngle);
-						((ArmorStand) entity).setRightLegPose(rightLegAngle);
-					}
-					case CREEPER -> ((Creeper) entity).setPowered(isPowered());
-					case ENDERMAN -> ((Enderman) entity).setCarriedBlock(material.createBlockData());
-					case WOLF -> {
-						((Wolf) entity).setAngry(isAngry());
-						((Wolf) entity).setTamed(isTamed());
-						if (tamed) ((Wolf) entity).setCollarColor(dyeColor);
-					}
-					case VILLAGER -> ((Villager) entity).setProfession(profession);
-					case PIG -> ((Pig) entity).setSaddle(saddled);
-					case SHEEP -> {
-						((Sheep) entity).setSheared(sheared);
-						((Sheep) entity).setColor(dyeColor);
-					}
-					case RABBIT -> ((Rabbit) entity).setRabbitType(rabbitType);
-					case HORSE -> {
-						((Horse) entity).setColor(horseColor);
-						((Horse) entity).setStyle(horseStyle);
-					}
-					case LLAMA -> {
-						((Llama) entity).setColor(llamaColor);
-						((Llama) entity).getInventory().setDecor(new ItemStack(material));
-					}
-					case PUFFERFISH -> ((PufferFish) entity).setPuffState(size);
-					case TROPICAL_FISH -> {
-						((TropicalFish) entity).setBodyColor(dyeColor);
-						((TropicalFish) entity).setPatternColor(patternDyeColor);
-						((TropicalFish) entity).setPattern(fishPattern);
-					}
-					case PARROT -> ((Parrot) entity).setVariant(parrotVariant);
-					case FOX -> ((Fox) entity).setFoxType(foxType);
-					case CAT -> ((Cat) entity).setCatType(catType);
-					case MUSHROOM_COW -> ((MushroomCow) entity).setVariant(cowVariant);
-					case PANDA -> {
-						((Panda) entity).setMainGene(mainGene);
-						((Panda) entity).setHiddenGene(hiddenGene);
-					}
-					case FROG -> ((Frog) entity).setVariant(frogVariant);
-					case AXOLOTL -> ((Axolotl) entity).setVariant(axolotlVariant);
-				}
-
+				Entity entity = startLoc.getWorld().spawnFallingBlock(startLoc, blockData);
 				if (consumer != null) consumer.accept(entity);
-			});
+
+				yield entity;
+			}
+			case DROPPED_ITEM -> {
+				Material material = dropItemMaterial.get(data);
+				if (material == null) yield null;
+
+				Entity entity = startLoc.getWorld().dropItem(startLoc, new ItemStack(material));
+				if (consumer != null) consumer.accept(entity);
+
+				yield entity;
+			}
+			default -> {
+				Class<? extends Entity> entityClass = entityType.getEntityClass();
+				if (entityClass == null) yield null;
+
+				yield startLoc.getWorld().spawn(startLoc, entityClass, e -> {
+					Collection<Transformer<?, ?>> transformers = options.get(entityType);
+					//noinspection rawtypes
+					for (Transformer transformer : transformers)
+						//noinspection unchecked
+						transformer.apply(e, data);
+
+					if (consumer != null) consumer.accept(e);
+				});
+			}
 		};
+	}
+
+	private <T> ConfigData<Boolean> addBoolean(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, boolean def, Class<T> type, BiConsumer<T, Boolean> setter) {
+		ConfigData<Boolean> supplier = ConfigDataUtil.getBoolean(config, name, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	private <T> ConfigData<Integer> addInteger(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, int def, Class<T> type, BiConsumer<T, Integer> setter) {
+		ConfigData<Integer> supplier = ConfigDataUtil.getInteger(config, name, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	private <T> ConfigData<Material> addMaterial(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, Material def, Class<T> type, BiConsumer<T, Material> setter) {
+		ConfigData<Material> supplier = ConfigDataUtil.getMaterial(config, name, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	private <T> ConfigData<BlockData> addBlockData(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, BlockData def, Class<T> type, BiConsumer<T, BlockData> setter) {
+		ConfigData<BlockData> supplier = ConfigDataUtil.getBlockData(config, name, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	private <T, E extends Enum<E>> ConfigData<E> addEnum(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, E def, Class<T> type, Class<E> enumType, BiConsumer<T, E> setter) {
+		ConfigData<E> supplier = ConfigDataUtil.getEnum(config, name, enumType, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	private <T> ConfigData<EulerAngle> addEulerAngle(Multimap<Class<?>, Transformer<?, ?>> transformers, ConfigurationSection config, String name, EulerAngle def, Class<T> type, BiConsumer<T, EulerAngle> setter) {
+		ConfigData<EulerAngle> supplier = ConfigDataUtil.getEulerAngle(config, name, def);
+		transformers.put(type, new Transformer<>(supplier, setter));
+
+		return supplier;
+	}
+
+	public Multimap<EntityType, Transformer<?, ?>> getOptions() {
+		return options;
+	}
+
+	public ConfigData<EntityType> getEntityType() {
+		return entityType;
+	}
+
+	public void setEntityType(ConfigData<EntityType> entityType) {
+		this.entityType = entityType;
+	}
+
+	public ConfigData<Material> getDroppedItemStack() {
+		return dropItemMaterial;
+	}
+
+	public ConfigData<BlockData> getFallingBlockData() {
+		return fallingBlockData;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getBaby() {
+		return baby;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getChested() {
+		return chested;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getPowered() {
+		return powered;
+	}
+
+	@Deprecated
+	public ConfigData<BlockData> getCarriedBlockData() {
+		return carriedBlockData;
+	}
+
+	@Deprecated
+	public ConfigData<Horse.Color> getHorseColor() {
+		return horseColor;
+	}
+
+	@Deprecated
+	public ConfigData<Horse.Style> getHorseStyle() {
+		return horseStyle;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getSaddled() {
+		return saddled;
+	}
+
+	@Deprecated
+	public ConfigData<Llama.Color> getLlamaColor() {
+		return llamaColor;
+	}
+
+	@Deprecated
+	public ConfigData<Parrot.Variant> getParrotVariant() {
+		return parrotVariant;
+	}
+
+	@Deprecated
+	public ConfigData<Integer> getSize() {
+		return size;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getSheared() {
+		return sheared;
+	}
+
+	@Deprecated
+	public ConfigData<DyeColor> getColor() {
+		return color;
+	}
+
+	@Deprecated
+	public ConfigData<Boolean> getTamed() {
+		return tamed;
+	}
+
+	@Deprecated
+	public ConfigData<TropicalFish.Pattern> getTropicalFishPattern() {
+		return tropicalFishPattern;
+	}
+
+	@Deprecated
+	public ConfigData<DyeColor> getTropicalFishPatternColor() {
+		return tropicalFishPatternColor;
+	}
+
+	@Deprecated
+	public ConfigData<Villager.Profession> getProfession() {
+		return profession;
+	}
+
+	public record Transformer<T, C>(ConfigData<C> supplier, BiConsumer<T, C> setter) {
+
+		public void apply(T entity, SpellData data) {
+			setter.accept(entity, supplier.get(data));
+		}
+
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -10,6 +10,8 @@ import org.bukkit.Color;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.Particle;
+import org.bukkit.util.Vector;
+import org.bukkit.util.EulerAngle;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.Particle.DustOptions;
@@ -441,6 +443,86 @@ public class ConfigDataUtil {
 
 			};
 		}
+	}
+
+	@NotNull
+	public static ConfigData<Vector> getVector(@NotNull ConfigurationSection config, @NotNull String path, @NotNull Vector def) {
+		if (config.isString(path)) {
+			String value = config.getString(path);
+			if (value == null) return (caster, target, power, args) -> def;
+
+			String[] data = value.split(",");
+			if (data.length != 3) return (caster, target, power, args) -> def;
+
+			try {
+				Vector vector = new Vector(Double.parseDouble(data[0]), Double.parseDouble(data[1]), Double.parseDouble(data[2]));
+				return (caster, target, power, args) -> vector;
+			} catch (NumberFormatException e) {
+				return (caster, target, power, args) -> def;
+			}
+		}
+
+		if (config.isConfigurationSection(path)) {
+			ConfigurationSection section = config.getConfigurationSection(path);
+			if (section == null) return (caster, target, power, args) -> def;
+
+			ConfigData<Double> x = getDouble(section, "x", def.getX());
+			ConfigData<Double> y = getDouble(section, "y", def.getY());
+			ConfigData<Double> z = getDouble(section, "z", def.getZ());
+
+			if (x.isConstant() && y.isConstant() && z.isConstant()) {
+				Vector vector = new Vector(x.get(null), y.get(null), z.get(null));
+				return (caster, target, power, args) -> vector;
+			}
+
+			return (caster, target, power, args) -> new Vector(
+				x.get(caster, target, power, args),
+				y.get(caster, target, power, args),
+				z.get(caster, target, power, args)
+			);
+		}
+
+		return (caster, target, power, args) -> def;
+	}
+
+	@NotNull
+	public static ConfigData<EulerAngle> getEulerAngle(@NotNull ConfigurationSection config, @NotNull String path, @NotNull EulerAngle def) {
+		if (config.isString(path)) {
+			String value = config.getString(path);
+			if (value == null) return (caster, target, power, args) -> def;
+
+			String[] data = value.split(",");
+			if (data.length != 3) return (caster, target, power, args) -> def;
+
+			try {
+				EulerAngle angle = new EulerAngle(Double.parseDouble(data[0]), Double.parseDouble(data[1]), Double.parseDouble(data[2]));
+				return (caster, target, power, args) -> angle;
+			} catch (NumberFormatException e) {
+				return (caster, target, power, args) -> def;
+			}
+		}
+
+		if (config.isConfigurationSection(path)) {
+			ConfigurationSection section = config.getConfigurationSection(path);
+			if (section == null) return (caster, target, power, args) -> def;
+
+			ConfigData<Double> x = getDouble(section, "x", def.getX());
+			ConfigData<Double> y = getDouble(section, "y", def.getY());
+			ConfigData<Double> z = getDouble(section, "z", def.getZ());
+
+			if (x.isConstant() && y.isConstant() && z.isConstant()) {
+				EulerAngle angle = new EulerAngle(x.get(null), y.get(null), z.get(null));
+				return (caster, target, power, args) -> angle;
+			}
+
+			return (caster, target, power, args) -> new EulerAngle(
+				x.get(caster, target, power, args),
+				y.get(caster, target, power, args),
+				z.get(caster, target, power, args)
+			);
+		}
+
+		return (caster, target, power, args) -> def;
 	}
 
 	@NotNull

--- a/core/src/main/java/com/nisovin/magicspells/util/data/DataEntity.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/data/DataEntity.java
@@ -27,6 +27,8 @@ public class DataEntity {
 		dataElements.put("falldistance", entity -> entity.getFallDistance() + "");
 		dataElements.put("fireticks", entity -> entity.getFireTicks() + "");
 		dataElements.put("tickslived", entity -> entity.getTicksLived() + "");
+		dataElements.put("height", entity -> entity.getHeight() + "");
+		dataElements.put("width", entity -> entity.getWidth() + "");
 		dataElements.put("class", entity -> entity.getClass().toString());
 		dataElements.put("class.canonicalname", entity -> entity.getClass().getCanonicalName());
 		dataElements.put("class.simplename", entity -> entity.getClass().getSimpleName());

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BlockDataHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BlockDataHandler.java
@@ -1,0 +1,49 @@
+package com.nisovin.magicspells.util.itemreader;
+
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.block.data.BlockData;
+import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.inventory.meta.BlockDataMeta;
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.BLOCK_DATA;
+
+public class BlockDataHandler {
+
+	private static final String CONFIG_NAME = BLOCK_DATA.toString();
+
+	public static void process(ConfigurationSection config, ItemMeta meta, MagicItemData data, Material material) {
+		if (!(meta instanceof BlockDataMeta blockDataMeta) || !config.isString(CONFIG_NAME)) return;
+
+		String blockDataString = config.getString(CONFIG_NAME);
+		if (blockDataString == null) return;
+
+		BlockData blockData;
+		try {
+			blockData = Bukkit.createBlockData(material, blockDataString);
+		} catch (IllegalArgumentException e) {
+			MagicSpells.error("Invalid block data '" + blockDataString + "' when parsing magic item.");
+			DebugHandler.debugIllegalArgumentException(e);
+
+			return;
+		}
+
+		blockDataMeta.setBlockData(blockData);
+		data.setAttribute(BLOCK_DATA, blockData);
+	}
+
+	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
+		if (!(meta instanceof BlockDataMeta blockDataMeta) || !data.hasAttribute(BLOCK_DATA)) return;
+		blockDataMeta.setBlockData((BlockData) data.getAttribute(BLOCK_DATA));
+	}
+
+	public static void processMagicItemData(ItemMeta meta, MagicItemData data, Material material) {
+		if (!(meta instanceof BlockDataMeta blockDataMeta) || !blockDataMeta.hasBlockData()) return;
+		data.setAttribute(BLOCK_DATA, blockDataMeta.getBlockData(material));
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -18,6 +18,7 @@ import org.bukkit.potion.PotionData;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.attribute.AttributeModifier;
@@ -27,784 +28,815 @@ import com.nisovin.magicspells.util.TxtUtil;
 
 public class MagicItemData {
 
-    private final EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
-    private final EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
-    private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+	private final EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
+	private final EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+	private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
 
-    private boolean strictEnchantLevel = true;
-    private boolean strictDurability = true;
-    private boolean strictEnchants = true;
+	private boolean strictEnchantLevel = true;
+	private boolean strictDurability = true;
+	private boolean strictBlockData = true;
+	private boolean strictEnchants = true;
 
-    public Object getAttribute(MagicItemAttribute attr) {
-        return itemAttributes.get(attr);
-    }
+	public Object getAttribute(MagicItemAttribute attr) {
+		return itemAttributes.get(attr);
+	}
 
-    public void setAttribute(MagicItemAttribute attr, Object obj) {
-        if (obj == null) return;
-        if (!attr.getDataType().isAssignableFrom(obj.getClass())) return;
+	public void setAttribute(MagicItemAttribute attr, Object obj) {
+		if (obj == null) return;
+		if (!attr.getDataType().isAssignableFrom(obj.getClass())) return;
 
-        itemAttributes.put(attr, obj);
-    }
+		itemAttributes.put(attr, obj);
+	}
 
-    public void removeAttribute(MagicItemAttribute attr) {
-        itemAttributes.remove(attr);
-    }
+	public void removeAttribute(MagicItemAttribute attr) {
+		itemAttributes.remove(attr);
+	}
 
-    public boolean hasAttribute(MagicItemAttribute atr) {
-        return itemAttributes.containsKey(atr);
-    }
-
-    public EnumSet<MagicItemAttribute> getBlacklistedAttributes() {
-        return blacklistedAttributes;
-    }
-
-    public EnumSet<MagicItemAttribute> getIgnoredAttributes() {
-        return ignoredAttributes;
-    }
-
-    public boolean isStrictEnchantLevel() {
-        return strictEnchantLevel;
-    }
-
-    public void setStrictEnchantLevel(boolean strictEnchantLevel) {
-        this.strictEnchantLevel = strictEnchantLevel;
-    }
-
-    public boolean isStrictDurability() {
-        return strictDurability;
-    }
-
-    public void setStrictDurability(boolean strictDurability) {
-        this.strictDurability = strictDurability;
-    }
+	public boolean hasAttribute(MagicItemAttribute atr) {
+		return itemAttributes.containsKey(atr);
+	}
 
-    public boolean isStrictEnchants() {
-        return strictEnchants;
-    }
-
-    public void setStrictEnchants(boolean strictEnchants) {
-        this.strictEnchants = strictEnchants;
-    }
-
-    private boolean hasEqualAttributes(MagicItemData other) {
-        Multimap<Attribute, AttributeModifier> attrSelf = (Multimap<Attribute, AttributeModifier>) itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
-        Multimap<Attribute, AttributeModifier> attrOther = (Multimap<Attribute, AttributeModifier>) other.itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
-
-        Set<Attribute> keysSelf = attrSelf.keySet();
-        Set<Attribute> keysOther = attrOther.keySet();
-        if (!keysSelf.equals(keysOther)) return false;
-
-        record AttributeModifierData(String name, double amt, AttributeModifier.Operation op, EquipmentSlot slot) {
-
-            public AttributeModifierData(AttributeModifier mod) {
-                this(mod.getName(), mod.getAmount(), mod.getOperation(), mod.getSlot());
-            }
-
-        }
-
-        for (Attribute attr : keysSelf) {
-            Collection<AttributeModifier> modsSelf = attrSelf.get(attr);
-            Collection<AttributeModifier> modsOther = attrOther.get(attr);
-            if (modsSelf.size() != modsOther.size()) return false;
-
-            HashMap<AttributeModifierData, Integer> freq = new HashMap<>();
-            for (AttributeModifier mod : modsSelf) {
-                AttributeModifierData data = new AttributeModifierData(mod);
-                Integer count = freq.get(data);
-
-                if (count == null) count = 0;
-                freq.put(data, count + 1);
-            }
-
-            for (AttributeModifier mod : modsOther) {
-                AttributeModifierData data = new AttributeModifierData(mod);
-                Integer count = freq.get(data);
-
-                if (count == null) return false;
-                if (count == 1) freq.remove(data);
-                else freq.put(data, count - 1);
-            }
-        }
-
-        return true;
-    }
-
-    public boolean matches(MagicItemData data) {
-        if (this == data) return true;
-
-        Set<MagicItemAttribute> keysSelf = itemAttributes.keySet();
-        Set<MagicItemAttribute> keysOther = data.itemAttributes.keySet();
-
-        for (MagicItemAttribute attr : keysSelf) {
-            if (ignoredAttributes.contains(attr)) continue;
-            if (!keysOther.contains(attr)) return false;
-        }
-
-        for (MagicItemAttribute attr : blacklistedAttributes) {
-            if (keysOther.contains(attr)) return false;
-        }
-
-        for (MagicItemAttribute attr : keysSelf) {
-            if (ignoredAttributes.contains(attr)) continue;
-
-            switch (attr) {
-                case ATTRIBUTES -> {
-                    if (!hasEqualAttributes(data)) return false;
-                }
-                case DURABILITY -> {
-                    Integer durabilitySelf = (Integer) itemAttributes.get(attr);
-                    Integer durabilityOther = (Integer) data.itemAttributes.get(attr);
-
-                    int compare = durabilitySelf.compareTo(durabilityOther);
-                    if (strictDurability ? compare != 0 : compare < 0) return false;
-                }
-                case ENCHANTS -> {
-                    if (strictEnchants && strictEnchantLevel) {
-                        if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
-                            return false;
-
-                        continue;
-                    }
-
-                    Map<Enchantment, Integer> enchantsSelf = (Map<Enchantment, Integer>) itemAttributes.get(attr);
-                    Map<Enchantment, Integer> enchantsOther = (Map<Enchantment, Integer>) data.itemAttributes.get(attr);
-
-                    if (strictEnchants && enchantsSelf.size() != enchantsOther.size()) return false;
-
-                    for (Enchantment enchant : enchantsSelf.keySet()) {
-                        if (!enchantsOther.containsKey(enchant)) return false;
-
-                        Integer levelSelf = enchantsSelf.get(enchant);
-                        Integer levelOther = enchantsOther.get(enchant);
-
-                        int compare = levelSelf.compareTo(levelOther);
-                        if (strictEnchantLevel ? compare != 0 : compare > 0) return false;
-                    }
-                }
-                case NAME -> {
-                    Component nameSelf = (Component) itemAttributes.get(attr);
-                    Component nameOther = (Component) data.itemAttributes.get(attr);
-                    return Util.getLegacyFromComponent(nameSelf).equals(Util.getLegacyFromComponent(nameOther));
-                }
-                case LORE -> {
-                    List<Component> loreSelf = (List<Component>) itemAttributes.get(attr);
-                    List<Component> loreOther = (List<Component>) data.itemAttributes.get(attr);
-                    if (loreSelf.size() != loreOther.size()) return false;
-
-                    for (int i = 0; i < loreSelf.size(); i++) {
-                        String self = Util.getLegacyFromComponent(loreSelf.get(i));
-                        String other = Util.getLegacyFromComponent(loreOther.get(i));
-                        if (!self.equals(other)) return false;
-                    }
-                    return true;
-                }
-                default -> {
-                    if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
-                }
-            }
-        }
-
-        return true;
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof MagicItemData other)) return false;
-        return itemAttributes.equals(other.itemAttributes)
-            && ignoredAttributes.equals(other.ignoredAttributes)
-            && blacklistedAttributes.equals(other.blacklistedAttributes);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(itemAttributes, ignoredAttributes, blacklistedAttributes);
-    }
-
-    @Override
-    public MagicItemData clone() {
-        MagicItemData data = new MagicItemData();
-
-        if (!itemAttributes.isEmpty()) data.itemAttributes.putAll(itemAttributes);
-        if (!ignoredAttributes.isEmpty()) data.ignoredAttributes.addAll(ignoredAttributes);
-        if (!blacklistedAttributes.isEmpty()) data.blacklistedAttributes.addAll(blacklistedAttributes);
-
-        return data;
-    }
-
-    public enum MagicItemAttribute {
-
-        TYPE(Material.class),
-        NAME(Component.class),
-        AMOUNT(Integer.class),
-        DURABILITY(Integer.class),
-        REPAIR_COST(Integer.class),
-        CUSTOM_MODEL_DATA(Integer.class),
-        POWER(Integer.class),
-        UNBREAKABLE(Boolean.class),
-        HIDE_TOOLTIP(Boolean.class),
-        FAKE_GLINT(Boolean.class),
-        POTION_DATA(PotionData.class),
-        COLOR(Color.class),
-        FIREWORK_EFFECT(FireworkEffect.class),
-        TITLE(String.class),
-        AUTHOR(String.class),
-        UUID(String.class),
-        TEXTURE(String.class),
-        SIGNATURE(String.class),
-        SKULL_OWNER(String.class),
-        ENCHANTS(Map.class),
-        LORE(List.class),
-        PAGES(List.class),
-        POTION_EFFECTS(List.class),
-        PATTERNS(List.class),
-        FIREWORK_EFFECTS(List.class),
-        ATTRIBUTES(Multimap.class);
-
-        private final Class<?> dataType;
-        private final String asString;
-
-        MagicItemAttribute(Class<?> dataType) {
-            this.dataType = dataType;
-            asString = name().toLowerCase().replace('_', '-');
-        }
-
-        public Class<?> getDataType() {
-            return dataType;
-        }
-
-        @Override
-        public String toString() {
-            return asString;
-        }
-
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder output = new StringBuilder();
-        boolean previous = false;
-
-        if (hasAttribute(MagicItemAttribute.TYPE))
-            output.append(((Material) getAttribute(MagicItemAttribute.TYPE)).name());
-
-        if (hasAttribute(MagicItemAttribute.NAME)) {
-            output.append('{');
-
-            output
-                .append("\"name\":\"")
-                .append(TxtUtil.escapeJSON(Util.getStringFromComponent((Component) getAttribute(MagicItemAttribute.NAME))))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.AMOUNT)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"amount\":")
-                .append((int) getAttribute(MagicItemAttribute.AMOUNT));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.DURABILITY)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"durability\":")
-                .append((int) getAttribute(MagicItemAttribute.DURABILITY));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.REPAIR_COST)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"repair-cost\":")
-                .append((int) getAttribute(MagicItemAttribute.REPAIR_COST));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"custom-model-data\":")
-                .append((int) getAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.POWER)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"power\":")
-                .append((int) getAttribute(MagicItemAttribute.POWER));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.UNBREAKABLE)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"unbreakable\":")
-                .append((boolean) getAttribute(MagicItemAttribute.UNBREAKABLE));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.HIDE_TOOLTIP)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"hide-tooltip\":")
-                .append((boolean) getAttribute(MagicItemAttribute.HIDE_TOOLTIP));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.COLOR)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
-            String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-
-            output
-                .append("\"color\":\"")
-                .append(hex)
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.POTION_DATA)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            PotionData potionData = (PotionData) getAttribute(MagicItemAttribute.POTION_DATA);
-
-            output
-                .append("\"potion-data\":\"")
-                .append(potionData.getType());
-
-            if (potionData.isExtended()) output.append(" extended");
-            else if (potionData.isUpgraded()) output.append(" upgraded");
-
-            output.append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            FireworkEffect effect = (FireworkEffect) getAttribute(MagicItemAttribute.FIREWORK_EFFECT);
-
-            output
-                .append("\"firework-effect\":\"")
-                .append(effect.getType())
-                .append(' ')
-                .append(effect.hasTrail())
-                .append(' ')
-                .append(effect.hasFlicker());
-
-            boolean previousColor = false;
-            if (!effect.getColors().isEmpty()) {
-                output.append(' ');
-                for (Color color : effect.getColors()) {
-                    if (previousColor) output.append(',');
-
-                    String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-                    output.append(hex);
-
-                    previousColor = true;
-                }
-
-                if (!effect.getFadeColors().isEmpty()) {
-                    output.append(' ');
-                    previousColor = false;
-                    for (Color color : effect.getFadeColors()) {
-                        if (previousColor) output.append(',');
-
-                        String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-                        output.append(hex);
-
-                        previousColor = true;
-                    }
-                }
-            }
-
-            output.append('"');
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.SKULL_OWNER)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"skull-owner\":\"")
-                .append((String) getAttribute(MagicItemAttribute.SKULL_OWNER))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.TITLE)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"title\":\"")
-                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.TITLE)))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.AUTHOR)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"author\":\"")
-                .append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.AUTHOR)))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.UUID)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"uuid\":\"")
-                .append(((String) getAttribute(MagicItemAttribute.UUID)))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.TEXTURE)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"texture\":\"")
-                .append(((String) getAttribute(MagicItemAttribute.TEXTURE)))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.SIGNATURE)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"signature\":\"")
-                .append(((String) getAttribute(MagicItemAttribute.SIGNATURE)))
-                .append('"');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.ENCHANTS)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTS);
-            boolean previousEnchantment = false;
-            output.append("\"enchants\":{");
-            for (Enchantment enchantment : enchantments.keySet()) {
-                if (previousEnchantment) output.append(',');
-
-                output
-                    .append('"')
-                    .append(enchantment.getKey().getKey())
-                    .append("\":")
-                    .append(enchantments.get(enchantment));
-
-                previousEnchantment = true;
-            }
-            output.append('}');
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.FAKE_GLINT)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output
-                .append("\"fake-glint\":")
-                .append((boolean) getAttribute(MagicItemAttribute.FAKE_GLINT));
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.ATTRIBUTES)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            Multimap<Attribute, AttributeModifier> attributes = (Multimap<Attribute, AttributeModifier>) getAttribute(MagicItemAttribute.ATTRIBUTES);
-            boolean previousAttribute = false;
-            output.append("\"attributes\":[");
-            for (Map.Entry<Attribute, AttributeModifier> entries : attributes.entries()) {
-                if (previousAttribute) output.append(',');
-
-                AttributeModifier modifier = entries.getValue();
-
-                output
-                    .append('"')
-                    .append(modifier.getName())
-                    .append(' ')
-                    .append(modifier.getAmount())
-                    .append(' ')
-                    .append(modifier.getOperation().name().toLowerCase());
-
-                EquipmentSlot slot = modifier.getSlot();
-                if (slot != null) {
-                    output
-                        .append(' ')
-                        .append(slot.name().toLowerCase());
-                }
-
-                output.append('"');
-                previousAttribute = true;
-            }
-            output.append(']');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.LORE)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            List<Component> lore = (List<Component>) getAttribute(MagicItemAttribute.LORE);
-            boolean previousLore = false;
-            output.append("\"lore\":[");
-            for (Component line : lore) {
-                if (previousLore) output.append(',');
-
-                output
-                    .append('"')
-                    .append(TxtUtil.escapeJSON(Util.getStringFromComponent(line)))
-                    .append('"');
-
-                previousLore = true;
-            }
-            output.append(']');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.PAGES)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            List<Component> pages = (List<Component>) getAttribute(MagicItemAttribute.PAGES);
-            boolean previousPages = false;
-            output.append("\"pages\":[");
-            for (Component page : pages) {
-                if (previousPages) output.append(',');
-
-                output
-                    .append('"')
-                    .append(TxtUtil.escapeJSON(Util.getStringFromComponent(page)))
-                    .append('"');
-
-                previousPages = true;
-            }
-            output.append(']');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.PATTERNS)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output.append("\"patterns\":[");
-            List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
-            boolean previousPattern = false;
-            for (Pattern pattern : patterns) {
-                if (previousPattern) output.append(',');
-
-                output
-                    .append('"')
-                    .append(pattern.getPattern().name())
-                    .append(' ')
-                    .append(pattern.getColor().name())
-                    .append('"');
-
-                previousPattern = true;
-            }
-            output.append(']');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.POTION_EFFECTS)) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output.append("\"potion-effects\":[");
-            List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
-            boolean previousEffect = false;
-            for (PotionEffect effect : effects) {
-                if (previousEffect) output.append(',');
-
-                output
-                    .append('"')
-                    .append(effect.getType().getName())
-                    .append(' ')
-                    .append(effect.getAmplifier())
-                    .append(' ')
-                    .append(effect.getDuration())
-                    .append('"');
-
-                previousEffect = true;
-            }
-            output.append(']');
-
-            previous = true;
-        }
-
-        if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECTS)) {
-            List<FireworkEffect> effects = (List<FireworkEffect>) getAttribute(MagicItemAttribute.FIREWORK_EFFECTS);
-
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output.append("\"firework-effects\":[");
-            boolean previousEffect = false;
-            for (FireworkEffect effect : effects) {
-                if (previousEffect) output.append(',');
-
-                output
-                    .append('"')
-                    .append(effect.getType())
-                    .append(' ')
-                    .append(effect.hasTrail())
-                    .append(' ')
-                    .append(effect.hasFlicker());
-
-                boolean previousColor = false;
-                if (!effect.getColors().isEmpty()) {
-                    output.append(' ');
-                    for (Color color : effect.getColors()) {
-                        if (previousColor) output.append(',');
-                        String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-                        output.append(hex);
-                        previousColor = true;
-                    }
-
-                    if (!effect.getFadeColors().isEmpty()) {
-                        output.append(' ');
-                        previousColor = false;
-                        for (Color color : effect.getFadeColors()) {
-                            if (previousColor) output.append(',');
-                            String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
-                            output.append(hex);
-                            previousColor = true;
-                        }
-                    }
-                }
-
-                output.append('"');
-                previousEffect = true;
-            }
-
-            output.append(']');
-            previous = true;
-        }
-
-        if (!ignoredAttributes.isEmpty()) {
-            if (previous) output.append(",");
-            else output.append('{');
-
-            output.append("\"ignored-attributes\":[");
-            boolean previousAttribute = false;
-            for (MagicItemAttribute attr : ignoredAttributes) {
-                if (previousAttribute) output.append(',');
-
-                output
-                    .append('"')
-                    .append(attr.name())
-                    .append('"');
-
-                previousAttribute = true;
-            }
-
-            output.append(']');
-            previous = true;
-        }
-
-        if (!blacklistedAttributes.isEmpty()) {
-            if (previous) output.append(",");
-            else output.append('{');
-
-            output.append("\"blacklisted-attributes\":[");
-            boolean previousAttribute = false;
-            for (MagicItemAttribute attr : blacklistedAttributes) {
-                if (previousAttribute) output.append(',');
-
-                output
-                    .append('"')
-                    .append(attr.name())
-                    .append('"');
-
-                previousAttribute = true;
-            }
-
-            output.append(']');
-            previous = true;
-        }
-
-        if (!strictEnchants) {
-            if (previous) output.append(",");
-            else output.append('{');
-
-            output.append("\"strict-enchants\": false");
-            previous = true;
-        }
-
-        if (!strictDurability) {
-            if (previous) output.append(',');
-            else output.append('{');
-
-            output.append("\"strict-durability\": false");
-            previous = true;
-        }
-
-        if (!strictEnchantLevel) {
-            if (previous) output.append(",");
-            else output.append('{');
-
-            output.append("\"strict-enchant-level\": false");
-            previous = true;
-        }
-
-        if (previous) output.append('}');
-
-        return output.toString();
-    }
+	public EnumSet<MagicItemAttribute> getBlacklistedAttributes() {
+		return blacklistedAttributes;
+	}
+
+	public EnumSet<MagicItemAttribute> getIgnoredAttributes() {
+		return ignoredAttributes;
+	}
+
+	public boolean isStrictEnchantLevel() {
+		return strictEnchantLevel;
+	}
+
+	public void setStrictEnchantLevel(boolean strictEnchantLevel) {
+		this.strictEnchantLevel = strictEnchantLevel;
+	}
+
+	public boolean isStrictDurability() {
+		return strictDurability;
+	}
+
+	public void setStrictDurability(boolean strictDurability) {
+		this.strictDurability = strictDurability;
+	}
+
+	public boolean isStrictBlockData() {
+		return strictBlockData;
+	}
+
+	public void setStrictBlockData(boolean strictBlockData) {
+		this.strictBlockData = strictBlockData;
+	}
+
+	public boolean isStrictEnchants() {
+		return strictEnchants;
+	}
+
+	public void setStrictEnchants(boolean strictEnchants) {
+		this.strictEnchants = strictEnchants;
+	}
+
+	private boolean hasEqualAttributes(MagicItemData other) {
+		Multimap<Attribute, AttributeModifier> attrSelf = (Multimap<Attribute, AttributeModifier>) itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
+		Multimap<Attribute, AttributeModifier> attrOther = (Multimap<Attribute, AttributeModifier>) other.itemAttributes.get(MagicItemAttribute.ATTRIBUTES);
+
+		Set<Attribute> keysSelf = attrSelf.keySet();
+		Set<Attribute> keysOther = attrOther.keySet();
+		if (!keysSelf.equals(keysOther)) return false;
+
+		record AttributeModifierData(String name, double amt, AttributeModifier.Operation op, EquipmentSlot slot) {
+
+			public AttributeModifierData(AttributeModifier mod) {
+				this(mod.getName(), mod.getAmount(), mod.getOperation(), mod.getSlot());
+			}
+
+		}
+
+		for (Attribute attr : keysSelf) {
+			Collection<AttributeModifier> modsSelf = attrSelf.get(attr);
+			Collection<AttributeModifier> modsOther = attrOther.get(attr);
+			if (modsSelf.size() != modsOther.size()) return false;
+
+			HashMap<AttributeModifierData, Integer> freq = new HashMap<>();
+			for (AttributeModifier mod : modsSelf) {
+				AttributeModifierData data = new AttributeModifierData(mod);
+				Integer count = freq.get(data);
+
+				if (count == null) count = 0;
+				freq.put(data, count + 1);
+			}
+
+			for (AttributeModifier mod : modsOther) {
+				AttributeModifierData data = new AttributeModifierData(mod);
+				Integer count = freq.get(data);
+
+				if (count == null) return false;
+				if (count == 1) freq.remove(data);
+				else freq.put(data, count - 1);
+			}
+		}
+
+		return true;
+	}
+
+	public boolean matches(MagicItemData data) {
+		if (this == data) return true;
+
+		Set<MagicItemAttribute> keysSelf = itemAttributes.keySet();
+		Set<MagicItemAttribute> keysOther = data.itemAttributes.keySet();
+
+		for (MagicItemAttribute attr : keysSelf) {
+			if (ignoredAttributes.contains(attr)) continue;
+			if (!keysOther.contains(attr)) return false;
+		}
+
+		for (MagicItemAttribute attr : blacklistedAttributes) {
+			if (keysOther.contains(attr)) return false;
+		}
+
+		for (MagicItemAttribute attr : keysSelf) {
+			if (ignoredAttributes.contains(attr)) continue;
+
+			switch (attr) {
+				case ATTRIBUTES -> {
+					if (!hasEqualAttributes(data)) return false;
+				}
+				case BLOCK_DATA -> {
+					BlockData blockDataSelf = (BlockData) itemAttributes.get(attr);
+					BlockData blockDataOther = (BlockData) data.itemAttributes.get(attr);
+
+					if (strictBlockData) {
+						if (!blockDataSelf.equals(blockDataOther))
+							return false;
+
+						continue;
+					}
+
+					if (!blockDataOther.matches(blockDataSelf)) return false;
+				}
+				case DURABILITY -> {
+					Integer durabilitySelf = (Integer) itemAttributes.get(attr);
+					Integer durabilityOther = (Integer) data.itemAttributes.get(attr);
+
+					int compare = durabilitySelf.compareTo(durabilityOther);
+					if (strictDurability ? compare != 0 : compare < 0) return false;
+				}
+				case ENCHANTS -> {
+					if (strictEnchants && strictEnchantLevel) {
+						if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr)))
+							return false;
+
+						continue;
+					}
+
+					Map<Enchantment, Integer> enchantsSelf = (Map<Enchantment, Integer>) itemAttributes.get(attr);
+					Map<Enchantment, Integer> enchantsOther = (Map<Enchantment, Integer>) data.itemAttributes.get(attr);
+
+					if (strictEnchants && enchantsSelf.size() != enchantsOther.size()) return false;
+
+					for (Enchantment enchant : enchantsSelf.keySet()) {
+						if (!enchantsOther.containsKey(enchant)) return false;
+
+						Integer levelSelf = enchantsSelf.get(enchant);
+						Integer levelOther = enchantsOther.get(enchant);
+
+						int compare = levelSelf.compareTo(levelOther);
+						if (strictEnchantLevel ? compare != 0 : compare > 0) return false;
+					}
+				}
+				case NAME -> {
+					Component nameSelf = (Component) itemAttributes.get(attr);
+					Component nameOther = (Component) data.itemAttributes.get(attr);
+					return Util.getLegacyFromComponent(nameSelf).equals(Util.getLegacyFromComponent(nameOther));
+				}
+				case LORE -> {
+					List<Component> loreSelf = (List<Component>) itemAttributes.get(attr);
+					List<Component> loreOther = (List<Component>) data.itemAttributes.get(attr);
+					if (loreSelf.size() != loreOther.size()) return false;
+
+					for (int i = 0; i < loreSelf.size(); i++) {
+						String self = Util.getLegacyFromComponent(loreSelf.get(i));
+						String other = Util.getLegacyFromComponent(loreOther.get(i));
+						if (!self.equals(other)) return false;
+					}
+					return true;
+				}
+				default -> {
+					if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
+				}
+			}
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o) return true;
+		if (!(o instanceof MagicItemData other)) return false;
+		return itemAttributes.equals(other.itemAttributes)
+			&& ignoredAttributes.equals(other.ignoredAttributes)
+			&& blacklistedAttributes.equals(other.blacklistedAttributes);
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(itemAttributes, ignoredAttributes, blacklistedAttributes);
+	}
+
+	@Override
+	public MagicItemData clone() {
+		MagicItemData data = new MagicItemData();
+
+		if (!itemAttributes.isEmpty()) data.itemAttributes.putAll(itemAttributes);
+		if (!ignoredAttributes.isEmpty()) data.ignoredAttributes.addAll(ignoredAttributes);
+		if (!blacklistedAttributes.isEmpty()) data.blacklistedAttributes.addAll(blacklistedAttributes);
+
+		return data;
+	}
+
+	public enum MagicItemAttribute {
+
+		TYPE(Material.class),
+		NAME(Component.class),
+		AMOUNT(Integer.class),
+		DURABILITY(Integer.class),
+		REPAIR_COST(Integer.class),
+		CUSTOM_MODEL_DATA(Integer.class),
+		POWER(Integer.class),
+		UNBREAKABLE(Boolean.class),
+		HIDE_TOOLTIP(Boolean.class),
+		FAKE_GLINT(Boolean.class),
+		POTION_DATA(PotionData.class),
+		COLOR(Color.class),
+		FIREWORK_EFFECT(FireworkEffect.class),
+		TITLE(String.class),
+		AUTHOR(String.class),
+		UUID(String.class),
+		TEXTURE(String.class),
+		SIGNATURE(String.class),
+		SKULL_OWNER(String.class),
+		BLOCK_DATA(BlockData.class),
+		ENCHANTS(Map.class),
+		LORE(List.class),
+		PAGES(List.class),
+		POTION_EFFECTS(List.class),
+		PATTERNS(List.class),
+		FIREWORK_EFFECTS(List.class),
+		ATTRIBUTES(Multimap.class);
+
+		private final Class<?> dataType;
+		private final String asString;
+
+		MagicItemAttribute(Class<?> dataType) {
+			this.dataType = dataType;
+			asString = name().toLowerCase().replace('_', '-');
+		}
+
+		public Class<?> getDataType() {
+			return dataType;
+		}
+
+		@Override
+		public String toString() {
+			return asString;
+		}
+
+	}
+
+	@Override
+	public String toString() {
+		StringBuilder output = new StringBuilder();
+		boolean previous = false;
+
+		if (hasAttribute(MagicItemAttribute.TYPE))
+			output.append(((Material) getAttribute(MagicItemAttribute.TYPE)).name());
+
+		if (hasAttribute(MagicItemAttribute.NAME)) {
+			output.append('{');
+
+			output
+				.append("\"name\":\"")
+				.append(TxtUtil.escapeJSON(Util.getStringFromComponent((Component) getAttribute(MagicItemAttribute.NAME))))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.AMOUNT)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"amount\":")
+				.append((int) getAttribute(MagicItemAttribute.AMOUNT));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.DURABILITY)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"durability\":")
+				.append((int) getAttribute(MagicItemAttribute.DURABILITY));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.REPAIR_COST)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"repair-cost\":")
+				.append((int) getAttribute(MagicItemAttribute.REPAIR_COST));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"custom-model-data\":")
+				.append((int) getAttribute(MagicItemAttribute.CUSTOM_MODEL_DATA));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.POWER)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"power\":")
+				.append((int) getAttribute(MagicItemAttribute.POWER));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.UNBREAKABLE)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"unbreakable\":")
+				.append((boolean) getAttribute(MagicItemAttribute.UNBREAKABLE));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.HIDE_TOOLTIP)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"hide-tooltip\":")
+				.append((boolean) getAttribute(MagicItemAttribute.HIDE_TOOLTIP));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.COLOR)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			Color color = (Color) getAttribute(MagicItemAttribute.COLOR);
+			String hex = String.format("#%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+
+			output
+				.append("\"color\":\"")
+				.append(hex)
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.POTION_DATA)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			PotionData potionData = (PotionData) getAttribute(MagicItemAttribute.POTION_DATA);
+
+			output
+				.append("\"potion-data\":\"")
+				.append(potionData.getType());
+
+			if (potionData.isExtended()) output.append(" extended");
+			else if (potionData.isUpgraded()) output.append(" upgraded");
+
+			output.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			FireworkEffect effect = (FireworkEffect) getAttribute(MagicItemAttribute.FIREWORK_EFFECT);
+
+			output
+				.append("\"firework-effect\":\"")
+				.append(effect.getType())
+				.append(' ')
+				.append(effect.hasTrail())
+				.append(' ')
+				.append(effect.hasFlicker());
+
+			boolean previousColor = false;
+			if (!effect.getColors().isEmpty()) {
+				output.append(' ');
+				for (Color color : effect.getColors()) {
+					if (previousColor) output.append(',');
+
+					String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+					output.append(hex);
+
+					previousColor = true;
+				}
+
+				if (!effect.getFadeColors().isEmpty()) {
+					output.append(' ');
+					previousColor = false;
+					for (Color color : effect.getFadeColors()) {
+						if (previousColor) output.append(',');
+
+						String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+						output.append(hex);
+
+						previousColor = true;
+					}
+				}
+			}
+
+			output.append('"');
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.SKULL_OWNER)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"skull-owner\":\"")
+				.append((String) getAttribute(MagicItemAttribute.SKULL_OWNER))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.TITLE)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"title\":\"")
+				.append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.TITLE)))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.AUTHOR)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"author\":\"")
+				.append(TxtUtil.escapeJSON((String) getAttribute(MagicItemAttribute.AUTHOR)))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.UUID)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"uuid\":\"")
+				.append(((String) getAttribute(MagicItemAttribute.UUID)))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.TEXTURE)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"texture\":\"")
+				.append(((String) getAttribute(MagicItemAttribute.TEXTURE)))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.SIGNATURE)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"signature\":\"")
+				.append(((String) getAttribute(MagicItemAttribute.SIGNATURE)))
+				.append('"');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.ENCHANTS)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			Map<Enchantment, Integer> enchantments = (Map<Enchantment, Integer>) getAttribute(MagicItemAttribute.ENCHANTS);
+			boolean previousEnchantment = false;
+			output.append("\"enchants\":{");
+			for (Enchantment enchantment : enchantments.keySet()) {
+				if (previousEnchantment) output.append(',');
+
+				output
+					.append('"')
+					.append(enchantment.getKey().getKey())
+					.append("\":")
+					.append(enchantments.get(enchantment));
+
+				previousEnchantment = true;
+			}
+			output.append('}');
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.FAKE_GLINT)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output
+				.append("\"fake-glint\":")
+				.append((boolean) getAttribute(MagicItemAttribute.FAKE_GLINT));
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.ATTRIBUTES)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			Multimap<Attribute, AttributeModifier> attributes = (Multimap<Attribute, AttributeModifier>) getAttribute(MagicItemAttribute.ATTRIBUTES);
+			boolean previousAttribute = false;
+			output.append("\"attributes\":[");
+			for (Map.Entry<Attribute, AttributeModifier> entries : attributes.entries()) {
+				if (previousAttribute) output.append(',');
+
+				AttributeModifier modifier = entries.getValue();
+
+				output
+					.append('"')
+					.append(modifier.getName())
+					.append(' ')
+					.append(modifier.getAmount())
+					.append(' ')
+					.append(modifier.getOperation().name().toLowerCase());
+
+				EquipmentSlot slot = modifier.getSlot();
+				if (slot != null) {
+					output
+						.append(' ')
+						.append(slot.name().toLowerCase());
+				}
+
+				output.append('"');
+				previousAttribute = true;
+			}
+			output.append(']');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.LORE)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			List<Component> lore = (List<Component>) getAttribute(MagicItemAttribute.LORE);
+			boolean previousLore = false;
+			output.append("\"lore\":[");
+			for (Component line : lore) {
+				if (previousLore) output.append(',');
+
+				output
+					.append('"')
+					.append(TxtUtil.escapeJSON(Util.getStringFromComponent(line)))
+					.append('"');
+
+				previousLore = true;
+			}
+			output.append(']');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.PAGES)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			List<Component> pages = (List<Component>) getAttribute(MagicItemAttribute.PAGES);
+			boolean previousPages = false;
+			output.append("\"pages\":[");
+			for (Component page : pages) {
+				if (previousPages) output.append(',');
+
+				output
+					.append('"')
+					.append(TxtUtil.escapeJSON(Util.getStringFromComponent(page)))
+					.append('"');
+
+				previousPages = true;
+			}
+			output.append(']');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.PATTERNS)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output.append("\"patterns\":[");
+			List<Pattern> patterns = (List<Pattern>) getAttribute(MagicItemAttribute.PATTERNS);
+			boolean previousPattern = false;
+			for (Pattern pattern : patterns) {
+				if (previousPattern) output.append(',');
+
+				output
+					.append('"')
+					.append(pattern.getPattern().name())
+					.append(' ')
+					.append(pattern.getColor().name())
+					.append('"');
+
+				previousPattern = true;
+			}
+			output.append(']');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.POTION_EFFECTS)) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output.append("\"potion-effects\":[");
+			List<PotionEffect> effects = (List<PotionEffect>) getAttribute(MagicItemAttribute.POTION_EFFECTS);
+			boolean previousEffect = false;
+			for (PotionEffect effect : effects) {
+				if (previousEffect) output.append(',');
+
+				output
+					.append('"')
+					.append(effect.getType().getName())
+					.append(' ')
+					.append(effect.getAmplifier())
+					.append(' ')
+					.append(effect.getDuration())
+					.append('"');
+
+				previousEffect = true;
+			}
+			output.append(']');
+
+			previous = true;
+		}
+
+		if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECTS)) {
+			List<FireworkEffect> effects = (List<FireworkEffect>) getAttribute(MagicItemAttribute.FIREWORK_EFFECTS);
+
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output.append("\"firework-effects\":[");
+			boolean previousEffect = false;
+			for (FireworkEffect effect : effects) {
+				if (previousEffect) output.append(',');
+
+				output
+					.append('"')
+					.append(effect.getType())
+					.append(' ')
+					.append(effect.hasTrail())
+					.append(' ')
+					.append(effect.hasFlicker());
+
+				boolean previousColor = false;
+				if (!effect.getColors().isEmpty()) {
+					output.append(' ');
+					for (Color color : effect.getColors()) {
+						if (previousColor) output.append(',');
+						String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+						output.append(hex);
+						previousColor = true;
+					}
+
+					if (!effect.getFadeColors().isEmpty()) {
+						output.append(' ');
+						previousColor = false;
+						for (Color color : effect.getFadeColors()) {
+							if (previousColor) output.append(',');
+							String hex = String.format("%02x%02x%02x", color.getRed(), color.getGreen(), color.getBlue());
+							output.append(hex);
+							previousColor = true;
+						}
+					}
+				}
+
+				output.append('"');
+				previousEffect = true;
+			}
+
+			output.append(']');
+			previous = true;
+		}
+
+		if (!ignoredAttributes.isEmpty()) {
+			if (previous) output.append(",");
+			else output.append('{');
+
+			output.append("\"ignored-attributes\":[");
+			boolean previousAttribute = false;
+			for (MagicItemAttribute attr : ignoredAttributes) {
+				if (previousAttribute) output.append(',');
+
+				output
+					.append('"')
+					.append(attr.name())
+					.append('"');
+
+				previousAttribute = true;
+			}
+
+			output.append(']');
+			previous = true;
+		}
+
+		if (!blacklistedAttributes.isEmpty()) {
+			if (previous) output.append(",");
+			else output.append('{');
+
+			output.append("\"blacklisted-attributes\":[");
+			boolean previousAttribute = false;
+			for (MagicItemAttribute attr : blacklistedAttributes) {
+				if (previousAttribute) output.append(',');
+
+				output
+					.append('"')
+					.append(attr.name())
+					.append('"');
+
+				previousAttribute = true;
+			}
+
+			output.append(']');
+			previous = true;
+		}
+
+		if (!strictEnchants) {
+			if (previous) output.append(",");
+			else output.append('{');
+
+			output.append("\"strict-enchants\": false");
+			previous = true;
+		}
+
+		if (!strictDurability) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output.append("\"strict-durability\": false");
+			previous = true;
+		}
+
+		if (!strictBlockData) {
+			if (previous) output.append(',');
+			else output.append('{');
+
+			output.append("\"strict-block-data\": false");
+			previous = true;
+		}
+
+		if (!strictEnchantLevel) {
+			if (previous) output.append(",");
+			else output.append('{');
+
+			output.append("\"strict-enchant-level\": false");
+			previous = true;
+		}
+
+		if (previous) output.append('}');
+
+		return output.toString();
+	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -18,13 +18,15 @@ import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonToken;
 import com.google.gson.reflect.TypeToken;
 import com.google.gson.stream.JsonReader;
-import com.google.common.collect.Multimap;
 import com.google.gson.JsonSyntaxException;
+
+import com.google.common.collect.Multimap;
 import com.google.common.collect.HashMultimap;
 
 import net.kyori.adventure.text.Component;
 
 import org.bukkit.Color;
+import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.FireworkEffect;
@@ -33,6 +35,7 @@ import org.bukkit.potion.PotionType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.block.banner.Pattern;
+import org.bukkit.block.data.BlockData;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.block.banner.PatternType;
@@ -111,6 +114,19 @@ public class MagicItemDataParser {
 						case "amount":
 							data.setAttribute(AMOUNT, value.getAsInt());
 							break;
+						case "block-data":
+							String blockDataString = value.getAsString();
+							BlockData blockData;
+							try {
+								blockData = Bukkit.createBlockData(type, blockDataString);
+							} catch (IllegalArgumentException e) {
+								MagicSpells.error("Invalid block data '" + blockDataString + "' when parsing magic item '" + str + "'.");
+								DebugHandler.debugIllegalArgumentException(e);
+
+								continue;
+							}
+
+							data.setAttribute(BLOCK_DATA, blockData);
 						case "durability":
 							data.setAttribute(DURABILITY, value.getAsInt());
 							break;
@@ -443,6 +459,11 @@ public class MagicItemDataParser {
 						case "strict-durability":
 						case "strict_durability":
 							data.setStrictDurability(value.getAsBoolean());
+							break;
+						case "strictblockdata":
+						case "strict-block-data":
+						case "strict_block_data":
+							data.setStrictBlockData(value.getAsBoolean());
 							break;
 						case "strictenchantlevel":
 						case "strict-enchant-level":

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -159,6 +159,9 @@ public class MagicItems {
 		// patterns
 		BannerHandler.processMagicItemData(meta, data);
 
+		// block data
+		BlockDataHandler.processMagicItemData(meta, data, itemStack.getType());
+
 		itemStackCache.put(itemStack, data);
 		return data;
 	}
@@ -260,6 +263,9 @@ public class MagicItems {
 		// Suspicious Stew
 		SuspiciousStewHandler.processItemMeta(meta, data);
 
+		// Block Data
+		BlockDataHandler.processItemMeta(meta, data);
+
 		// Unbreakable
 		if (data.hasAttribute(UNBREAKABLE))
 			meta.setUnbreakable((boolean) data.getAttribute(UNBREAKABLE));
@@ -324,6 +330,9 @@ public class MagicItems {
 
 				if (section.isBoolean("strict-enchants"))
 					magicItem.getMagicItemData().setStrictEnchants(section.getBoolean("strict-enchants"));
+
+				if (section.isBoolean("strict-block-data"))
+					magicItem.getMagicItemData().setStrictBlockData(section.getBoolean("strict-block-data"));
 
 				if (section.isBoolean("strict-durability"))
 					magicItem.getMagicItemData().setStrictDurability(section.getBoolean("strict-durability"));
@@ -446,6 +455,9 @@ public class MagicItems {
 			// Suspicious Stew
 			SuspiciousStewHandler.process(section, meta, itemData);
 
+			// Block Data
+			BlockDataHandler.process(section, meta, itemData, type);
+
 			// Unbreakable
 			if (section.isBoolean("unbreakable")) {
 				boolean unbreakable = section.getBoolean("unbreakable");
@@ -526,6 +538,9 @@ public class MagicItems {
 
 			if (section.isBoolean("strict-enchants"))
 				itemData.setStrictEnchants(section.getBoolean("strict-enchants"));
+
+			if (section.isBoolean("strict-block-data"))
+				itemData.setStrictBlockData(section.getBoolean("strict-block-data"));
 
 			if (section.isBoolean("strict-durability"))
 				itemData.setStrictDurability(section.getBoolean("strict-durability"));


### PR DESCRIPTION
- Added `height` and `width` to `DataSpell`.
- Added `block-data` and `strict-block-data` options to magic items.
  - `block-data` specifies the block data for an item with `BlockDataMeta`.
  - With `strict-block-data: false`, magic item comparison uses [BlockData#matches](https://hub.spigotmc.org/javadocs/spigot/org/bukkit/block/data/BlockData.html#matches(org.bukkit.block.data.BlockData)) instead of strict equality. Defaults to true.
- All of the options of `EntityData` now support replacement.
- Added `spell-on-spawn` to `SpawnEntitySpell`, `SteedSpell` and `TotemSpell`. Casts a spell when the entity spawns. Will cast with the entity or its location as a target if applicable.
- Fixed an issue where `PlayerMenuSpell` would open its menu with an extra slot.