### PR TITLE
Subspell additions, bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -2248,7 +2248,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			unregisterEvents(this);
 
 			sendMessage(strInterrupted, caster, null);
-			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower());
+			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower(), spellCast.getSpellArgs());
 		}
 
 	}
@@ -2339,7 +2339,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		private void interrupt() {
 			sendMessage(strInterrupted, caster, null);
 			end();
-			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower());
+			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower(), spellCast.getSpellArgs());
 		}
 
 		private void end() {

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1928,12 +1928,9 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		message = MagicSpells.doReplacements(message, caster, target, args, replacements);
 		Component msg = Util.getMiniMessage(MagicSpells.getTextColor() + message);
 
-		int rangeDoubled = range << 1;
-		Collection<Player> players = caster.getLocation().getNearbyPlayers(rangeDoubled);
+		Collection<Player> players = caster.getLocation().getNearbyPlayers(range);
 		for (Player player : players) {
-			if (player == caster) continue;
-			if (player == target) continue;
-
+			if (player == caster || player == target) continue;
 			player.sendMessage(msg);
 		}
 	}
@@ -2251,10 +2248,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			unregisterEvents(this);
 
 			sendMessage(strInterrupted, caster, null);
-			if (spellOnInterrupt != null) {
-				if (spellOnInterrupt.isTargetedLocationSpell()) spellOnInterrupt.castAtLocation(caster, caster.getLocation(), spellCast.getPower());
-				else spellOnInterrupt.cast(caster, spellCast.getPower());
-			}
+			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower());
 		}
 
 	}
@@ -2345,10 +2339,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		private void interrupt() {
 			sendMessage(strInterrupted, caster, null);
 			end();
-			if (spellOnInterrupt != null) {
-				if (spellOnInterrupt.isTargetedLocationSpell()) spellOnInterrupt.castAtLocation(caster, caster.getLocation(), spellCast.getPower());
-				else spellOnInterrupt.cast(caster, spellCast.getPower());
-			}
+			if (spellOnInterrupt != null) spellOnInterrupt.subcast(caster, caster.getLocation(), spellCast.getPower());
 		}
 
 		private void end() {

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -6,6 +6,7 @@ import java.util.Random;
 import java.util.HashMap;
 import java.util.Objects;
 import java.util.ArrayList;
+import java.util.function.Function;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.gson.JsonArray;
@@ -25,9 +26,12 @@ import com.nisovin.magicspells.Spell.PostCastAction;
 import com.nisovin.magicspells.Spell.SpellCastResult;
 import com.nisovin.magicspells.events.SpellCastEvent;
 import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellCastedEvent;
 import com.nisovin.magicspells.events.SpellTargetEvent;
+import com.nisovin.magicspells.util.config.FunctionData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
@@ -41,12 +45,13 @@ public class Subspell {
 	private CastMode mode = CastMode.PARTIAL;
 	private CastTargeting targeting = CastTargeting.NORMAL;
 
-	private int delay = -1;
-	private float subPower = 1F;
-	private double chance = -1D;
-	private String[] args = null;
 	private boolean invert = false;
+	private boolean passPower = true;
 	private boolean passTargeting = false;
+	private ConfigData<Integer> delay = (caster, target, power, args) -> -1;
+	private ConfigData<Double> chance = (caster, target, power, args) -> -1D;
+	private ConfigData<Float> subPower = (caster, target, power, args) -> 1F;
+	private ConfigData<String[]> args = (caster, target, power, args) -> null;
 
 	private boolean isTargetedEntity = false;
 	private boolean isTargetedLocation = false;
@@ -64,63 +69,107 @@ public class Subspell {
 
 			String[] castArguments = split[1].split(";");
 			for (String castArgument : castArguments) {
-				String[] keyValue = castArgument.split("=");
+				String[] keyValue = castArgument.split("=", 2);
 				if (keyValue.length != 2) {
 					MagicSpells.error("Invalid cast argument '" + castArgument + "' on subspell '" + data + "'.");
 					continue;
 				}
 
-				switch (keyValue[0].toLowerCase().trim()) {
-					case "mode" -> mode = CastMode.getFromString(keyValue[1].trim());
+				String key = keyValue[0].toLowerCase().trim(), value = keyValue[1].trim();
+				switch (key) {
+					case "mode" -> mode = CastMode.getFromString(value);
+					case "targeting" -> {
+						try {
+							targeting = CastTargeting.valueOf(value.toUpperCase());
+						} catch (IllegalArgumentException e) {
+							MagicSpells.error("Invalid target type '" + value + "' on subspell '" + data + "'.");
+							DebugHandler.debugIllegalArgumentException(e);
+						}
+					}
+					case "invert" -> invert = Boolean.parseBoolean(value);
+					case "pass-power" -> passPower = Boolean.parseBoolean(value);
+					case "pass-targeting" -> passTargeting = Boolean.parseBoolean(value);
 					case "args" -> {
 						try {
-							JsonElement element = JsonParser.parseString(keyValue[1].trim());
+							JsonElement element = JsonParser.parseString(value);
 							JsonArray array = element.getAsJsonArray();
 
+							List<ConfigData<String>> argumentData = new ArrayList<>();
 							List<String> arguments = new ArrayList<>();
-							array.forEach(e -> arguments.add(e.getAsString()));
 
-							args = arguments.toArray(new String[0]);
+							boolean constant = true;
+							for (JsonElement je : array) {
+								String val = je.getAsString();
+								ConfigData<String> supplier = ConfigDataUtil.getString(val);
+
+								argumentData.add(supplier);
+								arguments.add(val);
+
+								constant &= supplier.isConstant();
+							}
+
+							if (constant) {
+								String[] arg = arguments.toArray(new String[0]);
+								args = (caster, target, power, args) -> arg;
+
+								continue;
+							}
+
+							args = (caster, target, power, args) -> {
+								String[] ret = new String[argumentData.size()];
+								for (int i = 0; i < argumentData.size(); i++)
+									ret[i] = argumentData.get(i).get(caster, target, power, args);
+
+								return ret;
+							};
 						} catch (IllegalArgumentException e) {
-							MagicSpells.error("Invalid spell arguments '" + keyValue[1] + "' on subspell '" + data + "'.");
+							MagicSpells.error("Invalid spell arguments '" + value + "' on subspell '" + data + "'.");
 							DebugHandler.debugIllegalArgumentException(e);
 						} catch (ClassCastException | JsonSyntaxException e) {
-							MagicSpells.error("Invalid spell arguments '" + keyValue[1] + "' on subspell '" + data + "'.");
+							MagicSpells.error("Invalid spell arguments '" + value + "' on subspell '" + data + "'.");
 							DebugHandler.debug(e);
 						}
 					}
 					case "power" -> {
 						try {
-							subPower = Float.parseFloat(keyValue[1].trim());
+							float subPower = Float.parseFloat(value);
+							this.subPower = (caster, target, power, args) -> subPower;
 						} catch (NumberFormatException e) {
-							MagicSpells.error("Invalid power '" + keyValue[1] + "' on subspell '" + data + "'.");
-							DebugHandler.debugNumberFormat(e);
+							FunctionData<Float> subPowerData = FunctionData.build(value, Double::floatValue, true);
+							if (subPowerData == null) {
+								MagicSpells.error("Invalid power '" + value + "' on subspell '" + data + "'.");
+								continue;
+							}
+
+							subPower = subPowerData;
 						}
 					}
 					case "delay" -> {
 						try {
-							delay = Integer.parseInt(keyValue[1].trim());
+							int delay = Integer.parseInt(value);
+							this.delay = (caster, target, power, args) -> delay;
 						} catch (NumberFormatException e) {
-							MagicSpells.error("Invalid delay '" + keyValue[1] + "' on subspell '" + data + "'.");
-							DebugHandler.debugNumberFormat(e);
+							FunctionData<Integer> delayData = FunctionData.build(value, Double::intValue, true);
+							if (delayData == null) {
+								MagicSpells.error("Invalid delay '" + value + "' on subspell '" + data + "'.");
+								continue;
+							}
+
+							delay = delayData;
 						}
 					}
 					case "chance" -> {
 						try {
-							chance = Double.parseDouble(keyValue[1].trim()) / 100D;
+							double chance = Double.parseDouble(value);
+							this.chance = (caster, target, power, args) -> chance;
 						} catch (NumberFormatException e) {
-							MagicSpells.error("Invalid chance '" + keyValue[1] + "' on subspell '" + data + "'.");
-							DebugHandler.debugNumberFormat(e);
-						}
-					}
-					case "invert" -> invert = Boolean.parseBoolean(keyValue[1].trim());
-					case "pass-targeting" -> passTargeting = Boolean.parseBoolean(keyValue[1].trim());
-					case "targeting" -> {
-						try {
-							targeting = CastTargeting.valueOf(keyValue[1].toUpperCase());
-						} catch (IllegalArgumentException e) {
-							MagicSpells.error("Invalid target type '" + keyValue[1] + "' on subspell '" + data + "'.");
-							DebugHandler.debugIllegalArgumentException(e);
+							FunctionData<Double> chanceData = FunctionData.build(value, Function.identity(), true);
+							if (chanceData == null) {
+								MagicSpells.error("Invalid chance '" + value + "' on subspell '" + data + "'.");
+								continue;
+							}
+
+							chance = chanceData;
 						}
 					}
 					default -> MagicSpells.error("Invalid cast argument '" + castArgument + "' on subspell '" + data + "'.");
@@ -182,15 +231,15 @@ public class Subspell {
 		return isTargetedEntityFromLocation;
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power) {
-		return subcast(caster, location, target, power, passTargeting);
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power, @Nullable String[] args) {
+		return subcast(caster, location, target, power, args, passTargeting, true);
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power, boolean passTargeting) {
-		return subcast(caster, location, target, power, passTargeting, true);
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power, @Nullable String[] args, boolean passTargeting) {
+		return subcast(caster, location, target, power, args, passTargeting, true);
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power, boolean passTargeting, boolean useTargetForLocation) {
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location location, @NotNull LivingEntity target, float power, @Nullable String[] args, boolean passTargeting, boolean useTargetForLocation) {
 		if (invert) {
 			if (caster != null) {
 				LivingEntity temp = caster;
@@ -208,9 +257,11 @@ public class Subspell {
 		}
 
 		return switch (targeting) {
-			case ENTITY_FROM_LOCATION -> spell instanceof TargetedEntityFromLocationSpell && castAtEntityFromLocation(caster, location, target, power, passTargeting);
+			case ENTITY_FROM_LOCATION ->
+				spell instanceof TargetedEntityFromLocationSpell && castAtEntityFromLocation(caster, location, target, power, passTargeting);
 			case ENTITY -> spell instanceof TargetedEntitySpell && castAtEntity(caster, target, power, passTargeting);
-			case LOCATION -> spell instanceof TargetedLocationSpell && castAtLocation(caster, useTargetForLocation ? target.getLocation() : location, power);
+			case LOCATION ->
+				spell instanceof TargetedLocationSpell && castAtLocation(caster, useTargetForLocation ? target.getLocation() : location, power);
 			case NONE -> {
 				if (caster == null) yield false;
 
@@ -221,11 +272,11 @@ public class Subspell {
 		};
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull LivingEntity target, float power) {
-		return subcast(caster, target, power, passTargeting);
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull LivingEntity target, float power, @Nullable String[] args) {
+		return subcast(caster, target, power, args, passTargeting);
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull LivingEntity target, float power, boolean passTargeting) {
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull LivingEntity target, float power, @Nullable String[] args, boolean passTargeting) {
 		if (invert) {
 			if (caster != null) {
 				LivingEntity temp = caster;
@@ -233,7 +284,6 @@ public class Subspell {
 				target = temp;
 			} else caster = target;
 		}
-
 
 		CastTargeting targeting = this.targeting;
 		if (targeting == CastTargeting.NORMAL) {
@@ -244,7 +294,8 @@ public class Subspell {
 
 		return switch (targeting) {
 			case ENTITY -> spell instanceof TargetedEntitySpell && castAtEntity(caster, target, power, passTargeting);
-			case LOCATION -> spell instanceof TargetedLocationSpell && castAtLocation(caster, target.getLocation(), power);
+			case LOCATION ->
+				spell instanceof TargetedLocationSpell && castAtLocation(caster, target.getLocation(), power);
 			case NONE -> {
 				if (caster == null) yield false;
 
@@ -255,8 +306,8 @@ public class Subspell {
 		};
 	}
 
-	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location target, float power) {
-		if (invert && caster != null) return subcast(caster, target, caster, power);
+	public boolean subcast(@Nullable LivingEntity caster, @NotNull Location target, float power, @Nullable String[] args) {
+		if (invert && caster != null) return subcast(caster, target, caster, power, args);
 
 		CastTargeting targeting = this.targeting;
 		if (targeting == CastTargeting.NORMAL) {
@@ -276,29 +327,42 @@ public class Subspell {
 		};
 	}
 
-	public boolean subcast(@NotNull LivingEntity caster, float power) {
-		if (invert) return subcast(caster, caster, power);
+	public boolean subcast(@NotNull LivingEntity caster, float power, @Nullable String[] args) {
+		if (invert) return subcast(caster, caster, power, args);
 		if (targeting != CastTargeting.NORMAL && targeting != CastTargeting.NONE) return false;
 
 		PostCastAction action = cast(caster, power);
 		return action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
 	}
 
-	public PostCastAction cast(final LivingEntity caster, final float power) {
+	public PostCastAction cast(LivingEntity caster, float power) {
+		return cast(caster, power, null);
+	}
+
+	public PostCastAction cast(LivingEntity caster, float power, String[] args) {
+		if (!passPower) power = 1f;
+
+		double chance = this.chance.get(caster, power, args);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return PostCastAction.ALREADY_HANDLED;
-		if (delay < 0) return castReal(caster, power);
-		MagicSpells.scheduleDelayedTask(() -> castReal(caster, power), delay);
+
+		int delay = this.delay.get(caster, power, args);
+		if (delay < 0) return castReal(caster, power, args);
+
+		float finalPower = power;
+		MagicSpells.scheduleDelayedTask(() -> castReal(caster, finalPower, args), delay);
+
 		return PostCastAction.HANDLE_NORMALLY;
 	}
 
-	private PostCastAction castReal(LivingEntity caster, float basePower) {
-		float power = basePower * subPower;
+	private PostCastAction castReal(LivingEntity caster, float basePower, String[] args) {
+		float power = basePower * subPower.get(caster, basePower, null);
+		args = this.args.get(caster, power, args);
 
 		return switch (mode) {
 			case HARD, FULL -> spell.cast(caster, power, args).action;
 			case DIRECT -> spell.castSpell(caster, SpellCastState.NORMAL, power, args);
 			case PARTIAL -> {
-				SpellCastEvent castEvent = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power * subPower, args, 0, null, 0);
+				SpellCastEvent castEvent = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power, args, 0, null, 0);
 				if (!castEvent.callEvent() || castEvent.getSpellCastState() != SpellCastState.NORMAL)
 					yield PostCastAction.ALREADY_HANDLED;
 
@@ -312,32 +376,43 @@ public class Subspell {
 		};
 	}
 
-	public boolean castAtEntity(final LivingEntity caster, final LivingEntity target, final float power) {
-		return castAtEntity(caster, target, power, passTargeting);
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power) {
+		return castAtEntity(caster, target, power, null, passTargeting);
 	}
 
-	public boolean castAtEntity(final LivingEntity caster, final LivingEntity target, final float power, final boolean passTargeting) {
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, boolean passTargeting) {
+		return castAtEntity(caster, target, power, null, passTargeting | this.passTargeting);
+	}
+
+	public boolean castAtEntity(LivingEntity caster, LivingEntity target, float power, String[] args, boolean passTargeting) {
+		if (!passPower) power = 1f;
+
+		double chance = this.chance.get(caster, power, args);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return false;
-		if (delay < 0) return castAtEntityReal(caster, target, power, passTargeting);
-		MagicSpells.scheduleDelayedTask(() -> castAtEntityReal(caster, target, power, passTargeting), delay);
+
+		int delay = this.delay.get(caster, power, args);
+		if (delay < 0) return castAtEntityReal(caster, target, power, args, passTargeting);
+
+		float finalPower = power;
+		MagicSpells.scheduleDelayedTask(() -> castAtEntityReal(caster, target, finalPower, args, passTargeting), delay);
+
 		return true;
 	}
 
-	private boolean castAtEntityReal(LivingEntity caster, LivingEntity target, float basePower, boolean passTargeting) {
-		if (!isTargetedEntity) return isTargetedLocation && castAtLocationReal(caster, target.getLocation(), basePower);
+	private boolean castAtEntityReal(LivingEntity caster, LivingEntity target, float basePower, String[] args, boolean passTargeting) {
+		if (!isTargetedEntity) return isTargetedLocation && castAtLocationReal(caster, target.getLocation(), basePower, args);
 
-		passTargeting |= this.passTargeting;
+		float power = basePower * subPower.get(caster, basePower, args);
+		args = this.args.get(caster, power, args);
 
 		return switch (mode) {
 			case HARD -> {
 				if (caster == null) yield false;
 
-				SpellCastResult result = spell.cast(caster, basePower * subPower, args);
+				SpellCastResult result = spell.cast(caster, power, args);
 				yield result.state == SpellCastState.NORMAL && (result.action == PostCastAction.HANDLE_NORMALLY || result.action == PostCastAction.NO_MESSAGES);
 			}
 			case DIRECT -> {
-				float power = basePower * subPower;
-
 				if (passTargeting) yield passTargetingEntity(caster, target, power, args);
 				else {
 					TargetedEntitySpell targetedSpell = (TargetedEntitySpell) spell;
@@ -345,8 +420,6 @@ public class Subspell {
 				}
 			}
 			case PARTIAL -> {
-				float power = basePower * subPower;
-
 				SpellCastEvent castEvent = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power, args, 0, null, 0);
 				if (!castEvent.callEvent() || castEvent.getSpellCastState() != SpellCastState.NORMAL) yield false;
 
@@ -372,8 +445,6 @@ public class Subspell {
 			}
 			case FULL -> {
 				if (caster == null) yield false;
-
-				float power = basePower * subPower;
 
 				SpellCastEvent castEvent = spell.preCast(caster, power, args);
 				if (castEvent == null) yield false;
@@ -419,32 +490,45 @@ public class Subspell {
 		return success;
 	}
 
-	public boolean castAtLocation(final LivingEntity caster, final Location target, final float power) {
+	public boolean castAtLocation(LivingEntity caster, Location target, float power) {
+		return castAtLocation(caster, target, null, power);
+	}
+
+	public boolean castAtLocation(LivingEntity caster, Location target, String[] args, float power) {
+		if (!passPower) power = 1f;
+
+		double chance = this.chance.get(caster, power, args);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return false;
-		if (delay < 0) return castAtLocationReal(caster, target, power);
-		MagicSpells.scheduleDelayedTask(() -> castAtLocationReal(caster, target, power), delay);
+
+		int delay = this.delay.get(caster, power, args);
+		if (delay < 0) return castAtLocationReal(caster, target, power, args);
+
+		float finalPower = power;
+		MagicSpells.scheduleDelayedTask(() -> castAtLocationReal(caster, target, finalPower, args), delay);
+
 		return true;
 	}
 
-	private boolean castAtLocationReal(LivingEntity caster, Location target, float basePower) {
+	private boolean castAtLocationReal(LivingEntity caster, Location target, float basePower, String[] args) {
 		if (!isTargetedLocation) return false;
+
+		float power = basePower * subPower.get(caster, basePower, args);
+		args = this.args.get(caster, power, args);
 
 		return switch (mode) {
 			case HARD -> {
 				if (caster == null) yield false;
 
-				SpellCastResult result = spell.cast(caster, basePower * subPower, args);
+				SpellCastResult result = spell.cast(caster, power, args);
 				yield result.state == SpellCastState.NORMAL && (result.action == PostCastAction.HANDLE_NORMALLY ||
 					result.action == PostCastAction.NO_MESSAGES);
 			}
 			case DIRECT -> {
 				TargetedLocationSpell targetedSpell = (TargetedLocationSpell) spell;
-				yield caster != null ? targetedSpell.castAtLocation(caster, target, basePower * subPower, args)
-					: targetedSpell.castAtLocation(target, basePower * subPower, args);
+				yield caster != null ? targetedSpell.castAtLocation(caster, target, power, args)
+					: targetedSpell.castAtLocation(target, power, args);
 			}
 			case PARTIAL -> {
-				float power = basePower * subPower;
-
 				SpellCastEvent castEvent = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power, args, 0, null, 0);
 				if (!castEvent.callEvent() || castEvent.getSpellCastState() != SpellCastState.NORMAL) yield false;
 
@@ -466,8 +550,6 @@ public class Subspell {
 			}
 			case FULL -> {
 				if (caster == null) yield false;
-
-				float power = basePower * subPower;
 
 				SpellCastEvent castEvent = spell.preCast(caster, power, args);
 				if (castEvent == null) yield false;
@@ -493,42 +575,52 @@ public class Subspell {
 		};
 	}
 
-	public boolean castAtEntityFromLocation(final LivingEntity caster, final Location from, final LivingEntity target, final float power) {
-		return castAtEntityFromLocation(caster, from, target, power, passTargeting);
+	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power) {
+		return castAtEntityFromLocation(caster, from, target, power, null, passTargeting);
 	}
 
-	public boolean castAtEntityFromLocation(final LivingEntity caster, final Location from, final LivingEntity target, final float power, final boolean passTargeting) {
+	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power, boolean passTargeting) {
+		return castAtEntityFromLocation(caster, from, target, power, null, passTargeting | this.passTargeting);
+	}
+
+	public boolean castAtEntityFromLocation(LivingEntity caster, Location from, LivingEntity target, float power, String[] args, boolean passTargeting) {
+		if (!passPower) power = 1f;
+
+		double chance = this.chance.get(caster, power, args);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return false;
-		if (delay < 0) return castAtEntityFromLocationReal(caster, from, target, power, passTargeting);
-		MagicSpells.scheduleDelayedTask(() -> castAtEntityFromLocationReal(caster, from, target, power, passTargeting), delay);
+
+		int delay = this.delay.get(caster, power, args);
+		if (delay < 0) return castAtEntityFromLocationReal(caster, from, target, power, args, passTargeting);
+
+		float finalPower = power;
+		MagicSpells.scheduleDelayedTask(() -> castAtEntityFromLocationReal(caster, from, target, finalPower, args, passTargeting), delay);
+
 		return true;
 	}
 
-	private boolean castAtEntityFromLocationReal(LivingEntity caster, Location from, LivingEntity target, float basePower, boolean passTargeting) {
+	private boolean castAtEntityFromLocationReal(LivingEntity caster, Location from, LivingEntity target, float basePower, String[] args, boolean passTargeting) {
 		if (!isTargetedEntityFromLocation) return false;
 
-		passTargeting |= this.passTargeting;
+		float power = basePower * subPower.get(caster, basePower, args);
+		args = this.args.get(caster, power, args);
 
 		return switch (mode) {
 			case HARD -> {
 				if (caster == null) yield false;
 
-				SpellCastResult result = spell.cast(caster, basePower * subPower, args);
+				SpellCastResult result = spell.cast(caster, power, args);
 				yield result.state == SpellCastState.NORMAL && (result.action == PostCastAction.HANDLE_NORMALLY ||
 					result.action == PostCastAction.NO_MESSAGES);
 			}
 			case DIRECT -> {
-				if (passTargeting)
-					yield passTargetingEntityFromLocation(caster, from, target, basePower * subPower, args);
+				if (passTargeting) yield passTargetingEntityFromLocation(caster, from, target, power, args);
 				else {
 					TargetedEntityFromLocationSpell targetedSpell = (TargetedEntityFromLocationSpell) spell;
-					yield caster != null ? targetedSpell.castAtEntityFromLocation(caster, from, target, basePower * subPower, args) :
-						targetedSpell.castAtEntityFromLocation(from, target, basePower * subPower, args);
+					yield caster != null ? targetedSpell.castAtEntityFromLocation(caster, from, target, power, args) :
+						targetedSpell.castAtEntityFromLocation(from, target, power, args);
 				}
 			}
 			case PARTIAL -> {
-				float power = basePower * subPower;
-
 				SpellCastEvent castEvent = new SpellCastEvent(spell, caster, SpellCastState.NORMAL, power, args, 0, null, 0);
 				if (!castEvent.callEvent() || castEvent.getSpellCastState() != SpellCastState.NORMAL) yield false;
 
@@ -559,8 +651,6 @@ public class Subspell {
 			case FULL -> {
 				if (caster == null) yield false;
 
-				float power = basePower * subPower;
-
 				SpellCastEvent castEvent = spell.preCast(caster, power, args);
 				if (castEvent == null) yield false;
 
@@ -577,8 +667,10 @@ public class Subspell {
 							power = targetLocationEvent.getPower();
 							from = targetLocationEvent.getTargetLocation();
 
-							if (passTargeting) success = passTargetingEntityFromLocation(caster, from, target, power, args);
-							else success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, power, args);
+							if (passTargeting)
+								success = passTargetingEntityFromLocation(caster, from, target, power, args);
+							else
+								success = ((TargetedEntityFromLocationSpell) spell).castAtEntityFromLocation(caster, from, target, power, args);
 						}
 					}
 				}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -582,78 +582,56 @@ public enum ModifierType {
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) {
-				data.spell.cast(event.getCaster(), event.getPower());
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getPower());
 			return true;
 		}
 
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) {
-				data.spell.cast(event.getPlayer(), 1f);
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) {
-				if (data.spell.isTargetedEntitySpell()) data.spell.castAtEntity(event.getCaster(), event.getTarget(), event.getPower());
-				else if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(event.getCaster(), event.getTarget().getLocation(), event.getPower());
-				else data.spell.cast(event.getCaster(), event.getPower());
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getCaster(), event.getPower());
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) {
-				if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(event.getCaster(), event.getTargetLocation(), event.getPower());
-				else data.spell.cast(event.getCaster(), event.getPower());
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower());
 			return true;
 		}
 
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) {
-				data.spell.cast(event.getPlayer(), 1f);
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
 			return true;
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) {
-				data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) {
-				if (data.spell.isTargetedEntitySpell()) data.spell.castAtEntity(caster, target, result.data().power());
-				else if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(caster, target.getLocation(), result.data().power());
-				else data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) {
-				if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(caster, target, result.data().power());
-				else data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
@@ -698,7 +676,7 @@ public enum ModifierType {
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				data.spell.cast(event.getCaster(), event.getPower());
+				data.spell.subcast(event.getCaster(), event.getPower());
 				event.setCancelled(true);
 			}
 			return !check;
@@ -707,9 +685,7 @@ public enum ModifierType {
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (check && data.isValid()) {
-				data.spell.cast(event.getPlayer(), 1f);
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
 			return !check;
 		}
 
@@ -717,10 +693,7 @@ public enum ModifierType {
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				if (data.spell.isTargetedEntitySpell()) data.spell.castAtEntity(event.getCaster(), event.getTarget(), event.getPower());
-				else if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(event.getCaster(), event.getTarget().getLocation(), event.getPower());
-				else data.spell.cast(event.getCaster(), event.getPower());
-
+				data.spell.subcast(event.getCaster(), event.getTarget(), event.getPower());
 				event.setCancelled(true);
 				event.setCastCancelled(true);
 			}
@@ -731,8 +704,7 @@ public enum ModifierType {
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(event.getCaster(), event.getTargetLocation(), event.getPower());
-				else data.spell.cast(event.getCaster(), event.getPower());
+				data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower());
 				event.setCancelled(true);
 			}
 			return !check;
@@ -741,39 +713,28 @@ public enum ModifierType {
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (check && data.isValid()) {
-				data.spell.cast(event.getPlayer(), 1f);
-			}
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
 			return !check;
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) {
-				data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power());
 			return new ModifierResult(result.data(), !result.check());
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) {
-				if (data.spell.isTargetedEntitySpell()) data.spell.castAtEntity(caster, target, result.data().power());
-				else if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(caster, target.getLocation(), result.data().power());
-				else data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
 			return new ModifierResult(result.data(), !result.check());
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) {
-				if (data.spell.isTargetedLocationSpell()) data.spell.castAtLocation(caster, target, result.data().power());
-				else data.spell.cast(caster, result.data().power());
-			}
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
 			return new ModifierResult(result.data(), !result.check());
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -582,56 +582,56 @@ public enum ModifierType {
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getPower());
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getPower(), event.getSpellArgs());
 			return true;
 		}
 
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f, null);
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getCaster(), event.getPower());
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getCaster(), event.getPower(), event.getSpellArgs());
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower());
+			if (check && data.isValid()) data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower(), event.getSpellArgs());
 			return true;
 		}
 
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f, null);
 			return true;
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power(), result.data().args());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power(), result.data().args());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			CastData data = (CastData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power(), result.data().args());
 			return result.check() ? result : new ModifierResult(result.data(), true);
 		}
 
@@ -676,7 +676,7 @@ public enum ModifierType {
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				data.spell.subcast(event.getCaster(), event.getPower());
+				data.spell.subcast(event.getCaster(), event.getPower(), event.getSpellArgs());
 				event.setCancelled(true);
 			}
 			return !check;
@@ -685,7 +685,7 @@ public enum ModifierType {
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f, null);
 			return !check;
 		}
 
@@ -693,7 +693,7 @@ public enum ModifierType {
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				data.spell.subcast(event.getCaster(), event.getTarget(), event.getPower());
+				data.spell.subcast(event.getCaster(), event.getTarget(), event.getPower(), event.getSpellArgs());
 				event.setCancelled(true);
 				event.setCastCancelled(true);
 			}
@@ -704,7 +704,7 @@ public enum ModifierType {
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
 			if (check && data.isValid()) {
-				data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower());
+				data.spell.subcast(event.getCaster(), event.getTargetLocation(), event.getPower(), event.getSpellArgs());
 				event.setCancelled(true);
 			}
 			return !check;
@@ -713,28 +713,28 @@ public enum ModifierType {
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f);
+			if (check && data.isValid()) data.spell.subcast(event.getPlayer(), 1f, null);
 			return !check;
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, result.data().power(), result.data().args());
 			return new ModifierResult(result.data(), !result.check());
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power(), result.data().args());
 			return new ModifierResult(result.data(), !result.check());
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			CustomInsteadData data = (CustomInsteadData) customData;
-			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power());
+			if (result.check() && data.isValid()) data.spell.subcast(caster, target, result.data().power(), result.data().args());
 			return new ModifierResult(result.data(), !result.check());
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BowSpell.java
@@ -258,7 +258,7 @@ public class BowSpell extends Spell {
 				playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, caster.getLocation(), projectile.getLocation(), caster, projectile, arrowData.spellData);
 			}
 
-			if (spellOnShoot != null) spellOnShoot.subcast(caster, castEvent.getPower());
+			if (spellOnShoot != null) spellOnShoot.subcast(caster, castEvent.getPower(), null);
 		} else if (cancelShotOnFail) event.setCancelled(true);
 
 		postCast(castEvent, PostCastAction.HANDLE_NORMALLY);
@@ -309,7 +309,7 @@ public class BowSpell extends Spell {
 					SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(data.bowSpell, caster, proj.getLocation(), data.spellData.power());
 					if (!targetEvent.callEvent()) continue;
 
-					groundSpell.subcast(caster, targetEvent.getTargetLocation(), targetEvent.getPower());
+					groundSpell.subcast(caster, targetEvent.getTargetLocation(), targetEvent.getPower(), null);
 
 					if (data.bowSpell.removeArrow) remove = true;
 				}
@@ -351,8 +351,8 @@ public class BowSpell extends Spell {
 					LivingEntity subTarget = targetEvent.getTarget();
 					float subPower = targetEvent.getPower();
 
-					if (entitySpell != null) entitySpell.subcast(caster, caster.getLocation(), subTarget, subPower);
-					if (entityLocationSpell != null) entityLocationSpell.subcast(caster, arrow.getLocation(), subPower);
+					if (entitySpell != null) entitySpell.subcast(caster, caster.getLocation(), subTarget, subPower, null);
+					if (entityLocationSpell != null) entityLocationSpell.subcast(caster, arrow.getLocation(), subPower, null);
 
 					if (data.bowSpell.removeArrow) remove = true;
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -338,7 +338,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	 */
 	protected int addUse(LivingEntity entity) {
 		// Run spell on use increment first thing in case we want to intervene
-		if (spellOnUseIncrement != null) spellOnUseIncrement.subcast(entity, 1f);
+		if (spellOnUseIncrement != null) spellOnUseIncrement.subcast(entity, 1f, null);
 
 		if (numUses > 0 || (reagents != null && useCostInterval > 0)) {
 
@@ -364,7 +364,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	 */
 	protected boolean chargeUseCost(LivingEntity entity) {
 		// Run spell on cost first thing to dodge the early returns and allow intervention
-		if (spellOnCost != null) spellOnCost.subcast(entity, 1f);
+		if (spellOnCost != null) spellOnCost.subcast(entity, 1f, null);
 
 		if (reagents == null) return true;
 		if (useCostInterval <= 0) return true;
@@ -417,7 +417,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		cancelEffects(EffectPosition.CASTER, entity.getUniqueId().toString());
 		stopEffects(entity);
 
-		if (spellOnEnd != null) spellOnEnd.subcast(endSpellFromTarget ? entity : getLastCaster(entity), 1f);
+		if (spellOnEnd != null) spellOnEnd.subcast(endSpellFromTarget ? entity : getLastCaster(entity), 1f, null);
 		sendMessage(strFade, entity, null);
 
 		lastCaster.remove(entity.getUniqueId());

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -338,7 +338,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	 */
 	protected int addUse(LivingEntity entity) {
 		// Run spell on use increment first thing in case we want to intervene
-		if (spellOnUseIncrement != null) spellOnUseIncrement.cast(entity, 1f);
+		if (spellOnUseIncrement != null) spellOnUseIncrement.subcast(entity, 1f);
 
 		if (numUses > 0 || (reagents != null && useCostInterval > 0)) {
 
@@ -364,7 +364,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 	 */
 	protected boolean chargeUseCost(LivingEntity entity) {
 		// Run spell on cost first thing to dodge the early returns and allow intervention
-		if (spellOnCost != null) spellOnCost.cast(entity, 1f);
+		if (spellOnCost != null) spellOnCost.subcast(entity, 1f);
 
 		if (reagents == null) return true;
 		if (useCostInterval <= 0) return true;
@@ -417,7 +417,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 		cancelEffects(EffectPosition.CASTER, entity.getUniqueId().toString());
 		stopEffects(entity);
 
-		if (spellOnEnd != null) spellOnEnd.cast(endSpellFromTarget ? entity : getLastCaster(entity), 1f);
+		if (spellOnEnd != null) spellOnEnd.subcast(endSpellFromTarget ? entity : getLastCaster(entity), 1f);
 		sendMessage(strFade, entity, null);
 
 		lastCaster.remove(entity.getUniqueId());

--- a/core/src/main/java/com/nisovin/magicspells/spells/LocationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/LocationSpell.java
@@ -54,7 +54,7 @@ public class LocationSpell extends InstantSpell {
 			Location loc = location.getLocation();
 			if (loc == null) return PostCastAction.ALREADY_HANDLED;
 
-			if (spellToCast != null) spellToCast.subcast(caster, loc, power);
+			if (spellToCast != null) spellToCast.subcast(caster, loc, power, args);
 			playSpellEffects(caster, loc, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/LocationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/LocationSpell.java
@@ -42,7 +42,7 @@ public class LocationSpell extends InstantSpell {
 		super.initialize();
 
 		spellToCast = new Subspell(spellToCastName);
-		if (!spellToCast.process() || !spellToCast.isTargetedLocationSpell()) {
+		if (!spellToCast.process()) {
 			MagicSpells.error("LocationSpell '" + internalName + "' has an invalid spell defined!");
 			spellToCast = null;
 		}
@@ -54,7 +54,7 @@ public class LocationSpell extends InstantSpell {
 			Location loc = location.getLocation();
 			if (loc == null) return PostCastAction.ALREADY_HANDLED;
 
-			if (spellToCast != null) spellToCast.castAtLocation(caster, loc, power);
+			if (spellToCast != null) spellToCast.subcast(caster, loc, power);
 			playSpellEffects(caster, loc, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -32,10 +32,8 @@ import com.nisovin.magicspells.events.MagicSpellsGenericPlayerEvent;
 
 public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
-	private final Map<UUID, Float> castPower = new HashMap<>();
-	private final Map<UUID, Location> castLocTarget = new HashMap<>();
-	private final Map<UUID, LivingEntity> castEntityTarget = new HashMap<>();
 	private final Map<String, MenuOption> options = new LinkedHashMap<>();
+	private final Map<UUID, MenuData> menuData = new HashMap<>();
 
 	private int size;
 
@@ -279,10 +277,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	}
 
 	private void openMenu(Player caster, Player opener, LivingEntity entityTarget, Location locTarget, float power, String[] args) {
-		castPower.put(opener.getUniqueId(), power);
-		if (requireEntityTarget && entityTarget != null) castEntityTarget.put(opener.getUniqueId(), entityTarget);
-		if (requireLocationTarget && locTarget != null) castLocTarget.put(opener.getUniqueId(), locTarget);
-
+		menuData.put(opener.getUniqueId(), new MenuData(requireEntityTarget ? entityTarget : null, requireLocationTarget ? locTarget : null, power, args));
 
 		Inventory inv = Bukkit.createInventory(opener, size, Component.text(internalName));
 		applyOptionsToInventory(opener, inv, args);
@@ -364,9 +359,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		String closeState = castSpells(player, event.getCurrentItem(), event.getClick());
 
 		UUID id = player.getUniqueId();
-		castPower.remove(id);
-		castLocTarget.remove(id);
-		castEntityTarget.remove(id);
+		menuData.remove(id);
 
 		if (closeState.equals("ignore")) return;
 		if (closeState.equals("close")) {
@@ -399,16 +392,24 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 	private String processClickSpell(Player player, Subspell spell, MenuOption option) {
 		if (spell == null) return option.stayOpen ? "ignore" : "close";
-		UUID id = player.getUniqueId();
+
+		LivingEntity entityTarget = null;
+		Location locationTarget = null;
 		float power = option.power;
-		if (castPower.containsKey(id)) power *= castPower.get(id);
+		String[] args = null;
 
-		LivingEntity entityTarget = castEntityTarget.get(id);
-		Location locationTarget = castLocTarget.get(id);
+		UUID id = player.getUniqueId();
+		MenuData data = menuData.get(id);
+		if (data != null) {
+			locationTarget = data.targetLocation;
+			entityTarget = data.targetEntity;
+			power *= data.power;
+			args = data.args;
+		}
 
-		if (entityTarget != null) spell.subcast(player, entityTarget, power);
-		else if (locationTarget != null) spell.subcast(player, locationTarget, power);
-		else if (bypassNormalCast) spell.subcast(player, power);
+		if (entityTarget != null) spell.subcast(player, entityTarget, power, args);
+		else if (locationTarget != null) spell.subcast(player, locationTarget, power, args);
+		else if (bypassNormalCast) spell.subcast(player, power, args);
 		else spell.getSpell().cast(player, power, MagicSpells.NULL_ARGS);
 
 		return option.stayOpen ? "reopen" : "close";
@@ -417,9 +418,10 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
 		UUID id = event.getPlayer().getUniqueId();
-		castPower.remove(id);
-		castLocTarget.remove(id);
-		castEntityTarget.remove(id);
+		menuData.remove(id);
+	}
+
+	private record MenuData(LivingEntity targetEntity, Location targetLocation, float power, String[] args) {
 	}
 
 	private static class MenuOption {

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -402,10 +402,15 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		UUID id = player.getUniqueId();
 		float power = option.power;
 		if (castPower.containsKey(id)) power *= castPower.get(id);
-		if (spell.isTargetedEntitySpell() && castEntityTarget.containsKey(id)) spell.castAtEntity(player, castEntityTarget.get(id), power);
-		else if (spell.isTargetedLocationSpell() && castLocTarget.containsKey(id)) spell.castAtLocation(player, castLocTarget.get(id), power);
-		else if (bypassNormalCast) spell.cast(player, power);
+
+		LivingEntity entityTarget = castEntityTarget.get(id);
+		Location locationTarget = castLocTarget.get(id);
+
+		if (entityTarget != null) spell.subcast(player, entityTarget, power);
+		else if (locationTarget != null) spell.subcast(player, locationTarget, power);
+		else if (bypassNormalCast) spell.subcast(player, power);
 		else spell.getSpell().cast(player, power, MagicSpells.NULL_ARGS);
+
 		return option.stayOpen ? "reopen" : "close";
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
@@ -87,8 +87,8 @@ public final class MultiSpell extends InstantSpell {
 						delay += action.getDelay();
 					} else if (action.isSpell()) {
 						Subspell spell = action.getSpell();
-						if (delay == 0) spell.subcast(caster, power);
-						else MagicSpells.scheduleDelayedTask(new DelayedSpell(spell, caster, power), delay);
+						if (delay == 0) spell.subcast(caster, power, args);
+						else MagicSpells.scheduleDelayedTask(new DelayedSpell(spell, caster, power, args), delay);
 					}
 				}
 			} else {
@@ -105,18 +105,18 @@ public final class MultiSpell extends InstantSpell {
 						s = (int) Math.round(s + actions.get(i++).getChance());
 					}
 					Action action = actions.get(Math.max(0, i - 1)).getAction();
-					if (action.isSpell()) action.getSpell().subcast(caster, power);
+					if (action.isSpell()) action.getSpell().subcast(caster, power, args);
 				} else if (enableIndividualChances) {
 					for (ActionChance actionChance : actions) {
 						double chance = Math.random();
 						if ((actionChance.getChance() / 100.0D > chance) && actionChance.getAction().isSpell()) {
 							Action action = actionChance.getAction();
-							action.getSpell().subcast(caster, power);
+							action.getSpell().subcast(caster, power, args);
 						}
 					}
 				} else {
 					Action action = actions.get(random.nextInt(actions.size())).getAction();
-					action.getSpell().subcast(caster, power);
+					action.getSpell().subcast(caster, power, args);
 				}
 			}
 			playSpellEffects(EffectPosition.CASTER, caster, power, args);
@@ -226,21 +226,23 @@ public final class MultiSpell extends InstantSpell {
 
 	private static class DelayedSpell implements Runnable {
 		
-		private Subspell spell;
-		private UUID casterUUID;
-		private float power;
+		private final Subspell spell;
+		private final String[] args;
+		private final float power;
+		private final UUID casterUUID;
 
-		DelayedSpell(Subspell spell, LivingEntity livingEntity, float power) {
+		DelayedSpell(Subspell spell, LivingEntity caster, float power, String[] args) {
+			this.casterUUID = caster.getUniqueId();
 			this.spell = spell;
-			this.casterUUID = livingEntity.getUniqueId();
 			this.power = power;
+			this.args = args;
 		}
 
 		@Override
 		public void run() {
 			Entity entity = Bukkit.getEntity(casterUUID);
 			if (entity == null || !entity.isValid() || !(entity instanceof LivingEntity livingEntity)) return;
-			spell.subcast(livingEntity, power);
+			spell.subcast(livingEntity, power, args);
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
@@ -87,7 +87,7 @@ public final class MultiSpell extends InstantSpell {
 						delay += action.getDelay();
 					} else if (action.isSpell()) {
 						Subspell spell = action.getSpell();
-						if (delay == 0) spell.cast(caster, power);
+						if (delay == 0) spell.subcast(caster, power);
 						else MagicSpells.scheduleDelayedTask(new DelayedSpell(spell, caster, power), delay);
 					}
 				}
@@ -105,18 +105,18 @@ public final class MultiSpell extends InstantSpell {
 						s = (int) Math.round(s + actions.get(i++).getChance());
 					}
 					Action action = actions.get(Math.max(0, i - 1)).getAction();
-					if (action.isSpell()) action.getSpell().cast(caster, power);
+					if (action.isSpell()) action.getSpell().subcast(caster, power);
 				} else if (enableIndividualChances) {
 					for (ActionChance actionChance : actions) {
 						double chance = Math.random();
 						if ((actionChance.getChance() / 100.0D > chance) && actionChance.getAction().isSpell()) {
 							Action action = actionChance.getAction();
-							action.getSpell().cast(caster, power);
+							action.getSpell().subcast(caster, power);
 						}
 					}
 				} else {
 					Action action = actions.get(random.nextInt(actions.size())).getAction();
-					action.getSpell().cast(caster, power);
+					action.getSpell().subcast(caster, power);
 				}
 			}
 			playSpellEffects(EffectPosition.CASTER, caster, power, args);
@@ -240,7 +240,7 @@ public final class MultiSpell extends InstantSpell {
 		public void run() {
 			Entity entity = Bukkit.getEntity(casterUUID);
 			if (entity == null || !entity.isValid() || !(entity instanceof LivingEntity livingEntity)) return;
-			spell.cast(livingEntity, power);
+			spell.subcast(livingEntity, power);
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -318,7 +318,7 @@ public class PassiveSpell extends Spell {
 			if (castWithoutTarget) {
 				MagicSpells.debug(3, "    Casting without target");
 
-				spell.subcast(caster, power);
+				spell.subcast(caster, power, null);
 				if (!spellEffectsDone) {
 					playSpellEffects(EffectPosition.CASTER, caster, power, null);
 					spellEffectsDone = true;
@@ -330,7 +330,7 @@ public class PassiveSpell extends Spell {
 			if (target != null && !isActuallyNonTargeted(spell.getSpell())) {
 				MagicSpells.debug(3, "    Casting with target entity");
 
-				spell.subcast(caster, target, power);
+				spell.subcast(caster, target, power, null);
 				if (!spellEffectsDone) {
 					playSpellEffects(caster, target, data);
 					spellEffectsDone = true;
@@ -342,7 +342,7 @@ public class PassiveSpell extends Spell {
 			if (location != null) {
 				MagicSpells.debug(3, "    Casting with target location");
 
-				spell.subcast(caster, location, power);
+				spell.subcast(caster, location, power, null);
 				if (!spellEffectsDone) {
 					playSpellEffects(caster, location, data);
 					spellEffectsDone = true;
@@ -353,7 +353,7 @@ public class PassiveSpell extends Spell {
 
 			MagicSpells.debug(3, "    Casting normally");
 
-			spell.subcast(caster, power);
+			spell.subcast(caster, power, null);
 			if (!spellEffectsDone) {
 				playSpellEffects(EffectPosition.CASTER, caster, data);
 				spellEffectsDone = true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -318,7 +318,7 @@ public class PassiveSpell extends Spell {
 			if (castWithoutTarget) {
 				MagicSpells.debug(3, "    Casting without target");
 
-				spell.cast(caster, power);
+				spell.subcast(caster, power);
 				if (!spellEffectsDone) {
 					playSpellEffects(EffectPosition.CASTER, caster, power, null);
 					spellEffectsDone = true;
@@ -327,8 +327,10 @@ public class PassiveSpell extends Spell {
 				continue;
 			}
 
-			if (spell.isTargetedEntitySpell() && target != null && !isActuallyNonTargeted(spell.getSpell())) {
-				spell.castAtEntity(caster, target, power);
+			if (target != null && !isActuallyNonTargeted(spell.getSpell())) {
+				MagicSpells.debug(3, "    Casting with target entity");
+
+				spell.subcast(caster, target, power);
 				if (!spellEffectsDone) {
 					playSpellEffects(caster, target, data);
 					spellEffectsDone = true;
@@ -337,14 +339,12 @@ public class PassiveSpell extends Spell {
 				continue;
 			}
 
-			if (spell.isTargetedLocationSpell() && (location != null || target != null)) {
-				MagicSpells.debug(3, "    Casting at location");
+			if (location != null) {
+				MagicSpells.debug(3, "    Casting with target location");
 
-				Location loc = location != null ? location : target.getLocation();
-
-				spell.castAtLocation(caster, loc, power);
+				spell.subcast(caster, location, power);
 				if (!spellEffectsDone) {
-					playSpellEffects(caster, loc, data);
+					playSpellEffects(caster, location, data);
 					spellEffectsDone = true;
 				}
 
@@ -353,7 +353,7 @@ public class PassiveSpell extends Spell {
 
 			MagicSpells.debug(3, "    Casting normally");
 
-			spell.cast(caster, power);
+			spell.subcast(caster, power);
 			if (!spellEffectsDone) {
 				playSpellEffects(EffectPosition.CASTER, caster, data);
 				spellEffectsDone = true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -191,10 +191,10 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		));
 	}
 
-	private void processClickSpell(Subspell subspell, Player caster, Player target, float power) {
+	private void processClickSpell(Subspell subspell, Player caster, Player target, float power, String[] args) {
 		if (subspell == null) return;
-		if (castSpellsOnTarget) subspell.subcast(caster, target, power);
-		else subspell.subcast(caster, power);
+		if (castSpellsOnTarget) subspell.subcast(caster, target, power, args);
+		else subspell.subcast(caster, power, args);
 	}
 
 	private void open(Player opener, MenuData data) {
@@ -281,7 +281,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		OfflinePlayer target = skullMeta.getOwningPlayer();
 		if (target == null || !target.isOnline()) {
 			meta.displayName(translate(opener, null, skullNameOffline, args));
-			if (spellOffline != null) spellOffline.subcast(opener, power);
+			if (spellOffline != null) spellOffline.subcast(opener, power, args);
 
 			if (stayOpen) item.setItemMeta(meta);
 			else {
@@ -301,7 +301,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 		if (radius > 0 && targetPlayer.getLocation().distance(opener.getLocation()) > radius) {
 			meta.displayName(translate(opener, targetPlayer, skullNameRadius, args));
-			if (spellRange != null) spellRange.subcast(opener, power);
+			if (spellRange != null) spellRange.subcast(opener, power, args);
 
 			if (stayOpen) item.setItemMeta(meta);
 			else {
@@ -314,11 +314,11 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		}
 
 		switch (event.getClick()) {
-			case LEFT -> processClickSpell(spellOnLeft, opener, targetPlayer, power);
-			case RIGHT -> processClickSpell(spellOnRight, opener, targetPlayer, power);
-			case MIDDLE -> processClickSpell(spellOnMiddle, opener, targetPlayer, power);
-			case SHIFT_LEFT -> processClickSpell(spellOnSneakLeft, opener, targetPlayer, power);
-			case SHIFT_RIGHT -> processClickSpell(spellOnSneakRight, opener, targetPlayer, power);
+			case LEFT -> processClickSpell(spellOnLeft, opener, targetPlayer, power, args);
+			case RIGHT -> processClickSpell(spellOnRight, opener, targetPlayer, power, args);
+			case MIDDLE -> processClickSpell(spellOnMiddle, opener, targetPlayer, power, args);
+			case SHIFT_LEFT -> processClickSpell(spellOnSneakLeft, opener, targetPlayer, power, args);
+			case SHIFT_RIGHT -> processClickSpell(spellOnSneakRight, opener, targetPlayer, power, args);
 		}
 
 		if (variableTarget != null && !variableTarget.isEmpty() && MagicSpells.getVariableManager().getVariable(variableTarget) != null)

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -193,11 +193,8 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 	private void processClickSpell(Subspell subspell, Player caster, Player target, float power) {
 		if (subspell == null) return;
-		if (castSpellsOnTarget && subspell.isTargetedEntitySpell()) {
-			subspell.castAtEntity(caster, target, power);
-			return;
-		}
-		subspell.cast(caster, power);
+		if (castSpellsOnTarget) subspell.subcast(caster, target, power);
+		else subspell.subcast(caster, power);
 	}
 
 	private void open(Player opener, MenuData data) {
@@ -284,7 +281,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		OfflinePlayer target = skullMeta.getOwningPlayer();
 		if (target == null || !target.isOnline()) {
 			meta.displayName(translate(opener, null, skullNameOffline, args));
-			if (spellOffline != null) spellOffline.cast(opener, power);
+			if (spellOffline != null) spellOffline.subcast(opener, power);
 
 			if (stayOpen) item.setItemMeta(meta);
 			else {
@@ -304,7 +301,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 		if (radius > 0 && targetPlayer.getLocation().distance(opener.getLocation()) > radius) {
 			meta.displayName(translate(opener, targetPlayer, skullNameRadius, args));
-			if (spellRange != null) spellRange.cast(opener, power);
+			if (spellRange != null) spellRange.subcast(opener, power);
 
 			if (stayOpen) item.setItemMeta(meta);
 			else {

--- a/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
@@ -75,7 +75,7 @@ public class RandomSpell extends InstantSpell {
 			}
 			if (!set.randomOptionSetOptions.isEmpty()) {
 				Subspell spell = set.choose();
-				return spell != null && spell.subcast(caster, power) ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED;
+				return spell != null && spell.subcast(caster, power, args) ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED;
 			}
 			return PostCastAction.ALREADY_HANDLED;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
@@ -75,8 +75,7 @@ public class RandomSpell extends InstantSpell {
 			}
 			if (!set.randomOptionSetOptions.isEmpty()) {
 				Subspell spell = set.choose();
-				if (spell != null) return spell.cast(caster, power);
-				return PostCastAction.ALREADY_HANDLED;
+				return spell != null && spell.subcast(caster, power) ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED;
 			}
 			return PostCastAction.ALREADY_HANDLED;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -43,7 +43,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 
 		pointBlank = getConfigBoolean("point-blank", false);
 		stopOnFail = getConfigBoolean("stop-on-fail", true);
-		passTargeting = getConfigBoolean("pass-targeting", true);
+		passTargeting = getConfigBoolean("pass-targeting", false);
 		requireEntityTarget = getConfigBoolean("require-entity-target", false);
 		castRandomSpellInstead = getConfigBoolean("cast-random-spell-instead", false);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -197,23 +197,12 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 		}
 		return somethingWasDone;
 	}
-	
+
 	private boolean castTargetedSpells(Subspell spell, LivingEntity caster, Location center, LivingEntity targetEnt, Location targetLoc, float power) {
-		if (spell.isTargetedEntityFromLocationSpell() && targetEnt != null && center != null) {
-			return spell.castAtEntityFromLocation(caster, center, targetEnt, power, passTargeting);
-		}
-
-		if (spell.isTargetedEntitySpell() && targetEnt != null) {
-			return spell.castAtEntity(caster, targetEnt, power, passTargeting);
-		}
-
-		if (spell.isTargetedLocationSpell()) {
-			if (targetEnt != null) return spell.castAtLocation(caster, targetEnt.getLocation(), power);
-			if (targetLoc != null) return spell.castAtLocation(caster, targetLoc, power);
-		}
-
-		PostCastAction action = spell.cast(caster, power);
-		return action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
+		if (targetEnt != null && center != null) return spell.subcast(caster, center, targetEnt, power, passTargeting);
+		if (targetEnt != null) return spell.subcast(caster, targetEnt, power, passTargeting);
+		if (targetLoc != null) return spell.subcast(caster, targetLoc, power);
+		return spell.subcast(caster, power);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -47,7 +47,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 		requireEntityTarget = getConfigBoolean("require-entity-target", false);
 		castRandomSpellInstead = getConfigBoolean("cast-random-spell-instead", false);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
@@ -99,10 +99,10 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 				locTarget.setY(locTarget.getY() + yOffset.get(caster, null, power, args));
 				locTarget.setDirection(caster.getLocation().getDirection());
 			}
-			
+
 			boolean somethingWasDone = runSpells(caster, null, entTarget, locTarget, power, args);
 			if (!somethingWasDone) return noTarget(caster, args);
-			
+
 			if (entTarget != null) {
 				sendMessages(caster, entTarget, args);
 				return PostCastAction.NO_MESSAGES;
@@ -170,13 +170,13 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 				if (action.isSpell()) {
 					spell = action.getSpell();
 					if (delay == 0) {
-						boolean ok = castTargetedSpells(spell, caster, center, targetEnt, targetLoc, power);
+						boolean ok = castTargetedSpells(spell, caster, center, targetEnt, targetLoc, power, args);
 						if (ok) somethingWasDone = true;
 						else if (stopOnFail) break;
 						continue;
 					}
 
-					DelayedSpell ds = new DelayedSpell(spell, caster, center, targetEnt, targetLoc, power, delayedSpells);
+					DelayedSpell ds = new DelayedSpell(spell, caster, center, targetEnt, targetLoc, power, args, delayedSpells);
 					delayedSpells.add(ds);
 					MagicSpells.scheduleDelayedTask(ds, delay);
 					somethingWasDone = true;
@@ -184,7 +184,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			}
 		} else {
 			Action action = actions.get(random.nextInt(actions.size()));
-			if (action.isSpell()) somethingWasDone = castTargetedSpells(action.getSpell(), caster, center, targetEnt, targetLoc, power);
+			if (action.isSpell()) somethingWasDone = castTargetedSpells(action.getSpell(), caster, center, targetEnt, targetLoc, power, args);
 		}
 		if (somethingWasDone) {
 			if (caster != null) {
@@ -198,11 +198,11 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 		return somethingWasDone;
 	}
 
-	private boolean castTargetedSpells(Subspell spell, LivingEntity caster, Location center, LivingEntity targetEnt, Location targetLoc, float power) {
-		if (targetEnt != null && center != null) return spell.subcast(caster, center, targetEnt, power, passTargeting);
-		if (targetEnt != null) return spell.subcast(caster, targetEnt, power, passTargeting);
-		if (targetLoc != null) return spell.subcast(caster, targetLoc, power);
-		return spell.subcast(caster, power);
+	private boolean castTargetedSpells(Subspell spell, LivingEntity caster, Location center, LivingEntity targetEnt, Location targetLoc, float power, String[] args) {
+		if (targetEnt != null && center != null) return spell.subcast(caster, center, targetEnt, power, args, passTargeting);
+		if (targetEnt != null) return spell.subcast(caster, targetEnt, power, args, passTargeting);
+		if (targetLoc != null) return spell.subcast(caster, targetLoc, power, args);
+		return spell.subcast(caster, power, args);
 	}
 
 	@Override
@@ -226,10 +226,10 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 	}
 
 	private static class Action {
-		
+
 		private final Subspell spell;
 		private final int delay;
-		
+
 		private Action(Subspell spell) {
 			this.spell = spell;
 			delay = 0;
@@ -239,54 +239,56 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			this.delay = delay;
 			spell = null;
 		}
-		
+
 		public boolean isSpell() {
 			return spell != null;
 		}
-		
+
 		public Subspell getSpell() {
 			return spell;
 		}
-		
+
 		public boolean isDelay() {
 			return delay > 0;
 		}
-		
+
 		public int getDelay() {
 			return delay;
 		}
-		
+
 	}
-	
+
 	private class DelayedSpell implements Runnable {
-		
+
 		private final Subspell spell;
 		private final LivingEntity caster;
 		private final Location center;
 		private final LivingEntity targetEnt;
 		private final Location targetLoc;
+		private final String[] args;
 		private final float power;
-		
+
 		private List<DelayedSpell> delayedSpells;
 		private boolean cancelled;
-		
-		private DelayedSpell(Subspell spell, LivingEntity caster, Location center, LivingEntity targetEnt, Location targetLoc, float power, List<DelayedSpell> delayedSpells) {
+
+		private DelayedSpell(Subspell spell, LivingEntity caster, Location center, LivingEntity targetEnt, Location targetLoc, float power, String[] args, List<DelayedSpell> delayedSpells) {
 			this.spell = spell;
 			this.caster = caster;
 			this.center = center;
 			this.targetEnt = targetEnt;
 			this.targetLoc = targetLoc;
+			this.args = args;
 			this.power = power;
 			this.delayedSpells = delayedSpells;
 
 			cancelled = false;
 		}
-		
+
 		public void cancel() {
 			cancelled = true;
 			delayedSpells = null;
 		}
-		
+
 		public void cancelAll() {
 			for (DelayedSpell ds : delayedSpells) {
 				if (ds == this) continue;
@@ -295,7 +297,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			delayedSpells.clear();
 			cancel();
 		}
-		
+
 		@Override
 		public void run() {
 			if (cancelled) {
@@ -304,14 +306,14 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			}
 
 			if (caster == null || caster.isValid()) {
-				boolean ok = castTargetedSpells(spell, caster, center, targetEnt, targetLoc, power);
+				boolean ok = castTargetedSpells(spell, caster, center, targetEnt, targetLoc, power, args);
 				delayedSpells.remove(this);
 				if (!ok && stopOnFail) cancelAll();
 			} else cancelAll();
 
 			delayedSpells = null;
 		}
-		
+
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -197,7 +197,7 @@ public abstract class TargetedSpell extends InstantSpell {
 		if (info != null && info.cancelled()) return PostCastAction.ALREADY_HANDLED;
 		fizzle(livingEntity);
 		sendMessage(message, livingEntity, args);
-		if (spellOnFail != null) spellOnFail.cast(livingEntity, 1.0F);
+		if (spellOnFail != null) spellOnFail.subcast(livingEntity, 1.0F);
 		return alwaysActivate ? PostCastAction.NO_MESSAGES : PostCastAction.ALREADY_HANDLED;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedSpell.java
@@ -197,7 +197,7 @@ public abstract class TargetedSpell extends InstantSpell {
 		if (info != null && info.cancelled()) return PostCastAction.ALREADY_HANDLED;
 		fizzle(livingEntity);
 		sendMessage(message, livingEntity, args);
-		if (spellOnFail != null) spellOnFail.subcast(livingEntity, 1.0F);
+		if (spellOnFail != null) spellOnFail.subcast(livingEntity, info == null ? 1f : info.power(), args);
 		return alwaysActivate ? PostCastAction.NO_MESSAGES : PostCastAction.ALREADY_HANDLED;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/DodgeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/DodgeSpell.java
@@ -126,7 +126,7 @@ public class DodgeSpell extends BuffSpell {
 		targetLoc.add(v);
 		targetLoc.setDirection(entity.getLocation().getDirection());
 
-		if (spellBeforeDodge != null) spellBeforeDodge.subcast(entity, entityLoc, spellData.power());
+		if (spellBeforeDodge != null) spellBeforeDodge.subcast(entity, entityLoc, spellData.power(), spellData.args());
 
 		if (!BlockUtils.isPathable(targetLoc.getBlock().getType()) || !BlockUtils.isPathable(targetLoc.getBlock().getRelative(BlockFace.UP))) return;
 		entity.teleportAsync(targetLoc);
@@ -135,7 +135,7 @@ public class DodgeSpell extends BuffSpell {
 		playSpellEffectsTrail(entityLoc, targetLoc, spellData);
 		playSpellEffects(EffectPosition.DELAYED, targetLoc, spellData);
 
-		if (spellAfterDodge != null) spellAfterDodge.subcast(entity, targetLoc, spellData.power());
+		if (spellAfterDodge != null) spellAfterDodge.subcast(entity, targetLoc, spellData.power(), spellData.args());
 	}
 
 	public Map<UUID, CastData> getEntities() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/DodgeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/DodgeSpell.java
@@ -58,13 +58,13 @@ public class DodgeSpell extends BuffSpell {
 		super.initialize();
 
 		spellBeforeDodge = new Subspell(spellBeforeDodgeName);
-		if (!spellBeforeDodge.process() || !spellBeforeDodge.isTargetedLocationSpell()) {
+		if (!spellBeforeDodge.process()) {
 			if (!spellBeforeDodgeName.isEmpty()) MagicSpells.error("DodgeSpell '" + internalName + "' has an invalid spell-before-dodge defined!");
 			spellBeforeDodge = null;
 		}
 
 		spellAfterDodge = new Subspell(spellAfterDodgeName);
-		if (!spellAfterDodge.process() || !spellAfterDodge.isTargetedLocationSpell()) {
+		if (!spellAfterDodge.process()) {
 			if (!spellAfterDodgeName.isEmpty()) MagicSpells.error("DodgeSpell '" + internalName + "' has an invalid spell-after-dodge defined!");
 			spellAfterDodge = null;
 		}
@@ -126,7 +126,7 @@ public class DodgeSpell extends BuffSpell {
 		targetLoc.add(v);
 		targetLoc.setDirection(entity.getLocation().getDirection());
 
-		if (spellBeforeDodge != null) spellBeforeDodge.castAtLocation(entity, entityLoc, 1F);
+		if (spellBeforeDodge != null) spellBeforeDodge.subcast(entity, entityLoc, spellData.power());
 
 		if (!BlockUtils.isPathable(targetLoc.getBlock().getType()) || !BlockUtils.isPathable(targetLoc.getBlock().getRelative(BlockFace.UP))) return;
 		entity.teleportAsync(targetLoc);
@@ -135,7 +135,7 @@ public class DodgeSpell extends BuffSpell {
 		playSpellEffectsTrail(entityLoc, targetLoc, spellData);
 		playSpellEffects(EffectPosition.DELAYED, targetLoc, spellData);
 
-		if (spellAfterDodge != null) spellAfterDodge.castAtLocation(entity, targetLoc, 1F);
+		if (spellAfterDodge != null) spellAfterDodge.subcast(entity, targetLoc, spellData.power());
 	}
 
 	public Map<UUID, CastData> getEntities() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -283,15 +283,7 @@ public class MinionSpell extends BuffSpell {
 			minion.setHealth(health);
 		}
 
-		if (spawnSpell != null) {
-			if (spawnSpell.isTargetedLocationSpell()) {
-				spawnSpell.castAtLocation(player, minion.getLocation(), power);
-			} else if (spawnSpell.isTargetedEntityFromLocationSpell()) {
-				spawnSpell.castAtEntityFromLocation(player, minion.getLocation(), minion, power);
-			} else if (spawnSpell.isTargetedEntitySpell()) {
-				spawnSpell.castAtEntity(player, minion, power);
-			}
-		}
+		if (spawnSpell != null) spawnSpell.subcast(player, minion.getLocation(), minion, power);
 
 		// Apply potion effects
 		if (potionEffects != null) minion.addPotionEffects(potionEffects);
@@ -426,15 +418,8 @@ public class MinionSpell extends BuffSpell {
 				return;
 			}
 
-			if (((LivingEntity) entity).getHealth() - e.getFinalDamage() <= 0 && deathSpell != null) {
-				if (deathSpell.isTargetedLocationSpell()) {
-					deathSpell.castAtLocation(owner, minion.getLocation(), 1);
-				} else if (deathSpell.isTargetedEntityFromLocationSpell()) {
-					deathSpell.castAtEntityFromLocation(owner, minion.getLocation(), minion, 1);
-				} else if (deathSpell.isTargetedEntitySpell()) {
-					deathSpell.castAtEntity(owner, minion, 1);
-				}
-			}
+			if (((LivingEntity) entity).getHealth() - e.getFinalDamage() <= 0 && deathSpell != null)
+				deathSpell.subcast(owner, minion.getLocation(), minion, 1);
 
 			// If the minion is far away from the owner, forget about attacking
 			if (owner.getWorld().equals(minion.getWorld()) && owner.getLocation().distanceSquared(minion.getLocation()) > maxDistance * maxDistance) return;
@@ -488,15 +473,7 @@ public class MinionSpell extends BuffSpell {
 			Player owner = Bukkit.getPlayer(players.get(minion));
 			if (owner == null || !owner.isOnline() || !owner.isValid()) return;
 
-			if (attackSpell != null) {
-				if (attackSpell.isTargetedLocationSpell()) {
-					attackSpell.castAtLocation(owner, minion.getLocation(), 1);
-				} else if (attackSpell.isTargetedEntityFromLocationSpell()) {
-					attackSpell.castAtEntityFromLocation(owner, minion.getLocation(), (LivingEntity) entity, 1);
-				} else if (attackSpell.isTargetedEntitySpell()) {
-					attackSpell.castAtEntity(owner, (LivingEntity) entity, 1);
-				}
-			}
+			if (attackSpell != null) attackSpell.subcast(owner, minion.getLocation(), (LivingEntity) entity, 1);
 		}
 
 		// The target died, the minion will follow his owner

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -283,7 +283,7 @@ public class MinionSpell extends BuffSpell {
 			minion.setHealth(health);
 		}
 
-		if (spawnSpell != null) spawnSpell.subcast(player, minion.getLocation(), minion, power);
+		if (spawnSpell != null) spawnSpell.subcast(player, minion.getLocation(), minion, power, args);
 
 		// Apply potion effects
 		if (potionEffects != null) minion.addPotionEffects(potionEffects);
@@ -419,7 +419,7 @@ public class MinionSpell extends BuffSpell {
 			}
 
 			if (((LivingEntity) entity).getHealth() - e.getFinalDamage() <= 0 && deathSpell != null)
-				deathSpell.subcast(owner, minion.getLocation(), minion, 1);
+				deathSpell.subcast(owner, minion.getLocation(), minion, 1, null);
 
 			// If the minion is far away from the owner, forget about attacking
 			if (owner.getWorld().equals(minion.getWorld()) && owner.getLocation().distanceSquared(minion.getLocation()) > maxDistance * maxDistance) return;
@@ -473,7 +473,7 @@ public class MinionSpell extends BuffSpell {
 			Player owner = Bukkit.getPlayer(players.get(minion));
 			if (owner == null || !owner.isOnline() || !owner.isValid()) return;
 
-			if (attackSpell != null) attackSpell.subcast(owner, minion.getLocation(), (LivingEntity) entity, 1);
+			if (attackSpell != null) attackSpell.subcast(owner, minion.getLocation(), (LivingEntity) entity, 1, null);
 		}
 
 		// The target died, the minion will follow his owner

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
@@ -130,10 +130,13 @@ public class WindglideSpell extends BuffSpell {
 	public void onEntityCollision(EntityDamageEvent e) {
 		if (e.getCause() != EntityDamageEvent.DamageCause.FLY_INTO_WALL) return;
 		if (!(e.getEntity() instanceof LivingEntity entity)) return;
-		if (!isActive(entity)) return;
+
+		SpellData data = entities.get(entity.getUniqueId());
+		if (data == null) return;
+
 		if (blockCollisionDmg) e.setCancelled(true);
 		if (cancelOnCollision) turnOff(entity);
-		if (collisionSpell != null) collisionSpell.subcast(entity, entity.getLocation(), 1F);
+		if (collisionSpell != null) collisionSpell.subcast(entity, entity.getLocation(), data.power(), data.args());
 	}
 
 	public Subspell getGlideSpell() {
@@ -200,7 +203,7 @@ public class WindglideSpell extends BuffSpell {
 				Vector v = eLoc.getDirection().normalize().multiply(velocity).add(new Vector(0, height, 0));
 				entity.setVelocity(v);
 
-				if (glideSpell != null) glideSpell.subcast(caster, eLoc, data.power());
+				if (glideSpell != null) glideSpell.subcast(caster, eLoc, data.power(), data.args());
 				playSpellEffects(EffectPosition.SPECIAL, eLoc, data);
 				addUseAndChargeCost(caster);
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
@@ -66,14 +66,14 @@ public class WindglideSpell extends BuffSpell {
 		super.initialize();
 
 		glideSpell = new Subspell(glideSpellName);
-		if (!glideSpell.process() || !glideSpell.isTargetedLocationSpell()) {
+		if (!glideSpell.process()) {
 			glideSpell = null;
 			if (!glideSpellName.isEmpty())
 				MagicSpells.error("WindglideSpell " + internalName + " has an invalid spell defined: " + glideSpellName);
 		}
 
 		collisionSpell = new Subspell(collisionSpellName);
-		if (!collisionSpell.process() || !collisionSpell.isTargetedLocationSpell()) {
+		if (!collisionSpell.process()) {
 			collisionSpell = null;
 			if (!collisionSpellName.isEmpty())
 				MagicSpells.error("WindglideSpell " + internalName + " has an invalid collision-spell defined: " + collisionSpellName);
@@ -133,7 +133,7 @@ public class WindglideSpell extends BuffSpell {
 		if (!isActive(entity)) return;
 		if (blockCollisionDmg) e.setCancelled(true);
 		if (cancelOnCollision) turnOff(entity);
-		if (collisionSpell != null) collisionSpell.castAtLocation(entity, entity.getLocation(), 1F);
+		if (collisionSpell != null) collisionSpell.subcast(entity, entity.getLocation(), 1F);
 	}
 
 	public Subspell getGlideSpell() {
@@ -200,7 +200,7 @@ public class WindglideSpell extends BuffSpell {
 				Vector v = eLoc.getDirection().normalize().multiply(velocity).add(new Vector(0, height, 0));
 				entity.setVelocity(v);
 
-				if (glideSpell != null) glideSpell.castAtLocation(caster, eLoc, data.power());
+				if (glideSpell != null) glideSpell.subcast(caster, eLoc, data.power());
 				playSpellEffects(EffectPosition.SPECIAL, eLoc, data);
 				addUseAndChargeCost(caster);
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -113,7 +113,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		}
 
 		endSpell = new Subspell(endSpellName);
-		if (!endSpell.process() || !endSpell.isTargetedLocationSpell()) {
+		if (!endSpell.process()) {
 			if (!endSpellName.isEmpty())
 				MagicSpells.error("BeamSpell '" + internalName + "' has an invalid spell-on-end defined!");
 
@@ -121,7 +121,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		}
 
 		travelSpell = new Subspell(travelSpellName);
-		if (!travelSpell.process() || !travelSpell.isTargetedLocationSpell()) {
+		if (!travelSpell.process()) {
 			if (!travelSpellName.isEmpty())
 				MagicSpells.error("BeamSpell '" + internalName + "' has an invalid spell-on-travel defined!");
 
@@ -129,7 +129,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			if (!groundSpellName.isEmpty())
 				MagicSpells.error("BeamSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
 
@@ -137,7 +137,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		}
 
 		entityLocationSpell = new Subspell(entityLocationSpellName);
-		if (!entityLocationSpell.process() || !entityLocationSpell.isTargetedLocationSpell()) {
+		if (!entityLocationSpell.process()) {
 			if (!entityLocationSpellName.isEmpty())
 				MagicSpells.error("BeamSpell '" + internalName + "' has an invalid spell-on-entity-location defined!");
 
@@ -296,13 +296,13 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 			//check block collision
 			if (!isTransparent(loc.getBlock())) {
 				playSpellEffects(EffectPosition.DISABLED, loc, data);
-				if (groundSpell != null) groundSpell.castAtLocation(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
 				if (stopOnHitGround) break;
 			}
 
 			playSpellEffects(EffectPosition.SPECIAL, loc, data);
 
-			if (travelSpell != null) travelSpell.castAtLocation(caster, loc, power);
+			if (travelSpell != null) travelSpell.subcast(caster, loc, power);
 
 			//check entities in the beam range
 			for (LivingEntity e : loc.getNearbyLivingEntities(hitRadius, verticalHitRadius)) {
@@ -314,12 +314,8 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 
 				LivingEntity entity = event.getTarget();
 
-				if (hitSpell != null) {
-					if (hitSpell.isTargetedEntitySpell()) hitSpell.castAtEntity(caster, entity, event.getPower());
-					else if (hitSpell.isTargetedLocationSpell()) hitSpell.castAtLocation(caster, entity.getLocation(), event.getPower());
-				}
-
-				if (entityLocationSpell != null) entityLocationSpell.castAtLocation(caster, loc, power);
+				if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower());
+				if (entityLocationSpell != null) entityLocationSpell.subcast(caster, loc, power);
 
 				playSpellEffects(EffectPosition.TARGET, entity, data);
 				playSpellEffectsTrail(caster.getLocation(), entity.getLocation(), data);
@@ -332,7 +328,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
 			playSpellEffects(EffectPosition.DELAYED, loc, data);
-			if (endSpell != null) endSpell.castAtLocation(caster, loc, power);
+			if (endSpell != null) endSpell.subcast(caster, loc, power);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -296,13 +296,13 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 			//check block collision
 			if (!isTransparent(loc.getBlock())) {
 				playSpellEffects(EffectPosition.DISABLED, loc, data);
-				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power, args);
 				if (stopOnHitGround) break;
 			}
 
 			playSpellEffects(EffectPosition.SPECIAL, loc, data);
 
-			if (travelSpell != null) travelSpell.subcast(caster, loc, power);
+			if (travelSpell != null) travelSpell.subcast(caster, loc, power, args);
 
 			//check entities in the beam range
 			for (LivingEntity e : loc.getNearbyLivingEntities(hitRadius, verticalHitRadius)) {
@@ -314,8 +314,8 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 
 				LivingEntity entity = event.getTarget();
 
-				if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower());
-				if (entityLocationSpell != null) entityLocationSpell.subcast(caster, loc, power);
+				if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower(), args);
+				if (entityLocationSpell != null) entityLocationSpell.subcast(caster, loc, power, args);
 
 				playSpellEffects(EffectPosition.TARGET, entity, data);
 				playSpellEffectsTrail(caster.getLocation(), entity.getLocation(), data);
@@ -328,7 +328,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
 			playSpellEffects(EffectPosition.DELAYED, loc, data);
-			if (endSpell != null) endSpell.subcast(caster, loc, power);
+			if (endSpell != null) endSpell.subcast(caster, loc, power, args);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
@@ -311,7 +311,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 			//check block collision
 			if (!isTransparent(loc.getBlock())) {
 				playSpellEffects(EffectPosition.DISABLED, loc, data);
-				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power, args);
 				if (stopOnHitGround) break;
 			}
 
@@ -350,7 +350,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 				LivingEntity subTarget = event.getTarget();
 				float subPower = event.getPower();
 
-				if (hitSpell != null) hitSpell.subcast(caster, subTarget, subPower);
+				if (hitSpell != null) hitSpell.subcast(caster, subTarget, subPower, args);
 
 				playSpellEffects(EffectPosition.TARGET, subTarget, data);
 				playSpellEffectsTrail(caster.getLocation(), subTarget.getLocation(), data);
@@ -363,7 +363,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
 			playSpellEffects(EffectPosition.DELAYED, loc, data);
-			if (endSpell != null) endSpell.subcast(caster, loc, power);
+			if (endSpell != null) endSpell.subcast(caster, loc, power, args);
 		}
 
 		entities.add(armorStandList);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
@@ -138,13 +138,13 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 		}
 
 		endSpell = new Subspell(endSpellName);
-		if (!endSpell.process() || !endSpell.isTargetedLocationSpell()) {
+		if (!endSpell.process()) {
 			if (!endSpellName.isEmpty()) MagicSpells.error("BlockBeamSpell '" + internalName + "' has an invalid spell-on-end defined!");
 			endSpell = null;
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			if (!groundSpellName.isEmpty()) MagicSpells.error("BlockBeamSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
 			groundSpell = null;
 		}
@@ -311,7 +311,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 			//check block collision
 			if (!isTransparent(loc.getBlock())) {
 				playSpellEffects(EffectPosition.DISABLED, loc, data);
-				if (groundSpell != null) groundSpell.castAtLocation(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
 				if (stopOnHitGround) break;
 			}
 
@@ -347,15 +347,13 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 				SpellTargetEvent event = new SpellTargetEvent(this, caster, e, power, args);
 				if (!event.callEvent()) continue;
 
-				LivingEntity entity = event.getTarget();
+				LivingEntity subTarget = event.getTarget();
+				float subPower = event.getPower();
 
-				if (hitSpell != null) {
-					if (hitSpell.isTargetedEntitySpell()) hitSpell.castAtEntity(caster, entity, event.getPower());
-					else if (hitSpell.isTargetedLocationSpell()) hitSpell.castAtLocation(caster, entity.getLocation(), event.getPower());
-				}
+				if (hitSpell != null) hitSpell.subcast(caster, subTarget, subPower);
 
-				playSpellEffects(EffectPosition.TARGET, entity, data);
-				playSpellEffectsTrail(caster.getLocation(), entity.getLocation(), data);
+				playSpellEffects(EffectPosition.TARGET, subTarget, data);
+				playSpellEffectsTrail(caster.getLocation(), subTarget.getLocation(), data);
 				immune.add(e);
 
 				if (stopOnHitEntity) break mainLoop;
@@ -365,7 +363,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
 			playSpellEffects(EffectPosition.DELAYED, loc, data);
-			if (endSpell != null) endSpell.castAtLocation(caster, loc, power);
+			if (endSpell != null) endSpell.subcast(caster, loc, power);
 		}
 
 		entities.add(armorStandList);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
@@ -44,7 +44,7 @@ public class CastAtMarkSpell extends InstantSpell {
 		markSpell = (MarkSpell) spell;
 		
 		spellToCast = new Subspell(spellToCastName);
-		if (!spellToCast.process() || !spellToCast.isTargetedLocationSpell()) {
+		if (!spellToCast.process()) {
 			MagicSpells.error("CastAtMarkSpell '" + internalName + "' has an invalid spell defined!");
 			return;
 		}
@@ -70,7 +70,7 @@ public class CastAtMarkSpell extends InstantSpell {
 				sendMessage(caster, strNoMark);
 				return PostCastAction.HANDLE_NORMALLY;
 			}
-			spellToCast.castAtLocation(caster, effectiveMark, power);
+			spellToCast.subcast(caster, effectiveMark, power);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/CastAtMarkSpell.java
@@ -70,7 +70,7 @@ public class CastAtMarkSpell extends InstantSpell {
 				sendMessage(caster, strNoMark);
 				return PostCastAction.HANDLE_NORMALLY;
 			}
-			spellToCast.subcast(caster, effectiveMark, power);
+			spellToCast.subcast(caster, effectiveMark, power, args);
 		}
 		return PostCastAction.HANDLE_NORMALLY;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
@@ -102,7 +102,7 @@ public class LeapSpell extends InstantSpell {
 		if (event.getCause() != EntityDamageEvent.DamageCause.FALL) return;
 		LivingEntity livingEntity = (LivingEntity) event.getEntity();
 		if (!jumping.remove(livingEntity.getUniqueId())) return;
-		if (landSpell != null) landSpell.cast(livingEntity, 1F);
+		if (landSpell != null) landSpell.subcast(livingEntity, 1F);
 		playSpellEffects(EffectPosition.TARGET, livingEntity.getLocation(), new SpellData(livingEntity));
 		if (cancelDamage) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
@@ -102,7 +102,7 @@ public class LeapSpell extends InstantSpell {
 		if (event.getCause() != EntityDamageEvent.DamageCause.FALL) return;
 		LivingEntity livingEntity = (LivingEntity) event.getEntity();
 		if (!jumping.remove(livingEntity.getUniqueId())) return;
-		if (landSpell != null) landSpell.subcast(livingEntity, 1F);
+		if (landSpell != null) landSpell.subcast(livingEntity, 1f, null);
 		playSpellEffects(EffectPosition.TARGET, livingEntity.getLocation(), new SpellData(livingEntity));
 		if (cancelDamage) event.setCancelled(true);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -251,7 +251,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		}
 
 		airSpell = new Subspell(airSpellName);
-		if (!airSpell.process() || !airSpell.isTargetedLocationSpell()) {
+		if (!airSpell.process()) {
 			if (!airSpellName.equals(defaultSpellName)) MagicSpells.error(prefix + " has an invalid spell-on-hit-air defined!");
 			airSpell = null;
 		}
@@ -263,13 +263,13 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		}
 
 		tickSpell = new Subspell(tickSpellName);
-		if (!tickSpell.process() || !tickSpell.isTargetedLocationSpell()) {
+		if (!tickSpell.process()) {
 			if (!tickSpellName.equals(defaultSpellName)) MagicSpells.error(prefix + " has an invalid spell-on-tick defined!");
 			tickSpell = null;
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			if (!groundSpellName.equals(defaultSpellName)) MagicSpells.error(prefix + " has an invalid spell-on-hit-ground defined!");
 			groundSpell = null;
 		}
@@ -293,7 +293,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		}
 
 		entityLocationSpell = new Subspell(entityLocationSpellName);
-		if (!entityLocationSpell.process() || !entityLocationSpell.isTargetedLocationSpell()) {
+		if (!entityLocationSpell.process()) {
 			if (!entityLocationSpellName.isEmpty()) MagicSpells.error(prefix + " has an invalid spell-on-entity-location defined!");
 			entityLocationSpell = null;
 		}
@@ -316,7 +316,7 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 
 				if (params[1] == null) continue;
 				Subspell collisionSpell = new Subspell(params[1]);
-				if (!collisionSpell.process() || !collisionSpell.isTargetedLocationSpell()) {
+				if (!collisionSpell.process()) {
 					MagicSpells.error(prefix + " has an interaction with '" + params[0] + "' and their spell on collision '" + params[1] + "' is not a valid spell!");
 					continue;
 				}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -303,7 +303,7 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 			if (!tracker.getProjectile().equals(projectile)) continue;
 
 			if (tracker.getHitSpell() != null)
-				tracker.getHitSpell().subcast(tracker.getCaster(), entity, tracker.getPower());
+				tracker.getHitSpell().subcast(tracker.getCaster(), entity, tracker.getPower(), tracker.getArgs());
 
 			playSpellEffects(EffectPosition.TARGET, entity, tracker.getSpellData());
 			event.setCancelled(true);
@@ -358,7 +358,7 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 			if (!tracker.getProjectile().equals(projectile)) continue;
 
 			if (tracker.getCaster() != null && tracker.getGroundSpell() != null) {
-				tracker.getGroundSpell().subcast(tracker.getCaster(), projectile.getLocation(), tracker.getPower());
+				tracker.getGroundSpell().subcast(tracker.getCaster(), projectile.getLocation(), tracker.getPower(), tracker.getArgs());
 			}
 			tracker.stop(false);
 			iterator.remove();

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -155,31 +155,31 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			groundSpell = null;
 			if (!groundSpellName.isEmpty()) MagicSpells.error("ProjectileSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
 		}
 
 		tickSpell = new Subspell(tickSpellName);
-		if (!tickSpell.process() || !tickSpell.isTargetedLocationSpell()) {
+		if (!tickSpell.process()) {
 			tickSpell = null;
 			if (!tickSpellName.isEmpty()) MagicSpells.error("ProjectileSpell '" + internalName + "' has an invalid spell-on-tick defined!");
 		}
 
 		durationSpell = new Subspell(durationSpellName);
-		if (!durationSpell.process() || !durationSpell.isTargetedLocationSpell()) {
+		if (!durationSpell.process()) {
 			durationSpell = null;
 			if (!durationSpellName.isEmpty()) MagicSpells.error("ProjectileSpell '" + internalName + "' has an invalid spell-after-duration defined!");
 		}
 
 		modifierSpell = new Subspell(modifierSpellName);
-		if (!modifierSpell.process() || !modifierSpell.isTargetedLocationSpell()) {
+		if (!modifierSpell.process()) {
 			if (!modifierSpellName.isEmpty()) MagicSpells.error("ProjectileSpell '" + internalName + "' has an invalid spell-on-modifier-fail defined!");
 			modifierSpell = null;
 		}
 
 		entityLocationSpell = new Subspell(entityLocationSpellName);
-		if (!entityLocationSpell.process() || !entityLocationSpell.isTargetedLocationSpell()) {
+		if (!entityLocationSpell.process()) {
 			if (!entityLocationSpellName.isEmpty()) MagicSpells.error("ProjectileSpell '" + internalName + "' has an invalid spell-on-entity-location defined!");
 			entityLocationSpell = null;
 		}
@@ -302,10 +302,8 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 			if (tracker.getProjectile() == null) continue;
 			if (!tracker.getProjectile().equals(projectile)) continue;
 
-			if (tracker.getHitSpell() != null) {
-				if (tracker.getHitSpell().isTargetedEntitySpell()) tracker.getHitSpell().castAtEntity(tracker.getCaster(), entity, tracker.getPower());
-				else if (tracker.getHitSpell().isTargetedLocationSpell()) tracker.getHitSpell().castAtLocation(tracker.getCaster(), entity.getLocation(), tracker.getPower());
-			}
+			if (tracker.getHitSpell() != null)
+				tracker.getHitSpell().subcast(tracker.getCaster(), entity, tracker.getPower());
 
 			playSpellEffects(EffectPosition.TARGET, entity, tracker.getSpellData());
 			event.setCancelled(true);
@@ -360,7 +358,7 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 			if (!tracker.getProjectile().equals(projectile)) continue;
 
 			if (tracker.getCaster() != null && tracker.getGroundSpell() != null) {
-				tracker.getGroundSpell().castAtLocation(tracker.getCaster(), projectile.getLocation(), tracker.getPower());
+				tracker.getGroundSpell().subcast(tracker.getCaster(), projectile.getLocation(), tracker.getPower());
 			}
 			tracker.stop(false);
 			iterator.remove();

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
@@ -220,7 +220,7 @@ public class RitualSpell extends InstantSpell {
 
 			if (interrupted) {
 				stop(strRitualInterrupted);
-				if (spellOnInterrupt != null && caster.isValid()) spellOnInterrupt.subcast(caster, caster.getLocation(), power);
+				if (spellOnInterrupt != null && caster.isValid()) spellOnInterrupt.subcast(caster, caster.getLocation(), power, args);
 			}
 
 			if (duration >= ritualDuration) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RitualSpell.java
@@ -220,11 +220,7 @@ public class RitualSpell extends InstantSpell {
 
 			if (interrupted) {
 				stop(strRitualInterrupted);
-				if (spellOnInterrupt != null && caster.isValid()) {
-					if (spellOnInterrupt.isTargetedLocationSpell())
-						spellOnInterrupt.castAtLocation(caster, caster.getLocation(), power);
-					else spellOnInterrupt.cast(caster, power);
-				}
+				if (spellOnInterrupt != null && caster.isValid()) spellOnInterrupt.subcast(caster, caster.getLocation(), power);
 			}
 
 			if (duration >= ritualDuration) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
@@ -172,8 +172,8 @@ public class SteedSpell extends InstantSpell {
 			});
 			entity.addPassenger(caster);
 
-			if (entity instanceof LivingEntity le) spellOnSpawn.subcast(caster, le, power);
-			else spellOnSpawn.subcast(caster, entity.getLocation(), power);
+			if (entity instanceof LivingEntity le) spellOnSpawn.subcast(caster, le, power, args);
+			else spellOnSpawn.subcast(caster, entity.getLocation(), power, args);
 
 			playSpellEffects(EffectPosition.CASTER, caster, power, args);
 			mounted.put(caster.getUniqueId(), entity.getEntityId());

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/SteedSpell.java
@@ -172,11 +172,8 @@ public class SteedSpell extends InstantSpell {
 			});
 			entity.addPassenger(caster);
 
-			if (spellOnSpawn != null && entity instanceof LivingEntity le) {
-				if (spellOnSpawn.isTargetedEntitySpell()) spellOnSpawn.castAtEntity(caster, le, power);
-				else if (spellOnSpawn.isTargetedLocationSpell()) spellOnSpawn.castAtLocation(caster, le.getLocation(), power);
-				else spellOnSpawn.cast(caster, power);
-			}
+			if (entity instanceof LivingEntity le) spellOnSpawn.subcast(caster, le, power);
+			else spellOnSpawn.subcast(caster, entity.getLocation(), power);
 
 			playSpellEffects(EffectPosition.CASTER, caster, power, args);
 			mounted.put(caster.getUniqueId(), entity.getEntityId());

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -266,7 +266,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 						if (b.getType() == Material.AIR) BlockUtils.setBlockFromFallingBlock(b, block, true);
 					}
 					if (!info.spellActivated && spellOnLand != null) {
-						spellOnLand.subcast(info.caster, block.getLocation(), info.power);
+						spellOnLand.subcast(info.caster, block.getLocation(), info.power, info.args);
 						info.spellActivated = true;
 					}
 					block.remove();
@@ -274,7 +274,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			}
 			if (ensureSpellCast && block.isDead()) {
 				if (!info.spellActivated && spellOnLand != null) {
-					spellOnLand.subcast(info.caster, block.getLocation(), info.power);
+					spellOnLand.subcast(info.caster, block.getLocation(), info.power, info.args);
 					info.spellActivated = true;
 				}
 				MagicSpells.cancelTask(task);
@@ -325,7 +325,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			event.setDamage(damage);
 
 			if (spellOnLand != null && !info.spellActivated) {
-				spellOnLand.subcast(info.caster, target.getLocation(), power);
+				spellOnLand.subcast(info.caster, target.getLocation(), power, info.args);
 				info.spellActivated = true;
 			}
 		}
@@ -340,7 +340,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				event.setCancelled(true);
 			}
 			if (spellOnLand != null && !info.spellActivated) {
-				spellOnLand.subcast(info.caster, event.getBlock().getLocation().add(0.5, 0.5, 0.5), info.power);
+				spellOnLand.subcast(info.caster, event.getBlock().getLocation().add(0.5, 0.5, 0.5), info.power, info.args);
 				info.spellActivated = true;
 			}
 		}
@@ -361,7 +361,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				event.getEntity().remove();
 			}
 			if (spellOnLand != null && !info.spellActivated) {
-				spellOnLand.subcast(info.caster, entity.getLocation(), info.power);
+				spellOnLand.subcast(info.caster, entity.getLocation(), info.power, info.args);
 				info.spellActivated = true;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -114,7 +114,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 		}
 
 		spellOnLand = new Subspell(spellOnLandName);
-		if (!spellOnLand.process() || !spellOnLand.isTargetedLocationSpell()) {
+		if (!spellOnLand.process()) {
 			if (!spellOnLandName.isEmpty()) MagicSpells.error("ThrowBlockSpell '" + internalName + "' has an invalid spell-on-land defined!");
 			spellOnLand = null;
 		}
@@ -266,8 +266,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 						if (b.getType() == Material.AIR) BlockUtils.setBlockFromFallingBlock(b, block, true);
 					}
 					if (!info.spellActivated && spellOnLand != null) {
-						if (info.caster != null) spellOnLand.castAtLocation(info.caster, block.getLocation(), info.power);
-						else spellOnLand.castAtLocation(null, block.getLocation(), info.power);
+						spellOnLand.subcast(info.caster, block.getLocation(), info.power);
 						info.spellActivated = true;
 					}
 					block.remove();
@@ -275,10 +274,9 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			}
 			if (ensureSpellCast && block.isDead()) {
 				if (!info.spellActivated && spellOnLand != null) {
-					if (info.caster != null) spellOnLand.castAtLocation(info.caster, block.getLocation(), info.power);
-					else spellOnLand.castAtLocation(null, block.getLocation(), info.power);
+					spellOnLand.subcast(info.caster, block.getLocation(), info.power);
+					info.spellActivated = true;
 				}
-				info.spellActivated = true;
 				MagicSpells.cancelTask(task);
 			}
 			if (counter++ > 1500) MagicSpells.cancelTask(task);
@@ -327,8 +325,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			event.setDamage(damage);
 
 			if (spellOnLand != null && !info.spellActivated) {
-				if (info.caster != null) spellOnLand.castAtLocation(info.caster, target.getLocation(), power);
-				else spellOnLand.castAtLocation(null, target.getLocation(), power);
+				spellOnLand.subcast(info.caster, target.getLocation(), power);
 				info.spellActivated = true;
 			}
 		}
@@ -343,8 +340,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				event.setCancelled(true);
 			}
 			if (spellOnLand != null && !info.spellActivated) {
-				if (info.caster != null) spellOnLand.castAtLocation(info.caster, event.getBlock().getLocation().add(0.5, 0.5, 0.5), info.power);
-				else spellOnLand.castAtLocation(null, event.getBlock().getLocation().add(0.5, 0.5, 0.5), info.power);
+				spellOnLand.subcast(info.caster, event.getBlock().getLocation().add(0.5, 0.5, 0.5), info.power);
 				info.spellActivated = true;
 			}
 		}
@@ -365,8 +361,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				event.getEntity().remove();
 			}
 			if (spellOnLand != null && !info.spellActivated) {
-				if (info.caster != null) spellOnLand.castAtLocation(info.caster, entity.getLocation(), info.power);
-				else spellOnLand.castAtLocation(null, entity.getLocation(), info.power);
+				spellOnLand.subcast(info.caster, entity.getLocation(), info.power);
 				info.spellActivated = true;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
@@ -253,16 +253,7 @@ public class WallSpell extends InstantSpell implements TargetedLocationSpell {
 				if (!caster.isOnline()) return;
 			}
 
-			if (spellOnBreak == null) return;
-			if (spellOnBreak.isTargetedEntityFromLocationSpell()) {
-				spellOnBreak.castAtEntityFromLocation(caster, block.getLocation().add(0.5, 0, 0.5), player, 1F);
-			} else if (spellOnBreak.isTargetedEntitySpell()) {
-				spellOnBreak.castAtEntity(caster, player, 1F);
-			} else if (spellOnBreak.isTargetedLocationSpell()) {
-				spellOnBreak.castAtLocation(caster, block.getLocation().add(0.5, 0, 0.5), 1F);
-			} else {
-				spellOnBreak.cast(caster, 1F);
-			}
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, block.getLocation().add(0.5, 0, 0.5), player, 1f, false, false);
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
@@ -253,7 +253,7 @@ public class WallSpell extends InstantSpell implements TargetedLocationSpell {
 				if (!caster.isOnline()) return;
 			}
 
-			if (spellOnBreak != null) spellOnBreak.subcast(caster, block.getLocation().add(0.5, 0, 0.5), player, 1f, false, false);
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, block.getLocation().add(0.5, 0, 0.5), player, 1f, null, false, false);
 		}
 		
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -130,7 +130,7 @@ public class BuffListener extends PassiveListener {
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
 			if (s.getSpell() instanceof BuffSpell buff && buff.isActive(entity)) continue;
-			s.cast(entity, 1F);
+			s.subcast(entity, 1F);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/BuffListener.java
@@ -130,7 +130,7 @@ public class BuffListener extends PassiveListener {
 
 		for (Subspell s : passiveSpell.getActivatedSpells()) {
 			if (s.getSpell() instanceof BuffSpell buff && buff.isActive(entity)) continue;
-			s.subcast(entity, 1F);
+			s.subcast(entity, 1F, null);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -85,11 +85,6 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 				continue;
 			}
 
-			if (!spell.isTargetedLocationSpell() && !spell.isTargetedEntityFromLocationSpell() && !spell.isTargetedEntitySpell()) {
-				MagicSpells.error("AreaEffectSpell '" + internalName + "' attempted to use non-targeted spell '" + spellName + '\'');
-				continue;
-			}
-
 			spells.add(spell);
 		}
 
@@ -269,11 +264,10 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 	}
 
 	private void castSpells(LivingEntity caster, Location location, LivingEntity target, float power) {
+		Location source = spellSourceInCenter ? location : (caster == null ? null : caster.getLocation());
 		for (Subspell spell : spells) {
-			if (spellSourceInCenter && spell.isTargetedEntityFromLocationSpell()) spell.castAtEntityFromLocation(caster, location, target, power, passTargeting);
-			else if (caster != null && spell.isTargetedEntityFromLocationSpell()) spell.castAtEntityFromLocation(caster, caster.getLocation(), target, power, passTargeting);
-			else if (spell.isTargetedEntitySpell()) spell.castAtEntity(caster, target, power, passTargeting);
-			else if (spell.isTargetedLocationSpell()) spell.castAtLocation(caster, target.getLocation(), power);
+			if (source != null) spell.subcast(caster, source, target, power, passTargeting);
+			else spell.subcast(caster, target, power, passTargeting);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -43,7 +43,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 	private boolean failIfNoTargets;
 	private boolean reverseProximity;
 	private boolean spellSourceInCenter;
-	
+
 	public AreaEffectSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
@@ -65,18 +65,18 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 		reverseProximity = getConfigBoolean("reverse-proximity", false);
 		spellSourceInCenter = getConfigBoolean("spell-source-in-center", false);
 	}
-	
+
 	@Override
 	public void initialize() {
 		super.initialize();
-		
+
 		spells = new ArrayList<>();
 
 		if (spellNames == null || spellNames.isEmpty()) {
 			MagicSpells.error("AreaEffectSpell '" + internalName + "' has no spells defined!");
 			return;
 		}
-		
+
 		for (String spellName : spellNames) {
 			Subspell spell = new Subspell(spellName);
 
@@ -116,7 +116,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 			}
 
 			if (loc == null) return noTarget(caster, args);
-			
+
 			boolean done = doAoe(caster, loc, power, args);
 			if (!done) return noTarget(caster, args);
 		}
@@ -187,7 +187,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 			target = event.getTarget();
 			power = event.getPower();
 
-			castSpells(caster, location, target, power);
+			castSpells(caster, location, target, power, args);
 
 			data = new SpellData(caster, target, power, args);
 
@@ -240,7 +240,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 			target = event.getTarget();
 			power = event.getPower();
 
-			castSpells(caster, location, target, power);
+			castSpells(caster, location, target, power, args);
 
 			data = new SpellData(caster, target, power, args);
 			playSpellEffects(EffectPosition.TARGET, target, data);
@@ -263,11 +263,11 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 		return success;
 	}
 
-	private void castSpells(LivingEntity caster, Location location, LivingEntity target, float power) {
+	private void castSpells(LivingEntity caster, Location location, LivingEntity target, float power, String[] args) {
 		Location source = spellSourceInCenter ? location : (caster == null ? null : caster.getLocation());
 		for (Subspell spell : spells) {
-			if (source != null) spell.subcast(caster, source, target, power, passTargeting);
-			else spell.subcast(caster, target, power, passTargeting);
+			if (source != null) spell.subcast(caster, source, target, power, args, passTargeting);
+			else spell.subcast(caster, target, power, args, passTargeting);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -60,7 +60,7 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 		pointBlank = getConfigBoolean("point-blank", true);
 		circleShape = getConfigBoolean("circle-shape", false);
 		useProximity = getConfigBoolean("use-proximity", false);
-		passTargeting = getConfigBoolean("pass-targeting", true);
+		passTargeting = getConfigBoolean("pass-targeting", false);
 		failIfNoTargets = getConfigBoolean("fail-if-no-targets", true);
 		reverseProximity = getConfigBoolean("reverse-proximity", false);
 		spellSourceInCenter = getConfigBoolean("spell-source-in-center", false);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
@@ -296,10 +296,7 @@ public class AreaScanSpell extends TargetedSpell implements TargetedLocationSpel
 						target = event.getTargetLocation();
 						found = true;
 
-						if (spell != null) {
-							if (spell.isTargetedLocationSpell()) spell.castAtLocation(caster, target, subPower);
-							else spell.cast(caster, subPower);
-						}
+						if (spell != null) spell.subcast(caster, target, subPower);
 
 						SpellData effectData = power == subPower ? data : new SpellData(caster, subPower, args);
 						playSpellEffects(EffectPosition.TARGET, target, effectData);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
@@ -296,7 +296,7 @@ public class AreaScanSpell extends TargetedSpell implements TargetedLocationSpel
 						target = event.getTargetLocation();
 						found = true;
 
-						if (spell != null) spell.subcast(caster, target, subPower);
+						if (spell != null) spell.subcast(caster, target, subPower, args);
 
 						SpellData effectData = power == subPower ? data : new SpellData(caster, subPower, args);
 						playSpellEffects(EffectPosition.TARGET, target, effectData);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
@@ -57,7 +57,7 @@ public class BombSpell extends TargetedSpell implements TargetedLocationSpell {
 		super.initialize();
 
 		targetSpell = new Subspell(targetSpellName);
-		if (!targetSpell.process() || !targetSpell.isTargetedLocationSpell()) {
+		if (!targetSpell.process()) {
 			if (!targetSpellName.isEmpty()) MagicSpells.error("BombSpell '" + internalName + "' has an invalid spell defined!");
 			targetSpell = null;
 		}
@@ -136,7 +136,7 @@ public class BombSpell extends TargetedSpell implements TargetedLocationSpell {
 						blocks.remove(block);
 						block.setType(Material.AIR);
 						playSpellEffects(EffectPosition.DELAYED, l, data);
-						if (targetSpell != null) targetSpell.castAtLocation(livingEntity, l, power);
+						if (targetSpell != null) targetSpell.subcast(livingEntity, l, power);
 					}
 				} else if (!material.equals(block.getType())) stop(true);
 				else playSpellEffects(EffectPosition.SPECIAL, l, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
@@ -136,7 +136,7 @@ public class BombSpell extends TargetedSpell implements TargetedLocationSpell {
 						blocks.remove(block);
 						block.setType(Material.AIR);
 						playSpellEffects(EffectPosition.DELAYED, l, data);
-						if (targetSpell != null) targetSpell.subcast(livingEntity, l, power);
+						if (targetSpell != null) targetSpell.subcast(livingEntity, l, power, args);
 					}
 				} else if (!material.equals(block.getType())) stop(true);
 				else playSpellEffects(EffectPosition.SPECIAL, l, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -218,7 +218,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 					SpellTargetEvent event = new SpellTargetEvent(CarpetSpell.this, data.caster, player, data.power, data.args);
 					if (!event.callEvent()) continue;
 
-					spellOnTouch.subcast(data.caster, event.getTarget(), event.getPower());
+					spellOnTouch.subcast(data.caster, event.getTarget(), event.getPower(), data.args);
 				}
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -72,7 +72,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 		super.initialize();
 
 		spellOnTouch = new Subspell(spellOnTouchName);
-		if (!spellOnTouch.process() || !spellOnTouch.isTargetedEntitySpell()) {
+		if (!spellOnTouch.process()) {
 			if (!spellOnTouchName.isEmpty()) MagicSpells.error("CarpetSpell '" + internalName + "' has an invalid spell-on-touch defined!");
 			spellOnTouch = null;
 		}
@@ -218,7 +218,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 					SpellTargetEvent event = new SpellTargetEvent(CarpetSpell.this, data.caster, player, data.power, data.args);
 					if (!event.callEvent()) continue;
 
-					spellOnTouch.castAtEntity(data.caster, event.getTarget(), event.getPower());
+					spellOnTouch.subcast(data.caster, event.getTarget(), event.getPower());
 				}
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -13,7 +13,6 @@ import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.TargetInfo;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
@@ -185,11 +184,8 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 	}
 
 	private void castSpellAt(LivingEntity caster, Location from, LivingEntity target, float power) {
-		if (spellToCast.isTargetedEntityFromLocationSpell() && from != null)
-			spellToCast.castAtEntityFromLocation(caster, from, target, power);
-		if (spellToCast.isTargetedEntitySpell()) spellToCast.castAtEntity(caster, target, power);
-		if (spellToCast.isTargetedLocationSpell()) spellToCast.castAtLocation(caster, target.getLocation(), power);
-		else spellToCast.cast(caster, power);
+		if (from != null) spellToCast.subcast(caster, from, target, power);
+		else spellToCast.subcast(caster, target, power);
 	}
 
 	private class ChainBouncer implements Runnable {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -173,7 +173,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				if (i == 0) from = start;
 				else from = targets.get(i - 1).getLocation();
 
-				castSpellAt(caster, from, targets.get(i), targetPowers.get(i));
+				castSpellAt(caster, from, targets.get(i), targetPowers.get(i), args);
 
 				data = new SpellData(caster, targets.get(i), targetPowers.get(i), args);
 				if (i > 0) playSpellEffectsTrail(targets.get(i - 1).getLocation(), targets.get(i).getLocation(), data);
@@ -183,9 +183,9 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		} else new ChainBouncer(caster, start, targets, targetPowers, interval, args);
 	}
 
-	private void castSpellAt(LivingEntity caster, Location from, LivingEntity target, float power) {
-		if (from != null) spellToCast.subcast(caster, from, target, power);
-		else spellToCast.subcast(caster, target, power);
+	private void castSpellAt(LivingEntity caster, Location from, LivingEntity target, float power, String[] args) {
+		if (from != null) spellToCast.subcast(caster, from, target, power, args);
+		else spellToCast.subcast(caster, target, power, args);
 	}
 
 	private class ChainBouncer implements Runnable {
@@ -219,7 +219,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 
 			SpellData data = new SpellData(caster, targets.get(current), targetPowers.get(current), args);
 
-			castSpellAt(caster, from, targets.get(current), targetPowers.get(current));
+			castSpellAt(caster, from, targets.get(current), targetPowers.get(current), args);
 			if (current > 0) {
 				playSpellEffectsTrail(targets.get(current - 1).getLocation().add(0, 0.5, 0), targets.get(current).getLocation().add(0, 0.5, 0), data);
 			} else if (current == 0 && caster != null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CollisionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CollisionSpell.java
@@ -22,12 +22,12 @@ public class CollisionSpell extends TargetedSpell implements TargetedEntitySpell
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo.noTarget()) return noTarget(caster, args);
-			LivingEntity target = targetInfo.target();
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
+			LivingEntity target = info.target();
 
 			target.setCollidable(targetBooleanState.getBooleanState(target.isCollidable()));
-			playSpellEffects(caster, target, targetInfo.power(), args);
+			playSpellEffects(caster, target, info.power(), args);
 			sendMessages(caster, target, args);
 
 			return PostCastAction.NO_MESSAGES;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
@@ -46,7 +46,7 @@ public class CreatureTargetSpell extends InstantSpell {
 
 		playSpellEffects(caster, target, power, args);
 
-		if (targetSpell != null) targetSpell.subcast(caster, caster.getLocation(), target, power);
+		if (targetSpell != null) targetSpell.subcast(caster, caster.getLocation(), target, power, args);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CreatureTargetSpell.java
@@ -46,10 +46,7 @@ public class CreatureTargetSpell extends InstantSpell {
 
 		playSpellEffects(caster, target, power, args);
 
-		if (targetSpell == null) return;
-		if (targetSpell.isTargetedEntityFromLocationSpell()) targetSpell.castAtEntityFromLocation(caster, caster.getLocation(), target, power);
-		else if (targetSpell.isTargetedLocationSpell()) targetSpell.castAtLocation(caster, target.getLocation(), power);
-		else if (targetSpell.isTargetedEntitySpell()) targetSpell.castAtEntity(caster, target, power);
+		if (targetSpell != null) targetSpell.subcast(caster, caster.getLocation(), target, power);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CrippleSpell.java
@@ -38,11 +38,11 @@ public class CrippleSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
-			TargetInfo<LivingEntity> target = getTargetedEntity(caster, power, args);
-			if (target == null) return noTarget(caster, args);
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-			cripple(caster, target.target(), target.power(), args);
-			sendMessages(caster, target.target(), args);
+			cripple(caster, info.target(), info.power(), args);
+			sendMessages(caster, info.target(), args);
 
 			return PostCastAction.NO_MESSAGES;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -263,7 +263,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 			if (current.distanceSquared(caster.getLocation().toVector()) < 4 || tick > range * 1.5) {
 				stop(true);
 				playSpellEffects(EffectPosition.DELAYED, caster, data);
-				if (spellOnAnimation != null) spellOnAnimation.subcast(caster, 1F);
+				if (spellOnAnimation != null) spellOnAnimation.subcast(caster, data.power(), data.args());
 				if (!instant) giveToCaster(caster, giveAmt);
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -263,7 +263,7 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 			if (current.distanceSquared(caster.getLocation().toVector()) < 4 || tick > range * 1.5) {
 				stop(true);
 				playSpellEffects(EffectPosition.DELAYED, caster, data);
-				if (spellOnAnimation != null) spellOnAnimation.cast(caster, 1F);
+				if (spellOnAnimation != null) spellOnAnimation.subcast(caster, 1F);
 				if (!instant) giveToCaster(caster, giveAmt);
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
@@ -197,9 +197,9 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 
 		private void cast(LivingEntity caster) {
 			lastCast = System.currentTimeMillis();
-			if (targetEntity != null) spellToCast.castAtEntity(caster, targetEntity, power);
-			else if (targetLocation != null) spellToCast.castAtLocation(caster, targetLocation, power);
-			else spellToCast.cast(caster, power);
+			if (targetEntity != null) spellToCast.subcast(caster, targetEntity, power);
+			else if (targetLocation != null) spellToCast.subcast(caster, targetLocation, power);
+			else spellToCast.subcast(caster, power);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HoldRightSpell.java
@@ -150,6 +150,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 		private final float maxDistance;
 		private final float maxDuration;
 		private final int resetTime;
+		private final String[] args;
 		private final float power;
 
 		private long start = System.currentTimeMillis();
@@ -158,6 +159,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 		private CastData(LivingEntity caster, LivingEntity target, float power, String[] args) {
 			targetEntity = target;
 			this.power = power;
+			this.args = args;
 
 			maxDistance = HoldRightSpell.this.maxDistance.get(caster, target, power, args);
 			maxDuration = HoldRightSpell.this.maxDuration.get(caster, target, power, args);
@@ -167,6 +169,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 		private CastData(LivingEntity caster, Location target, float power, String[] args) {
 			targetLocation = target;
 			this.power = power;
+			this.args = args;
 
 			maxDistance = HoldRightSpell.this.maxDistance.get(caster, null, power, args);
 			maxDuration = HoldRightSpell.this.maxDuration.get(caster, null, power, args);
@@ -175,6 +178,7 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 
 		private CastData(LivingEntity caster, float power, String[] args) {
 			this.power = power;
+			this.args = args;
 
 			maxDistance = HoldRightSpell.this.maxDistance.get(caster, null, power, args);
 			maxDuration = HoldRightSpell.this.maxDuration.get(caster, null, power, args);
@@ -197,9 +201,9 @@ public class HoldRightSpell extends TargetedSpell implements TargetedEntitySpell
 
 		private void cast(LivingEntity caster) {
 			lastCast = System.currentTimeMillis();
-			if (targetEntity != null) spellToCast.subcast(caster, targetEntity, power);
-			else if (targetLocation != null) spellToCast.subcast(caster, targetLocation, power);
-			else spellToCast.subcast(caster, power);
+			if (targetEntity != null) spellToCast.subcast(caster, targetEntity, power, args);
+			else if (targetLocation != null) spellToCast.subcast(caster, targetLocation, power, args);
+			else spellToCast.subcast(caster, power, args);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -242,6 +242,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		private Location currentLocation;
 		private Vector currentVelocity;
 		private BoundingBox hitBox;
+		private String[] args;
 		private float power;
 		private long startTime;
 		private int taskId;
@@ -280,6 +281,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			this.caster = caster;
 			this.target = target;
 			this.power = power;
+			this.args = args;
 
 			data = new SpellData(caster, target, power, args);
 
@@ -343,14 +345,14 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 				power = data.power();
 
 				if (!result.check()) {
-					if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power);
+					if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power, args);
 					if (stopOnModifierFail) stop();
 					return;
 				}
 			}
 
 			if (maxDuration > 0 && startTime + maxDuration < System.currentTimeMillis()) {
-				if (hitAirAfterDuration && durationSpell != null) durationSpell.subcast(caster, currentLocation, power);
+				if (hitAirAfterDuration && durationSpell != null) durationSpell.subcast(caster, currentLocation, power, args);
 				stop();
 				return;
 			}
@@ -396,13 +398,13 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			}
 
 			if (stopOnHitGround && !BlockUtils.isPathable(currentLocation.getBlock())) {
-				if (hitGround && groundSpell != null) groundSpell.subcast(caster, currentLocation, power);
+				if (hitGround && groundSpell != null) groundSpell.subcast(caster, currentLocation, power, args);
 				stop();
 				return;
 			}
 
 			if (hitAirDuring && airSpellInterval > 0 && counter % airSpellInterval == 0 && airSpell != null)
-				airSpell.subcast(caster, currentLocation, power);
+				airSpell.subcast(caster, currentLocation, power, args);
 
 			if (intermediateSpecialEffects > 0) playIntermediateEffectLocations(oldLocation, oldVelocity);
 
@@ -440,8 +442,8 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 				// Should we bounce the missile back?
 				if (!preImpact.getRedirected()) {
 					// Apparently didn't get redirected, carry out the plans
-					if (hitSpell != null) hitSpell.subcast(caster, target, power);
-					if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation, power);
+					if (hitSpell != null) hitSpell.subcast(caster, target, power, args);
+					if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation, power, args);
 
 					playSpellEffects(EffectPosition.TARGET, target, data);
 					if (stopOnHitTarget) stop();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -228,7 +228,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			if (monitor.target == null) continue;
 			if (!monitor.target.equals(entity)) continue;
 
-			if (hitSpell != null) hitSpell.subcast(monitor.caster, entity, monitor.power);
+			if (hitSpell != null) hitSpell.subcast(monitor.caster, entity, monitor.power, monitor.args);
 			playSpellEffects(EffectPosition.TARGET, entity, monitor.data);
 			event.setCancelled(true);
 
@@ -246,7 +246,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			if (monitor.projectile == null) continue;
 			if (!monitor.projectile.equals(projectile)) continue;
 			if (monitor.caster == null) continue;
-			if (groundSpell != null) groundSpell.subcast(monitor.caster, projectile.getLocation(), monitor.power);
+			if (groundSpell != null) groundSpell.subcast(monitor.caster, projectile.getLocation(), monitor.power, monitor.args);
 			monitor.stop();
 		}
 
@@ -376,7 +376,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 				args = data.args();
 
 				if (!result.check()) {
-					if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power);
+					if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power, args);
 
 					if (stopOnModifierFail) stop();
 					return;
@@ -384,7 +384,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			}
 
 			if (maxDuration > 0 && startTime + maxDuration < System.currentTimeMillis()) {
-				if (durationSpell != null) durationSpell.subcast(caster, currentLocation, power);
+				if (durationSpell != null) durationSpell.subcast(caster, currentLocation, power, args);
 				stop();
 				return;
 			}
@@ -406,7 +406,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			projectile.setVelocity(currentVelocity);
 			currentLocation = projectile.getLocation();
 
-			if (counter % airSpellInterval == 0 && airSpell != null) airSpell.subcast(caster, currentLocation, power);
+			if (counter % airSpellInterval == 0 && airSpell != null) airSpell.subcast(caster, currentLocation, power, args);
 
 			if (intermediateSpecialEffects > 0) playIntermediateEffectLocations(previousLocation, oldVelocity);
 
@@ -423,7 +423,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 				float subPower = targetEvent.getPower();
 
 				playSpellEffects(EffectPosition.TARGET, subTarget, new SpellData(caster, subTarget, subPower, args));
-				if (hitSpell != null) hitSpell.subcast(caster, subTarget, subPower);
+				if (hitSpell != null) hitSpell.subcast(caster, subTarget, subPower, args);
 				stop();
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -101,7 +101,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		targeted = getConfigBoolean("targeted", true);
 		pointBlank = getConfigBoolean("point-blank", false);
 		stopOnFail = getConfigBoolean("stop-on-fail", false);
-		passTargeting = getConfigBoolean("pass-targeting", true);
+		passTargeting = getConfigBoolean("pass-targeting", false);
 		cancelOnDeath = getConfigBoolean("cancel-on-death", false);
 		stopOnSuccess = getConfigBoolean("stop-on-success", false);
 		requireEntityTarget = getConfigBoolean("require-entity-target", false);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -461,26 +461,9 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private boolean cast(Subspell spell) {
 			boolean success;
 
-			if (targetEntity != null) {
-				if (spell.isTargetedEntitySpell())
-					success = spell.castAtEntity(caster, targetEntity, data.power(), passTargeting);
-				else if (spell.isTargetedLocationSpell())
-					success = spell.castAtLocation(caster, targetEntity.getLocation(), data.power());
-				else {
-					PostCastAction action = spell.cast(caster, data.power());
-					success = action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
-				}
-			} else if (targetLocation != null) {
-				if (spell.isTargetedLocationSpell())
-					success = spell.castAtLocation(caster, targetLocation, data.power());
-				else {
-					PostCastAction action = spell.cast(caster, data.power());
-					success = action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
-				}
-			} else {
-				PostCastAction action = spell.cast(caster, data.power());
-				success = action == PostCastAction.HANDLE_NORMALLY || action == PostCastAction.NO_MESSAGES;
-			}
+			if (targetEntity != null) success = spell.subcast(caster, targetEntity, data.power(), passTargeting);
+			else if (targetLocation != null) success = spell.subcast(caster, targetLocation, data.power());
+			else success = spell.subcast(caster, data.power());
 
 			if (stopOnSuccess && success || stopOnFail && !success) {
 				cancel();
@@ -526,11 +509,9 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 
 			if (spellOnEnd != null) {
-				if (spellOnEnd.isTargetedEntitySpell() && targetEntity != null)
-					spellOnEnd.castAtEntity(caster, targetEntity, data.power(), passTargeting);
-				else if (spellOnEnd.isTargetedLocationSpell() && (targetEntity != null || targetLocation != null))
-					spellOnEnd.castAtLocation(caster, targetEntity != null ? targetEntity.getLocation() : targetLocation, data.power());
-				else spellOnEnd.cast(caster, data.power());
+				if (targetEntity != null) spellOnEnd.subcast(caster, targetEntity, data.power(), passTargeting);
+				else if (targetLocation != null) spellOnEnd.subcast(caster, targetLocation, data.power());
+				else if (caster != null) spellOnEnd.subcast(caster, data.power());
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -101,7 +101,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		targeted = getConfigBoolean("targeted", true);
 		pointBlank = getConfigBoolean("point-blank", false);
 		stopOnFail = getConfigBoolean("stop-on-fail", false);
-		passTargeting = getConfigBoolean("pass-targeting", false);
+		passTargeting = getConfigBoolean("pass-targeting", true);
 		cancelOnDeath = getConfigBoolean("cancel-on-death", false);
 		stopOnSuccess = getConfigBoolean("stop-on-success", false);
 		requireEntityTarget = getConfigBoolean("require-entity-target", false);
@@ -461,9 +461,9 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private boolean cast(Subspell spell) {
 			boolean success;
 
-			if (targetEntity != null) success = spell.subcast(caster, targetEntity, data.power(), passTargeting);
-			else if (targetLocation != null) success = spell.subcast(caster, targetLocation, data.power());
-			else success = spell.subcast(caster, data.power());
+			if (targetEntity != null) success = spell.subcast(caster, targetEntity, data.power(), data.args(), passTargeting);
+			else if (targetLocation != null) success = spell.subcast(caster, targetLocation, data.power(), data.args());
+			else success = spell.subcast(caster, data.power(), data.args());
 
 			if (stopOnSuccess && success || stopOnFail && !success) {
 				cancel();
@@ -509,9 +509,9 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			}
 
 			if (spellOnEnd != null) {
-				if (targetEntity != null) spellOnEnd.subcast(caster, targetEntity, data.power(), passTargeting);
-				else if (targetLocation != null) spellOnEnd.subcast(caster, targetLocation, data.power());
-				else if (caster != null) spellOnEnd.subcast(caster, data.power());
+				if (targetEntity != null) spellOnEnd.subcast(caster, targetEntity, data.power(), data.args(), passTargeting);
+				else if (targetLocation != null) spellOnEnd.subcast(caster, targetLocation, data.power(), data.args());
+				else if (caster != null) spellOnEnd.subcast(caster, data.power(), data.args());
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
@@ -79,19 +79,19 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		super.initialize();
 		
 		locationSpell = new Subspell(locationSpellName);
-		if (!locationSpell.process() || !locationSpell.isTargetedLocationSpell()) {
+		if (!locationSpell.process()) {
 			if (!locationSpellName.isEmpty()) MagicSpells.error("NovaSpell " + internalName + " has an invalid spell defined!");
 			locationSpell = null;
 		}
 		
 		spellOnWaveRemove = new Subspell(spellOnWaveRemoveName);
-		if (!spellOnWaveRemove.process() || !spellOnWaveRemove.isTargetedLocationSpell()) {
+		if (!spellOnWaveRemove.process()) {
 			if (!spellOnWaveRemoveName.isEmpty()) MagicSpells.error("NovaSpell " + internalName + " has an invalid spell-on-wave-remove defined!");
 			spellOnWaveRemove = null;
 		}
 		
 		spellOnEnd = new Subspell(spellOnEndName);
-		if (!spellOnEnd.process() || !spellOnEnd.isTargetedLocationSpell()) {
+		if (!spellOnEnd.process()) {
 			if (!spellOnEndName.isEmpty()) MagicSpells.error("NovaSpell " + internalName + " has an invalid spell-on-end defined!");
 			spellOnEnd = null;
 		}
@@ -219,7 +219,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 			if (removePreviousBlocks) {
 				for (Block b : blocks) {
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-					if (spellOnWaveRemove != null) spellOnWaveRemove.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 				}
 				blocks.clear();
 			}
@@ -255,7 +255,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 					if (blocks.contains(b)) continue;
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 					blocks.add(b);
-					if (locationSpell != null) locationSpell.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 				}
 			}
 			
@@ -264,7 +264,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private void stop() {
 			for (Block b : blocks) {
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-				if (spellOnEnd != null) spellOnEnd.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 			}
 			blocks.clear();
 			MagicSpells.cancelTask(taskId);
@@ -317,7 +317,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 			if (removePreviousBlocks) {
 				for (Block b : blocks) {
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-					if (spellOnWaveRemove != null) spellOnWaveRemove.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 				}
 				blocks.clear();
 			}
@@ -351,7 +351,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 				if (blocks.contains(b)) return;
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 				blocks.add(b);
-				if (locationSpell != null) locationSpell.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 			}
 			
 			// Generate the circle
@@ -379,7 +379,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 				if (blocks.contains(b)) continue;
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 				blocks.add(b);
-				if (locationSpell != null) locationSpell.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 			}
 			
 		}
@@ -387,7 +387,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private void stop() {
 			for (Block b : blocks) {
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-				if (spellOnEnd != null) spellOnEnd.castAtLocation(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
 			}
 			blocks.clear();
 			MagicSpells.cancelTask(taskId);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
@@ -171,8 +171,8 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		if (expandingRadiusChange < 1) expandingRadiusChange = 1;
 
 		// Start tracker
-		if (!circleShape) new NovaTrackerSquare(nearbyPlayers, startLoc.getBlock(), blockData, caster, radius, startRadius, heightPerTick, novaTickInterval, expandingRadiusChange, power);
-		else new NovaTrackerCircle(nearbyPlayers, startLoc.getBlock(), blockData, caster, radius, startRadius, heightPerTick, novaTickInterval, expandingRadiusChange, power);
+		if (!circleShape) new NovaTrackerSquare(nearbyPlayers, startLoc.getBlock(), blockData, caster, radius, startRadius, heightPerTick, novaTickInterval, expandingRadiusChange, power, args);
+		else new NovaTrackerCircle(nearbyPlayers, startLoc.getBlock(), blockData, caster, radius, startRadius, heightPerTick, novaTickInterval, expandingRadiusChange, power, args);
 	}
 	
 	private class NovaTrackerSquare implements Runnable {
@@ -183,6 +183,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private LivingEntity caster;
 		private Block center;
 		private float power;
+		private String[] args;
 		private int radiusNova;
 		private int startRadius;
 		private int heightPerTick;
@@ -191,12 +192,13 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private int count;
 		private int temp;
 
-		private NovaTrackerSquare(Collection<Player> nearby, Block center, BlockData blockData, LivingEntity caster, int radius, int startRadius, int heightPerTick, int tickInterval, int activeRadiusChange, float power) {
+		private NovaTrackerSquare(Collection<Player> nearby, Block center, BlockData blockData, LivingEntity caster, int radius, int startRadius, int heightPerTick, int tickInterval, int activeRadiusChange, float power, String[] args) {
 			this.nearby = nearby;
 			this.center = center;
 			this.blockData = blockData;
 			this.caster = caster;
 			this.power = power;
+			this.args = args;
 			this.radiusNova = radius;
 			this.blocks = new HashSet<>();
 			this.radiusChange = activeRadiusChange;
@@ -219,7 +221,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 			if (removePreviousBlocks) {
 				for (Block b : blocks) {
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 				}
 				blocks.clear();
 			}
@@ -255,7 +257,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 					if (blocks.contains(b)) continue;
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 					blocks.add(b);
-					if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 				}
 			}
 			
@@ -264,7 +266,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private void stop() {
 			for (Block b : blocks) {
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 			}
 			blocks.clear();
 			MagicSpells.cancelTask(taskId);
@@ -280,6 +282,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private LivingEntity caster;
 		private Block center;
 		private float power;
+		private String[] args;
 		private int radiusNova;
 		private int startRadius;
 		private int heightPerTick;
@@ -288,12 +291,13 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private int count;
 		private int temp;
 
-		private NovaTrackerCircle(Collection<Player> nearby, Block center, BlockData blockData, LivingEntity caster, int radius, int startRadius, int heightPerTick, int tickInterval, int activeRadiusChange, float power) {
+		private NovaTrackerCircle(Collection<Player> nearby, Block center, BlockData blockData, LivingEntity caster, int radius, int startRadius, int heightPerTick, int tickInterval, int activeRadiusChange, float power, String[] args) {
 			this.nearby = nearby;
 			this.center = center;
 			this.blockData = blockData;
 			this.caster = caster;
 			this.power = power;
+			this.args = args;
 			this.radiusNova = radius;
 			this.blocks = new HashSet<>();
 			this.startRadius = startRadius;
@@ -317,7 +321,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 			if (removePreviousBlocks) {
 				for (Block b : blocks) {
 					for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+					if (spellOnWaveRemove != null) spellOnWaveRemove.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 				}
 				blocks.clear();
 			}
@@ -351,7 +355,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 				if (blocks.contains(b)) return;
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 				blocks.add(b);
-				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 			}
 			
 			// Generate the circle
@@ -379,7 +383,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 				if (blocks.contains(b)) continue;
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), blockData);
 				blocks.add(b);
-				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (locationSpell != null) locationSpell.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 			}
 			
 		}
@@ -387,7 +391,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 		private void stop() {
 			for (Block b : blocks) {
 				for (Player p : nearby) p.sendBlockChange(b.getLocation(), b.getBlockData());
-				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power);
+				if (spellOnEnd != null) spellOnEnd.subcast(caster, b.getLocation().add(0.5, 0, 0.5),  power, args);
 			}
 			blocks.clear();
 			MagicSpells.cancelTask(taskId);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OffsetLocationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OffsetLocationSpell.java
@@ -34,7 +34,7 @@ public class OffsetLocationSpell extends TargetedSpell implements TargetedLocati
 		super.initialize();
 
 		spellToCast = new Subspell(spellToCastName);
-		if (!spellToCast.process() || !spellToCast.isTargetedLocationSpell()) {
+		if (!spellToCast.process()) {
 			MagicSpells.error("OffsetLocationSpell '" + internalName + "' has an invalid spell defined!");
 			spellToCast = null;
 		}
@@ -52,7 +52,7 @@ public class OffsetLocationSpell extends TargetedSpell implements TargetedLocati
 
 			Location loc = Util.applyOffsets(baseTargetLocation.clone(), relativeOffset, absoluteOffset);
 
-			if (spellToCast != null) spellToCast.castAtLocation(caster, loc, power);
+			if (spellToCast != null) spellToCast.subcast(caster, loc, power);
 			playSpellEffects(caster, loc, power, args);
 
 			if (!info.empty()) {
@@ -66,7 +66,7 @@ public class OffsetLocationSpell extends TargetedSpell implements TargetedLocati
 
 	@Override
 	public boolean castAtLocation(LivingEntity caster, Location target, float power, String[] args) {
-		if (spellToCast != null) spellToCast.castAtLocation(caster, Util.applyOffsets(target.clone(), relativeOffset, absoluteOffset), power);
+		if (spellToCast != null) spellToCast.subcast(caster, Util.applyOffsets(target.clone(), relativeOffset, absoluteOffset), power);
 		playSpellEffects(caster, target, power, args);
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OffsetLocationSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OffsetLocationSpell.java
@@ -52,7 +52,7 @@ public class OffsetLocationSpell extends TargetedSpell implements TargetedLocati
 
 			Location loc = Util.applyOffsets(baseTargetLocation.clone(), relativeOffset, absoluteOffset);
 
-			if (spellToCast != null) spellToCast.subcast(caster, loc, power);
+			if (spellToCast != null) spellToCast.subcast(caster, loc, power, args);
 			playSpellEffects(caster, loc, power, args);
 
 			if (!info.empty()) {
@@ -66,7 +66,7 @@ public class OffsetLocationSpell extends TargetedSpell implements TargetedLocati
 
 	@Override
 	public boolean castAtLocation(LivingEntity caster, Location target, float power, String[] args) {
-		if (spellToCast != null) spellToCast.subcast(caster, Util.applyOffsets(target.clone(), relativeOffset, absoluteOffset), power);
+		if (spellToCast != null) spellToCast.subcast(caster, Util.applyOffsets(target.clone(), relativeOffset, absoluteOffset), power, args);
 		playSpellEffects(caster, target, power, args);
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -335,7 +335,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			Location loc = getLocation();
 
 			if (!isTransparent(loc.getBlock())) {
-				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power, args);
 				if (stopOnHitGround) {
 					stop(true);
 					return;
@@ -374,7 +374,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				}
 			}
 
-			if (orbitSpell != null) orbitSpell.subcast(caster, loc, power);
+			if (orbitSpell != null) orbitSpell.subcast(caster, loc, power, args);
 
 			box.setCenter(loc);
 
@@ -390,7 +390,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				if (event.isCancelled()) continue;
 
 				immune.add(event.getTarget());
-				if (entitySpell != null) entitySpell.subcast(event.getCaster(), event.getTarget(), event.getPower());
+				if (entitySpell != null) entitySpell.subcast(event.getCaster(), event.getTarget(), event.getPower(), args);
 
 				SpellData data = new SpellData(caster, event.getTarget(), event.getPower(), args);
 				playSpellEffects(EffectPosition.TARGET, event.getTarget(), data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -104,21 +104,21 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		super.initialize();
 
 		orbitSpell = new Subspell(orbitSpellName);
-		if (!orbitSpell.process() || !orbitSpell.isTargetedLocationSpell()) {
+		if (!orbitSpell.process()) {
 			orbitSpell = null;
 			if (!orbitSpellName.isEmpty())
 				MagicSpells.error("OrbitSpell '" + internalName + "' has an invalid spell defined!");
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			groundSpell = null;
 			if (!groundSpellName.isEmpty())
 				MagicSpells.error("OrbitSpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
 		}
 
 		entitySpell = new Subspell(entitySpellName);
-		if (!entitySpell.process() || !entitySpell.isTargetedEntitySpell()) {
+		if (!entitySpell.process()) {
 			entitySpell = null;
 			if (!entitySpellName.isEmpty())
 				MagicSpells.error("OrbitSpell '" + internalName + "' has an invalid spell-on-hit-entity defined!");
@@ -335,7 +335,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			Location loc = getLocation();
 
 			if (!isTransparent(loc.getBlock())) {
-				if (groundSpell != null) groundSpell.castAtLocation(caster, loc, power);
+				if (groundSpell != null) groundSpell.subcast(caster, loc, power);
 				if (stopOnHitGround) {
 					stop(true);
 					return;
@@ -374,7 +374,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				}
 			}
 
-			if (orbitSpell != null) orbitSpell.castAtLocation(caster, loc, power);
+			if (orbitSpell != null) orbitSpell.subcast(caster, loc, power);
 
 			box.setCenter(loc);
 
@@ -390,7 +390,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				if (event.isCancelled()) continue;
 
 				immune.add(event.getTarget());
-				if (entitySpell != null) entitySpell.castAtEntity(event.getCaster(), event.getTarget(), event.getPower());
+				if (entitySpell != null) entitySpell.subcast(event.getCaster(), event.getTarget(), event.getPower());
 
 				SpellData data = new SpellData(caster, event.getTarget(), event.getPower(), args);
 				playSpellEffects(EffectPosition.TARGET, event.getTarget(), data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
@@ -299,7 +299,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		maxDistanceSquared *= maxDistanceSquared;
 
 		Location currentLoc;
-		while(iterator.hasNext()) {
+		while (iterator.hasNext()) {
 			ParticleProjectileTracker tracker = iterator.next();
 			if (tracker == null || tracker.isStopped()) continue;
 			currentLoc = tracker.getCurrentLocation();
@@ -323,7 +323,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 				if (AccurateMath.abs(dir.angle(facing)) > cone) continue;
 			}
 
-			if (projectileSpell != null) projectileSpell.subcast(caster, currentLoc, 1F);
+			if (projectileSpell != null) projectileSpell.subcast(caster, currentLoc, power, args);
 
 			if (stop.get(data)) {
 				playSpellEffects(EffectPosition.TARGET, currentLoc, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
@@ -186,13 +186,13 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		super.initialize();
 
 		projectileSpell = new Subspell(projectileSpellName);
-		if (!projectileSpell.process() || !projectileSpell.isTargetedLocationSpell()) {
+		if (!projectileSpell.process()) {
 			if (!projectileSpellName.isEmpty()) MagicSpells.error("ProjectileModifySpell '" + internalName + "' has an invalid spell defined!");
 			projectileSpell = null;
 		}
 
 		airSpell = new Subspell(airSpellName);
-		if (!airSpell.process() || !airSpell.isTargetedLocationSpell()) {
+		if (!airSpell.process()) {
 			if (!airSpellName.isEmpty()) MagicSpells.error("ProjectileModifySpell '" + internalName + "' has an invalid spell-on-hit-air defined!");
 			airSpell = null;
 		}
@@ -204,13 +204,13 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		}
 
 		tickSpell = new Subspell(tickSpellName);
-		if (!tickSpell.process() || !tickSpell.isTargetedLocationSpell()) {
+		if (!tickSpell.process()) {
 			if (!tickSpellName.isEmpty()) MagicSpells.error("ProjectileModifySpell '" + internalName + "' has an invalid spell-on-tick defined!");
 			tickSpell = null;
 		}
 
 		groundSpell = new Subspell(groundSpellName);
-		if (!groundSpell.process() || !groundSpell.isTargetedLocationSpell()) {
+		if (!groundSpell.process()) {
 			if (!groundSpellName.isEmpty()) MagicSpells.error("ProjectileModifySpell '" + internalName + "' has an invalid spell-on-hit-ground defined!");
 			groundSpell = null;
 		}
@@ -234,7 +234,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		}
 
 		entityLocationSpell = new Subspell(entityLocationSpellName);
-		if (!entityLocationSpell.process() || !entityLocationSpell.isTargetedLocationSpell()) {
+		if (!entityLocationSpell.process()) {
 			if (!entityLocationSpellName.isEmpty()) MagicSpells.error("ProjectileModifySpell '" + internalName + "' has an invalid spell-on-entity-location defined!");
 			entityLocationSpell = null;
 		}
@@ -323,7 +323,7 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 				if (AccurateMath.abs(dir.angle(facing)) > cone) continue;
 			}
 
-			if (projectileSpell != null) projectileSpell.castAtLocation(caster, currentLoc, 1F);
+			if (projectileSpell != null) projectileSpell.subcast(caster, currentLoc, 1F);
 
 			if (stop.get(data)) {
 				playSpellEffects(EffectPosition.TARGET, currentLoc, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -97,7 +97,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		if (spellNames != null && !spellNames.isEmpty()) {
 			for (String spellName : spellNames) {
 				Subspell spell = new Subspell(spellName);
-				if (!spell.process() || !spell.isTargetedLocationSpell()) continue;
+				if (!spell.process()) continue;
 				spells.add(spell);
 			}
 		}
@@ -319,7 +319,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		private boolean activate() {
 			boolean activated = false;
 			for (Subspell spell : spells) {
-				activated = spell.castAtLocation(caster, location, power) || activated;
+				activated = spell.subcast(caster, location, power) || activated;
 			}
 			playSpellEffects(EffectPosition.DELAYED, location, data);
 			if (totalPulses > 0 && (activated || !onlyCountOnSuccess)) {
@@ -336,10 +336,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			if (!block.getWorld().isChunkLoaded(block.getX() >> 4, block.getZ() >> 4)) block.getChunk().load();
 			block.setType(Material.AIR);
 			playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
-			if (spellOnBreak != null) {
-				if (spellOnBreak.isTargetedLocationSpell()) spellOnBreak.castAtLocation(caster, location, power);
-				else spellOnBreak.cast(caster, power);
-			}
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, location, power);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -279,6 +279,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		private final Block block;
 		private final Location location;
 		private final SpellData data;
+		private final String[] args;
 		private final float power;
 		private int pulseCount;
 
@@ -290,6 +291,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			this.block = block;
 			this.location = block.getLocation().add(0.5, 0.5, 0.5).setDirection(from.getDirection());
 			this.power = power;
+			this.args = args;
 			this.pulseCount = 0;
 
 			data = new SpellData(caster, power, args);
@@ -319,7 +321,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		private boolean activate() {
 			boolean activated = false;
 			for (Subspell spell : spells) {
-				activated = spell.subcast(caster, location, power) || activated;
+				activated = spell.subcast(caster, location, power, args) || activated;
 			}
 			playSpellEffects(EffectPosition.DELAYED, location, data);
 			if (totalPulses > 0 && (activated || !onlyCountOnSuccess)) {
@@ -336,7 +338,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			if (!block.getWorld().isChunkLoaded(block.getX() >> 4, block.getZ() >> 4)) block.getChunk().load();
 			block.setType(Material.AIR);
 			playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
-			if (spellOnBreak != null) spellOnBreak.subcast(caster, location, power);
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, location, power, args);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -186,7 +186,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		private void rewind() {
 			MagicSpells.cancelTask(taskId);
 			entities.remove(entity);
-			if (rewindSpell != null) rewindSpell.cast(caster, power);
+			if (rewindSpell != null) rewindSpell.subcast(caster, power);
 			new ForceRewinder(caster, entity, locations, startHealth, startMana, power, args);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -186,7 +186,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		private void rewind() {
 			MagicSpells.cancelTask(taskId);
 			entities.remove(entity);
-			if (rewindSpell != null) rewindSpell.subcast(caster, power);
+			if (rewindSpell != null) rewindSpell.subcast(caster, power, args);
 			new ForceRewinder(caster, entity, locations, startHealth, startMana, power, args);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -169,7 +169,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (filter.check(spell)) return;
 			event.setCancelled(true);
 			Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, () -> {
-				if (preventCastSpell != null) preventCastSpell.subcast(event.getCaster(), 1);
+				if (preventCastSpell != null) preventCastSpell.subcast(event.getCaster(), 1, null);
 				if (spell.isHelperSpell() && !notifyHelperSpells) return;
 				if (spell instanceof PassiveSpell && !notifyPassiveSpells) return;
 				sendMessage(strSilenced, event.getCaster(), event.getSpellArgs());
@@ -184,7 +184,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 		public void onChat(AsyncChatEvent event) {
 			if (!silenced.containsKey(event.getPlayer().getUniqueId())) return;
 			event.setCancelled(true);
-			if (preventChatSpell != null) preventChatSpell.subcast(event.getPlayer(), 1);
+			if (preventChatSpell != null) preventChatSpell.subcast(event.getPlayer(), 1, null);
 			sendMessage(strSilenced, event.getPlayer(), MagicSpells.NULL_ARGS);
 		}
 
@@ -196,7 +196,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 		public void onCommand(PlayerCommandPreprocessEvent event) {
 			if (!silenced.containsKey(event.getPlayer().getUniqueId())) return;
 			event.setCancelled(true);
-			if (preventCommandSpell != null) preventCommandSpell.subcast(event.getPlayer(), 1);
+			if (preventCommandSpell != null) preventCommandSpell.subcast(event.getPlayer(), 1, null);
 			sendMessage(strSilenced, event.getPlayer(), MagicSpells.NULL_ARGS);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -169,7 +169,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 			if (filter.check(spell)) return;
 			event.setCancelled(true);
 			Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, () -> {
-				if (preventCastSpell != null) preventCastSpell.cast(event.getCaster(), 1);
+				if (preventCastSpell != null) preventCastSpell.subcast(event.getCaster(), 1);
 				if (spell.isHelperSpell() && !notifyHelperSpells) return;
 				if (spell instanceof PassiveSpell && !notifyPassiveSpells) return;
 				sendMessage(strSilenced, event.getCaster(), event.getSpellArgs());
@@ -184,7 +184,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 		public void onChat(AsyncChatEvent event) {
 			if (!silenced.containsKey(event.getPlayer().getUniqueId())) return;
 			event.setCancelled(true);
-			if (preventChatSpell != null) preventChatSpell.cast(event.getPlayer(), 1);
+			if (preventChatSpell != null) preventChatSpell.subcast(event.getPlayer(), 1);
 			sendMessage(strSilenced, event.getPlayer(), MagicSpells.NULL_ARGS);
 		}
 
@@ -196,7 +196,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 		public void onCommand(PlayerCommandPreprocessEvent event) {
 			if (!silenced.containsKey(event.getPlayer().getUniqueId())) return;
 			event.setCancelled(true);
-			if (preventCommandSpell != null) preventCommandSpell.cast(event.getPlayer(), 1);
+			if (preventCommandSpell != null) preventCommandSpell.subcast(event.getPlayer(), 1);
 			sendMessage(strSilenced, event.getPlayer(), MagicSpells.NULL_ARGS);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SkinSpell.java
@@ -26,7 +26,7 @@ public class SkinSpell extends TargetedSpell implements TargetedEntitySpell {
 	public PostCastAction castSpell(LivingEntity caster, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL) {
 			TargetInfo<Player> info = getTargetedPlayer(caster, power, args);
-			if (info.noTarget()) return noTarget(caster, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
 			Util.setSkin(info.target(), texture, signature);
 			playSpellEffects(caster, info.target(), info.power(), args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -421,8 +421,8 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		}
 
 		if (spellOnSpawn != null) {
-			if (entity instanceof LivingEntity livingEntity) spellOnSpawn.subcast(caster, livingEntity, power);
-			else spellOnSpawn.subcast(caster, entity.getLocation(), power);
+			if (entity instanceof LivingEntity livingEntity) spellOnSpawn.subcast(caster, livingEntity, power, args);
+			else spellOnSpawn.subcast(caster, entity.getLocation(), power, args);
 		}
 
 		int targetInterval = this.targetInterval.get(data);
@@ -535,7 +535,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			if (damager != monster) return;
 
 			if (event.getEntity() instanceof LivingEntity damaged) {
-				attackSpell.subcast(caster, monster.getLocation(), damaged, power);
+				attackSpell.subcast(caster, monster.getLocation(), damaged, power, args);
 				event.setCancelled(cancelAttack);
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -421,12 +421,8 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		}
 
 		if (spellOnSpawn != null) {
-			if (spellOnSpawn.isTargetedEntitySpell() && entity instanceof LivingEntity livingEntity)
-				spellOnSpawn.castAtEntity(caster, livingEntity, power);
-			else if (spellOnSpawn.isTargetedLocationSpell())
-				spellOnSpawn.castAtLocation(caster, entity.getLocation(), power);
-			else
-				spellOnSpawn.cast(caster, power);
+			if (entity instanceof LivingEntity livingEntity) spellOnSpawn.subcast(caster, livingEntity, power);
+			else spellOnSpawn.subcast(caster, entity.getLocation(), power);
 		}
 
 		int targetInterval = this.targetInterval.get(data);
@@ -439,8 +435,8 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			if (duration > 0) MagicSpells.scheduleDelayedTask(() -> HandlerList.unregisterAll(monitor), duration);
 		}
 
-		if (caster != null) playSpellEffects(caster, source, entity, power, args);
-		else playSpellEffects(source, entity, power, args);
+		if (caster != null) playSpellEffects(caster, source, entity, data);
+		else playSpellEffects(source, entity, data);
 
 		return true;
 	}
@@ -539,15 +535,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			if (damager != monster) return;
 
 			if (event.getEntity() instanceof LivingEntity damaged) {
-				if (attackSpell.isTargetedEntityFromLocationSpell())
-					attackSpell.castAtEntityFromLocation(caster, monster.getLocation(), damaged, power);
-				else if (attackSpell.isTargetedEntitySpell())
-					attackSpell.castAtEntity(caster, damaged, power);
-				else if (attackSpell.isTargetedLocationSpell())
-					attackSpell.castAtLocation(caster, damaged.getLocation(), power);
-				else
-					attackSpell.cast(caster, power);
-
+				attackSpell.subcast(caster, monster.getLocation(), damaged, power);
 				event.setCancelled(cancelAttack);
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
@@ -145,7 +145,7 @@ public class SpawnTntSpell extends TargetedSpell implements TargetedLocationSpel
 		LivingEntity caster = data.caster();
 		if (caster == null || !caster.isValid()) return;
 
-		spellToCast.subcast(caster, event.getEntity().getLocation(), data.power());
+		spellToCast.subcast(caster, event.getEntity().getLocation(), data.power(), data.args());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
@@ -60,7 +60,7 @@ public class SpawnTntSpell extends TargetedSpell implements TargetedLocationSpel
 		super.initialize();
 
 		spellToCast = new Subspell(spellToCastName);
-		if (!spellToCast.process() || !spellToCast.isTargetedLocationSpell()) {
+		if (!spellToCast.process()) {
 			if (!spellToCastName.isEmpty())
 				MagicSpells.error("SpawnTntSpell '" + internalName + "' has an invalid spell defined!");
 			spellToCast = null;
@@ -145,7 +145,7 @@ public class SpawnTntSpell extends TargetedSpell implements TargetedLocationSpel
 		LivingEntity caster = data.caster();
 		if (caster == null || !caster.isValid()) return;
 
-		spellToCast.castAtLocation(caster, event.getEntity().getLocation(), data.power());
+		spellToCast.subcast(caster, event.getEntity().getLocation(), data.power());
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -162,14 +162,14 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		if (spellNames != null && !spellNames.isEmpty()) {
 			for (String spellName : spellNames) {
 				Subspell spell = new Subspell(spellName);
-				if (!spell.process() || !spell.isTargetedLocationSpell()) continue;
+				if (!spell.process()) continue;
 				spells.add(spell);
 			}
 		}
 
 		if (!spellNameOnBreak.isEmpty()) {
 			spellOnBreak = new Subspell(spellNameOnBreak);
-			if (!spellOnBreak.process() || !spellOnBreak.isTargetedLocationSpell()) {
+			if (!spellOnBreak.process()) {
 				MagicSpells.error("TotemSpell '" + internalName + "' has an invalid spell-on-break defined");
 				spellOnBreak = null;
 			}
@@ -381,11 +381,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			});
 			totemLocation = armorStand.getLocation();
 
-			if (spellOnSpawn != null) {
-				if (spellOnSpawn.isTargetedEntitySpell()) spellOnSpawn.castAtEntity(caster, armorStand, power);
-				else if (spellOnSpawn.isTargetedLocationSpell()) spellOnSpawn.castAtLocation(caster, armorStand.getLocation(), power);
-				else spellOnSpawn.cast(caster, power);
-			}
+			if (spellOnSpawn != null) spellOnSpawn.subcast(caster, armorStand, power);
 		}
 
 		private boolean pulse() {
@@ -408,7 +404,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		private boolean activate() {
 			boolean activated = false;
 			for (Subspell spell : spells) {
-				activated = spell.castAtLocation(caster, totemLocation, power) || activated;
+				activated = spell.subcast(caster, totemLocation, power) || activated;
 			}
 
 			playSpellEffects(EffectPosition.SPECIAL, totemLocation, data);
@@ -426,7 +422,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			if (!totemLocation.getChunk().isLoaded()) totemLocation.getChunk().load();
 			armorStand.remove();
 			playSpellEffects(EffectPosition.DISABLED, totemLocation, data);
-			if (spellOnBreak != null) spellOnBreak.castAtLocation(caster, totemLocation, power);
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, totemLocation, power);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -342,12 +342,14 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		private final double maxDistanceSq;
 		private final int totalPulses;
 		private final SpellData data;
+		private final String[] args;
 		private final float power;
 		private int pulseCount;
 
 		private Totem(LivingEntity caster, Location loc, float power, String[] args) {
 			this.caster = caster;
 			this.power = power;
+			this.args = args;
 
 			data = new SpellData(caster, power, args);
 
@@ -381,7 +383,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			});
 			totemLocation = armorStand.getLocation();
 
-			if (spellOnSpawn != null) spellOnSpawn.subcast(caster, armorStand, power);
+			if (spellOnSpawn != null) spellOnSpawn.subcast(caster, armorStand, power, args);
 		}
 
 		private boolean pulse() {
@@ -404,7 +406,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		private boolean activate() {
 			boolean activated = false;
 			for (Subspell spell : spells) {
-				activated = spell.subcast(caster, totemLocation, power) || activated;
+				activated = spell.subcast(caster, totemLocation, power, args) || activated;
 			}
 
 			playSpellEffects(EffectPosition.SPECIAL, totemLocation, data);
@@ -422,7 +424,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			if (!totemLocation.getChunk().isLoaded()) totemLocation.getChunk().load();
 			armorStand.remove();
 			playSpellEffects(EffectPosition.DISABLED, totemLocation, data);
-			if (spellOnBreak != null) spellOnBreak.subcast(caster, totemLocation, power);
+			if (spellOnBreak != null) spellOnBreak.subcast(caster, totemLocation, power, args);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
@@ -67,11 +67,13 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public PostCastAction castSpell(LivingEntity livingEntity, SpellCastState state, float power, String[] args) {
 		if (state == SpellCastState.NORMAL && livingEntity instanceof Player caster) {
-			TargetInfo<LivingEntity> targetInfo = getTargetedEntity(caster, power, args);
-			if (targetInfo == null) return noTarget(caster, args);
-			LivingEntity target = targetInfo.target();
+			TargetInfo<LivingEntity> info = getTargetedEntity(caster, power, args);
+			if (info.noTarget()) return noTarget(caster, args, info);
 
-			glow(caster, target, targetInfo.power(), args);
+			LivingEntity target = info.target();
+			power = info.power();
+
+			glow(caster, target, power, args);
 			playSpellEffects(caster, target, power, args);
 			sendMessages(caster, target, args);
 

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
@@ -8,6 +8,10 @@ public interface ConfigData<T> {
 
 	T get(LivingEntity caster, LivingEntity target, float power, String[] args);
 
+	default T get(LivingEntity caster, float power, String[] args) {
+		return get(caster, null, power, args);
+	}
+
 	default T get(SpellData data) {
 		if (data == null) return get(null, null, 1f, null);
 		return get(data.caster(), data.target(), data.power(), data.args());

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
@@ -163,8 +163,8 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			return;
 		}
 
-		if (count % spellInterval == 0 && spellOnTick != null && spellOnTick.isTargetedLocationSpell()) {
-			spellOnTick.castAtLocation(caster, currentLocation.clone(), power);
+		if (count % spellInterval == 0 && spellOnTick != null) {
+			spellOnTick.subcast(caster, currentLocation.clone(), power);
 		}
 
 		for (Entity e : entity.getNearbyEntities(hitRadius, vertHitRadius, hitRadius)) {
@@ -175,7 +175,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			EventUtil.call(event);
 			if (!event.isCancelled()) {
 				if (spell != null) spell.playEffects(EffectPosition.TARGET, event.getTarget(), data);
-				if (spellOnHitEntity != null) spellOnHitEntity.castAtEntity(caster, event.getTarget(), event.getPower());
+				if (spellOnHitEntity != null) spellOnHitEntity.subcast(caster, event.getTarget(), event.getPower());
 				if (stopOnHitEntity) stop();
 				return;
 			}
@@ -183,7 +183,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 
 		if (entity.isOnGround()) {
 			if (spellOnHitGround != null && !groundSpellCasted) {
-				spellOnHitGround.castAtLocation(caster, entity.getLocation(), power);
+				spellOnHitGround.subcast(caster, entity.getLocation(), power);
 				groundSpellCasted = true;
 			}
 			if (stopOnHitGround) {
@@ -191,7 +191,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 				return;
 			}
 			if (!landed) MagicSpells.scheduleDelayedTask(() -> {
-				if (spellOnDelay != null) spellOnDelay.castAtLocation(caster, entity.getLocation(), power);
+				if (spellOnDelay != null) spellOnDelay.subcast(caster, entity.getLocation(), power);
 				stop();
 			}, spellDelay);
 			landed = true;

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -552,7 +552,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 
 			if (casterSpell != null && target.equals(caster)) casterSpell.subcast(caster, target, subPower, args);
 			if (entitySpell != null && !target.equals(caster)) entitySpell.subcast(caster, target, subPower, args);
-			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation.clone(), subPower, args);
+			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLoc.clone(), subPower, args);
 
 			if (spell != null)
 				spell.playEffects(EffectPosition.TARGET, currentLoc, new SpellData(caster, target, subPower, args));

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -265,7 +265,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 
 		if (maxDuration > 0 && startTime + maxDuration < System.currentTimeMillis()) {
 			if (hitAirAfterDuration && durationSpell != null) {
-				durationSpell.subcast(caster, currentLocation, power);
+				durationSpell.subcast(caster, currentLocation, power, args);
 				if (spell != null) spell.playEffects(EffectPosition.TARGET, currentLocation, data);
 			}
 			stop();
@@ -276,10 +276,9 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			ModifierResult result = projectileModifiers.apply(caster, data);
 			data = result.data();
 			power = data.power();
-			args = data.args();
 
 			if (!result.check()) {
-				if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power);
+				if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power, args);
 				if (stopOnModifierFail) stop();
 				return;
 			}
@@ -420,7 +419,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 		// Cast spell mid air
 		if (hitAirDuring && counter % spellInterval == 0 && tickSpell != null) {
 			if (tickSpellLimit <= 0 || ticks < tickSpellLimit) {
-				tickSpell.subcast(caster, currentLocation.clone(), power);
+				tickSpell.subcast(caster, currentLocation.clone(), power, args);
 				ticks++;
 			}
 		}
@@ -434,7 +433,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			if (!groundMaterials.contains(b.getType()) || disallowedGroundMaterials.contains(b.getType())) continue;
 			if (hitGround && groundSpell != null) {
 				Util.setLocationFacingFromVector(previousLocation, currentVelocity);
-				groundSpell.subcast(caster, previousLocation, power);
+				groundSpell.subcast(caster, previousLocation, power, args);
 				if (spell != null) spell.playEffects(EffectPosition.TARGET, currentLocation, data);
 			}
 			if (stopOnHitGround) {
@@ -445,7 +444,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 
 		if (currentLocation.distanceSquared(startLocation) >= maxDistanceSquared) {
 			if (hitAirAtEnd && airSpell != null) {
-				airSpell.subcast(caster, currentLocation.clone(), power);
+				airSpell.subcast(caster, currentLocation.clone(), power, args);
 				if (spell != null) spell.playEffects(EffectPosition.TARGET, currentLocation, data);
 			}
 			stop();
@@ -475,7 +474,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			double z = (tracker.currentLocation.getZ() + collisionTracker.currentLocation.getZ()) / 2D;
 
 			Location middleLoc = new Location(tracker.currentLocation.getWorld(), x, y, z);
-			collisionSpell.subcast(tracker.caster, middleLoc, tracker.power);
+			collisionSpell.subcast(tracker.caster, middleLoc, tracker.power, tracker.args);
 			toRemove.add(collisionTracker);
 			toRemove.add(tracker);
 			collisionTracker.stop(false);
@@ -551,9 +550,9 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			target = targetEvent.getTarget();
 			subPower = targetEvent.getPower();
 
-			if (casterSpell != null && target.equals(caster)) casterSpell.subcast(caster, target, subPower);
-			if (entitySpell != null && !target.equals(caster)) entitySpell.subcast(caster, target, subPower);
-			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation.clone(), subPower);
+			if (casterSpell != null && target.equals(caster)) casterSpell.subcast(caster, target, subPower, args);
+			if (entitySpell != null && !target.equals(caster)) entitySpell.subcast(caster, target, subPower, args);
+			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation.clone(), subPower, args);
 
 			if (spell != null)
 				spell.playEffects(EffectPosition.TARGET, currentLoc, new SpellData(caster, target, subPower, args));

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -552,7 +552,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 
 			if (casterSpell != null && target.equals(caster)) casterSpell.subcast(caster, target, subPower, args);
 			if (entitySpell != null && !target.equals(caster)) entitySpell.subcast(caster, target, subPower, args);
-			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLoc.clone(), subPower, args);
+			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLoc, subPower, args);
 
 			if (spell != null)
 				spell.playEffects(EffectPosition.TARGET, currentLoc, new SpellData(caster, target, subPower, args));

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -181,18 +181,14 @@ public class ProjectileTracker implements Runnable, Tracker {
 			args = spellData.args();
 
 			if (!result.check()) {
-				if (modifierSpell != null) {
-					if (modifierSpell.isTargetedLocationSpell()) modifierSpell.castAtLocation(caster, currentLocation, power);
-					else modifierSpell.cast(caster, power);
-				}
-
+				if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power);
 				if (stopOnModifierFail) stop();
 				return;
 			}
 		}
 
 		if (maxDuration > 0 && startTime + maxDuration < System.currentTimeMillis()) {
-			if (durationSpell != null) durationSpell.castAtLocation(caster, currentLocation, power);
+			if (durationSpell != null) durationSpell.subcast(caster, currentLocation, power);
 			stop();
 			return;
 		}
@@ -207,7 +203,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 			if (stopped) return;
 		}
 
-		if (counter % tickSpellInterval == 0 && tickSpell != null) tickSpell.castAtLocation(caster, currentLocation, power);
+		if (counter % tickSpellInterval == 0 && tickSpell != null) tickSpell.subcast(caster, currentLocation, power);
 
 		if (spell != null) {
 			if (specialEffectInterval > 0 && counter % specialEffectInterval == 0) spell.playEffects(EffectPosition.SPECIAL, currentLocation, spellData);
@@ -291,11 +287,10 @@ public class ProjectileTracker implements Runnable, Tracker {
 			if (!targetList.canTarget(caster, entity)) continue;
 
 			SpellTargetEvent event = new SpellTargetEvent(spell, caster, entity, power, args);
-			EventUtil.call(event);
-			if (event.isCancelled()) continue;
+			if (!event.callEvent()) continue;
 
-			if (hitSpell != null) hitSpell.castAtEntity(caster, entity, event.getPower());
-			if (entityLocationSpell != null) entityLocationSpell.castAtLocation(caster, currentLocation, event.getPower());
+			if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower());
+			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation, event.getPower());
 
 			stop();
 			return;

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -181,14 +181,14 @@ public class ProjectileTracker implements Runnable, Tracker {
 			args = spellData.args();
 
 			if (!result.check()) {
-				if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power);
+				if (modifierSpell != null) modifierSpell.subcast(caster, currentLocation, power, args);
 				if (stopOnModifierFail) stop();
 				return;
 			}
 		}
 
 		if (maxDuration > 0 && startTime + maxDuration < System.currentTimeMillis()) {
-			if (durationSpell != null) durationSpell.subcast(caster, currentLocation, power);
+			if (durationSpell != null) durationSpell.subcast(caster, currentLocation, power, args);
 			stop();
 			return;
 		}
@@ -203,7 +203,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 			if (stopped) return;
 		}
 
-		if (counter % tickSpellInterval == 0 && tickSpell != null) tickSpell.subcast(caster, currentLocation, power);
+		if (counter % tickSpellInterval == 0 && tickSpell != null) tickSpell.subcast(caster, currentLocation, power, args);
 
 		if (spell != null) {
 			if (specialEffectInterval > 0 && counter % specialEffectInterval == 0) spell.playEffects(EffectPosition.SPECIAL, currentLocation, spellData);
@@ -289,8 +289,8 @@ public class ProjectileTracker implements Runnable, Tracker {
 			SpellTargetEvent event = new SpellTargetEvent(spell, caster, entity, power, args);
 			if (!event.callEvent()) continue;
 
-			if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower());
-			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation, event.getPower());
+			if (hitSpell != null) hitSpell.subcast(caster, entity, event.getPower(), args);
+			if (entityLocationSpell != null) entityLocationSpell.subcast(caster, currentLocation, event.getPower(), args);
 
 			stop();
 			return;


### PR DESCRIPTION
- Fixed issue where the `broadcast-range` for `str-cast-others` was doubled.
- Fixed an issue where the `hit-radius` and `vertical-hit-radius` of `ParticleProjectileSpell` were halved when hitting entities.
- Extracted subspell casting decisions into `Subspell`.
- Added `invert`, `pass-power`, and `pass-targeting` options to `Subspell`.
- Changed the default value of `pass-targeting` on `TargetedMultiSpell`, `AreaEffectSpell`, and `LoopSpell` to `false`, matching old behavior.
- The subspell options `delay`, `chance`, `power` and `args` now support replacement. Additionally, arguments are now passed to subspell casts, allowing for argument replacement.
- Fixed issues with `CollisionSpell`, `CrippleSpell`, `SkinSpell`, and `GlowSpell` relating to checking `TargetInfo`.