### PR TITLE
Fix heal percent in HealSpell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HealSpell.java
@@ -102,7 +102,7 @@ public class HealSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (healPercent == 0) {
 			amount = this.healAmount.get(caster, target, power, args);
 			if (powerAffectsHealAmount) amount *= power;
-		} else amount = (Util.getMaxHealth(caster) - health) * (healPercent / 100);
+		} else amount = Util.getMaxHealth(target) * (healPercent / 100);
 
 		if (checkPlugins) {
 			MagicSpellsEntityRegainHealthEvent event = new MagicSpellsEntityRegainHealthEvent(target, amount, RegainReason.CUSTOM);


### PR DESCRIPTION
- Fixed an issue where `heal-percent` in `HealSpell` healed a percentage of missing health, rather than max health.
- Fixed an issue where `heal-percent` in `HealSpell` took the percentage to heal from the caster, instead of the target.