### PR TITLE
Changes to "FlySpell", "WindwalkSpell", and "buff" trigger

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VelocityActiveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VelocityActiveCondition.java
@@ -1,0 +1,42 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+import com.nisovin.magicspells.spells.instant.VelocitySpell;
+
+public class VelocityActiveCondition extends Condition {
+
+	private VelocitySpell velocitySpell;
+
+	@Override
+	public boolean initialize(String var) {
+		Spell spell = MagicSpells.getSpellByInternalName(var);
+		if (!(spell instanceof VelocitySpell)) return false;
+		velocitySpell = (VelocitySpell) spell;
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		return isJumping(caster);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return isJumping(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+	private boolean isJumping(LivingEntity target) {
+		return velocitySpell.isJumping(target);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
@@ -27,11 +27,12 @@ public class WindwalkSpell extends BuffSpell {
 
 	private final Map<UUID, CastData> players;
 
-	private ConfigData<Integer> maxY;
-	private ConfigData<Integer> maxAltitude;
+	private final boolean enableMaxY;
+	private final ConfigData<Integer> maxY;
+	private final ConfigData<Integer> maxAltitude;
 
-	private ConfigData<Float> flySpeed;
-	private ConfigData<Float> launchSpeed;
+	private final ConfigData<Float> flySpeed;
+	private final ConfigData<Float> launchSpeed;
 
 	private boolean cancelOnLand;
 
@@ -42,6 +43,7 @@ public class WindwalkSpell extends BuffSpell {
 
 		maxY = getConfigDataInt("max-y", 260);
 		maxAltitude = getConfigDataInt("max-altitude", 100);
+		enableMaxY = getConfigBoolean("enable-max-y", true);
 
 		flySpeed = getConfigDataFloat("fly-speed", 0.1F);
 		launchSpeed = getConfigDataFloat("launch-speed", 1F);
@@ -175,7 +177,7 @@ public class WindwalkSpell extends BuffSpell {
 				v = pl.getVelocity();
 
 				yLimit = maxY.get(pl, null, data.power(), data.args());
-				if (yLimit > 0) {
+				if (enableMaxY) {
 					yDiff = loc.getBlockY() - yLimit;
 					if (yDiff > 0) {
 						pl.setVelocity(v.setY(-yDiff * 1.5));

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
@@ -63,10 +63,8 @@ public class WindwalkSpell extends BuffSpell {
 		if (!(entity instanceof Player player)) return false;
 
 		float launchSpeed = this.launchSpeed.get(entity, null, power, args);
-		if (launchSpeed > 0) {
-			entity.teleportAsync(entity.getLocation().add(0, 0.25, 0));
-			entity.setVelocity(new Vector(0, launchSpeed, 0));
-		}
+		if (launchSpeed > 0) entity.setVelocity(new Vector(0, launchSpeed, 0));
+		else entity.teleportAsync(entity.getLocation().add(0, 0.25, 0));
 
 		players.put(entity.getUniqueId(), new CastData(power, args));
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
@@ -40,6 +40,10 @@ public class VelocitySpell extends InstantSpell implements TargetedEntitySpell, 
 		powerAffectsSpeed = getConfigBoolean("power-affects-speed", true);
 	}
 
+	public boolean isJumping(LivingEntity livingEntity) {
+		return jumping.contains(livingEntity.getUniqueId());
+	}
+
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -30,7 +30,7 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 // No trigger variable currently used
 public class BuffListener extends PassiveListener {
 
-	private final EnumSet<GameMode> gameModes = EnumSet.of(GameMode.CREATIVE, GameMode.SPECTATOR);
+	private final EnumSet<GameMode> invalidGameModes = EnumSet.of(GameMode.CREATIVE, GameMode.SPECTATOR);
 
 	@Override
 	public void initialize(String var) {
@@ -81,7 +81,7 @@ public class BuffListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onGameModeChange(PlayerGameModeChangeEvent event) {
-		if (gameModes.contains(event.getNewGameMode())) off(event.getPlayer());
+		if (invalidGameModes.contains(event.getNewGameMode())) off(event.getPlayer());
 		else MagicSpells.scheduleDelayedTask(() -> on(event.getPlayer()), 1);
 	}
 
@@ -125,7 +125,7 @@ public class BuffListener extends PassiveListener {
 	}
 
 	private void on(LivingEntity entity) {
-		if (!canTrigger(entity, true)) return;
+		if (!canTrigger(entity, false)) return;
 		if (!hasSpell(entity)) return;
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
@@ -136,7 +136,7 @@ public class BuffListener extends PassiveListener {
 	}
 
 	private void off(LivingEntity entity) {
-		if (!canTrigger(entity, true)) return;
+		if (!canTrigger(entity, false)) return;
 		if (!hasSpell(entity)) return;
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -22,7 +22,6 @@ import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.BuffSpell;
-import com.nisovin.magicspells.spells.PassiveSpell;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.events.SpellLearnEvent;
 import com.nisovin.magicspells.events.SpellForgetEvent;
@@ -113,9 +112,7 @@ public class BuffListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onSpellLearn(final SpellLearnEvent event) {
-		Spell spell = event.getSpell();
-		if (!(spell instanceof PassiveSpell)) return;
-		if (!spell.getInternalName().equalsIgnoreCase(passiveSpell.getInternalName())) return;
+		if (!passiveSpell.equals(event.getSpell())) return;
 		MagicSpells.scheduleDelayedTask(() -> on(event.getLearner()), 1);
 	}
 
@@ -123,8 +120,7 @@ public class BuffListener extends PassiveListener {
 	@EventHandler
 	public void onSpellForget(SpellForgetEvent event) {
 		Spell spell = event.getSpell();
-		if (!(spell instanceof PassiveSpell)) return;
-		if (!spell.getInternalName().equalsIgnoreCase(passiveSpell.getInternalName())) return;
+		if (spell != null && !passiveSpell.equals(spell)) return;
 		off(event.getForgetter());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -129,9 +129,8 @@ public class BuffListener extends PassiveListener {
 		if (!hasSpell(entity)) return;
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
-			if (!(s.getSpell() instanceof BuffSpell buff)) continue;
-			if (buff.isActive(entity)) continue;
-			buff.castAtEntity(entity, entity, 1F);
+			if (s.getSpell() instanceof BuffSpell buff && buff.isActive(entity)) continue;
+			s.cast(entity, 1F);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -83,7 +83,7 @@ public class BuffListener extends PassiveListener {
 	@EventHandler
 	public void onGameModeChange(PlayerGameModeChangeEvent event) {
 		if (gameModes.contains(event.getNewGameMode())) off(event.getPlayer());
-		else on(event.getPlayer());
+		else MagicSpells.scheduleDelayedTask(() -> on(event.getPlayer()), 1);
 	}
 
 	@OverridePriority

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
@@ -20,6 +20,7 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 
 	private final Set<UUID> wasAllowedFlight;
 
+	private final boolean setFlying;
 	private final TargetBooleanState targetBooleanState;
 
 	public FlySpell(MagicConfig config, String spellName) {
@@ -27,6 +28,7 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 
 		wasAllowedFlight = new HashSet<>();
 
+		setFlying = getConfigBoolean("set-flying", true);
 		targetBooleanState = TargetBooleanState.getFromName(getConfigString("target-state", "toggle"));
 	}
 
@@ -94,13 +96,13 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 				player.setAllowFlight(true);
 				wasAllowedFlight.add(uuid);
 			}
-			player.teleportAsync(player.getLocation().add(0, 0.25, 0));
+			if (setFlying) player.teleportAsync(player.getLocation().add(0, 0.25, 0));
 		}
 		else {
 			boolean wasAllowed = wasAllowedFlight.remove(uuid);
 			if (wasAllowed) player.setAllowFlight(false);
 		}
-		player.setFlying(newState);
+		if (setFlying) player.setFlying(newState);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FlySpell.java
@@ -1,5 +1,11 @@
 package com.nisovin.magicspells.spells.targeted;
 
+import java.util.Set;
+import java.util.UUID;
+import java.util.HashSet;
+
+import org.bukkit.Bukkit;
+import org.bukkit.GameMode;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
@@ -11,15 +17,19 @@ import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 
 public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
-	
-	private TargetBooleanState targetBooleanState;
-	
+
+	private final Set<UUID> wasAllowedFlight;
+
+	private final TargetBooleanState targetBooleanState;
+
 	public FlySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
+
+		wasAllowedFlight = new HashSet<>();
+
 		targetBooleanState = TargetBooleanState.getFromName(getConfigString("target-state", "toggle"));
 	}
-	
+
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
@@ -27,7 +37,7 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 			if (targetInfo.noTarget()) return noTarget(caster, args, targetInfo);
 			Player target = targetInfo.target();
 
-			target.setFlying(targetBooleanState.getBooleanState(target.isFlying()));
+			setFlyingState(target);
 			playSpellEffects(caster, target, targetInfo.power(), args);
 			sendMessages(caster, target, args);
 
@@ -40,7 +50,7 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args) {
 		if (!(target instanceof Player player) || !validTargetList.canTarget(caster, target)) return false;
-		player.setFlying(targetBooleanState.getBooleanState(((Player) target).isFlying()));
+		setFlyingState(player);
 		playSpellEffects(caster, target, power, args);
 		return true;
 	}
@@ -53,7 +63,7 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power, String[] args) {
 		if (!(target instanceof Player player) || !validTargetList.canTarget(target)) return false;
-		player.setFlying(targetBooleanState.getBooleanState(((Player) target).isFlying()));
+		setFlyingState(player);
 		playSpellEffects(EffectPosition.TARGET, target, power, args);
 		return true;
 	}
@@ -61,6 +71,36 @@ public class FlySpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public boolean castAtEntity(LivingEntity target, float power) {
 		return castAtEntity(target, power, null);
+	}
+
+	@Override
+	protected void turnOff() {
+		Player player;
+		for (UUID uuid : wasAllowedFlight) {
+			player = Bukkit.getPlayer(uuid);
+			if (player == null) continue;
+			if (player.getGameMode() == GameMode.CREATIVE) continue;
+			if (player.getGameMode() == GameMode.SPECTATOR) continue;
+			player.setAllowFlight(false);
+		}
+		wasAllowedFlight.clear();
+	}
+
+	private void setFlyingState(Player player) {
+		boolean newState = targetBooleanState.getBooleanState(player.isFlying() || player.getAllowFlight());
+		UUID uuid = player.getUniqueId();
+		if (newState) {
+			if (!player.getAllowFlight()) {
+				player.setAllowFlight(true);
+				wasAllowedFlight.add(uuid);
+			}
+			player.teleportAsync(player.getLocation().add(0, 0.25, 0));
+		}
+		else {
+			boolean wasAllowed = wasAllowedFlight.remove(uuid);
+			if (wasAllowed) player.setAllowFlight(false);
+		}
+		player.setFlying(newState);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -177,6 +177,7 @@ public class ConditionManager {
 		addCondition("loopactive", LoopActiveCondition.class);
 		addCondition("ownedloopactive", OwnedLoopActiveCondition.class);
 		addCondition("always", AlwaysCondition.class);
+		addCondition("velocityactive", VelocityActiveCondition.class);
 	}
 
 }


### PR DESCRIPTION
* `FlySpell`:
  * Fixed spell not allowing flight.
  * Added `set-flying` bool toggle (def: `true`).
* `WindwalkSpell`:
  * Fixed `launch-speed` being interrupted.
  * Added `enable-max-y` bool toggle (def: `true`). (It used to instead depend on `max-y > 0`.)
  * Spell restores fly speed after ending.
  * Added `always-fly` bool toggle (def: `false`).
* `buff` passive spell trigger:
  * Spells will now turn off when the player is in Spectator or Creative and will turn on otherwise.
  * Forgetting all spells will turn off buffs.
  * Non buff `spells` will be cast when the buffs are turned on.
* Added `velocityactive` modifier condition,