### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1700,6 +1700,16 @@ public class MagicSpells extends JavaPlugin {
 		return matcher.find();
 	}
 
+	public static String getTargetName(LivingEntity target) {
+		if (target instanceof Player) return target.getName();
+
+		EntityType type = target.getType();
+		String name = plugin.entityNames.get(type);
+		if (name != null) return name;
+
+		return Util.getStrictStringFromComponent(target.name());
+	}
+
 	public static void registerEvents(final Listener listener) {
 		registerEvents(listener, EventPriority.NORMAL);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -2170,13 +2170,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	}
 
 	protected String getTargetName(LivingEntity target) {
-		if (target instanceof Player) return target.getName();
-
-		EntityType type = target.getType();
-		String name = MagicSpells.getEntityNames().get(type);
-		if (name != null) return name;
-
-		return Util.getStringFromComponent(target.name());
+		return MagicSpells.getTargetName(target);
 	}
 
 	protected String[] getReplacements(SpellData data, String... replacements) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -111,7 +111,6 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 	private String modifierSpellName;
 	private String entityLocationSpellName;
 
-	private Subspell defaultSpell;
 	private String defaultSpellName;
 
 	public ParticleProjectileSpell(MagicConfig config, String spellName) {
@@ -246,12 +245,8 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 
 		String prefix = "ParticleProjectileSpell '" + internalName + "'";
 
-		defaultSpell = new Subspell(defaultSpellName);
-		if (!defaultSpell.process()) {
-			if (!defaultSpellName.isEmpty()) MagicSpells.error(prefix + " has an invalid spell defined!");
-			defaultSpell = null;
-		}
-		defaultSpellName = null;
+		Subspell defaultSpell = new Subspell(defaultSpellName);
+		if (!defaultSpell.process() && !defaultSpellName.isEmpty()) MagicSpells.error(prefix + " has an invalid spell defined!");
 
 		airSpell = new Subspell(airSpellName);
 		if (!airSpell.process()) {
@@ -308,6 +303,8 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 			entityLocationSpell = null;
 		}
 		entityLocationSpellName = null;
+
+		defaultSpellName = null;
 
 		if (interactions != null && !interactions.isEmpty()) {
 			for (String str : interactions) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -133,7 +133,9 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		if (requireEntityTarget.get(data)) {
 			TargetInfo<LivingEntity> info = getTargetedEntity(data);
 			if (info.noTarget()) return noTarget(info);
+
 			data = info.spellData();
+			data = data.location(data.target().getLocation());
 
 			new OrbitTracker(data);
 			return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
@@ -247,7 +249,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 
 			distancePerTick = 6.28f * tickInterval / secondsPerRevolution.get(data) / 20;
 
-			maxDuration = OrbitSpell.this.maxDuration.get(data);
+			maxDuration = OrbitSpell.this.maxDuration.get(data) * TimeUtil.MILLISECONDS_PER_SECOND;
 
 			this.data = data;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
@@ -29,7 +29,7 @@ import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
 public class ParticleCloudSpell extends TargetedSpell implements TargetedLocationSpell, TargetedEntitySpell {
 
-	private ConfigData<Vector> relativeOffset;
+	private final ConfigData<Vector> relativeOffset;
 
 	private final ConfigData<Component> customName;
 
@@ -121,14 +121,16 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 	public CastResult cast(SpellData data) {
 		if (canTargetEntities.get(data)) {
 			TargetInfo<LivingEntity> info = getTargetedEntity(data);
-			if (info.noTarget()) return noTarget(info);
+			if (info.cancelled()) return noTarget(info);
 
-			Location location = info.target().getLocation();
-			location.setDirection(data.caster().getLocation().getDirection());
-			data = info.spellData().location(location);
+			if (!info.noTarget()) {
+				Location location = info.target().getLocation();
+				location.setDirection(data.caster().getLocation().getDirection());
+				data = info.spellData().location(location);
 
-			spawnCloud(data);
-			return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+				spawnCloud(data);
+				return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+			}
 		}
 
 		if (canTargetLocation.get(data)) {
@@ -188,9 +190,7 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 			cloud.setRadiusPerTick(radiusPerTick.get(finalData));
 			cloud.setReapplicationDelay(reapplicationDelay.get(finalData));
 
-			for (PotionEffect eff : potionEffects) {
-				cloud.addCustomEffect(eff, true);
-			}
+			for (PotionEffect eff : potionEffects) cloud.addCustomEffect(eff, true);
 
 			if (customName != null) {
 				cloud.customName(customName.get(finalData));

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -80,7 +80,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 					BlockData data = Bukkit.createBlockData(block.trim().toLowerCase());
 					replace.add(data);
 				} catch (IllegalArgumentException e) {
-					MagicSpells.error("ReplaceSpell " + internalName + " has an invalid replace-blocks item: " + block);
+					MagicSpells.error("ReplaceSpell '" + internalName + "' has an invalid 'replace-blocks' item: " + block);
 				}
 			}
 		}
@@ -93,7 +93,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 					BlockData data = Bukkit.createBlockData(s.trim().toLowerCase());
 					replaceWith.add(data);
 				} catch (IllegalArgumentException e) {
-					MagicSpells.error("ReplaceSpell " + internalName + " has an invalid replace-with item: " + s);
+					MagicSpells.error("ReplaceSpell '" + internalName + "' has an invalid 'replace-with' item: " + s);
 				}
 			}
 		}
@@ -105,7 +105,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 					BlockData data = Bukkit.createBlockData(s.trim().toLowerCase());
 					replaceBlacklist.add(data);
 				} catch (IllegalArgumentException e) {
-					MagicSpells.error("ReplaceSpell " + internalName + " has an invalid replace-blacklist item: " + s);
+					MagicSpells.error("ReplaceSpell '" + internalName + "' has an invalid 'replace-blacklist' item: " + s);
 				}
 			}
 		}
@@ -113,14 +113,14 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 		if (replace.size() != replaceWith.size() && (!replaceRandom.isConstant() || !replaceRandom.get())) {
 			replaceRandom = data -> true;
 			if (replaceRandom.isConstant())
-				MagicSpells.error("ReplaceSpell " + internalName + " replace-random is false, but replace-blocks and replace-with have different sizes!");
+				MagicSpells.error("ReplaceSpell '" + internalName + "' had 'replace-random' as false, but replace-blocks and replace-with have different sizes!");
 			else
-				MagicSpells.error("ReplaceSpell " + internalName + " replace-random can be false, but replace-blocks and replace-with have different sizes!");
+				MagicSpells.error("ReplaceSpell '" + internalName + "' has a 'replace-random' that can be false, but replace-blocks and replace-with have different sizes!");
 		}
 		this.replaceRandom = replaceRandom;
 
-		if (replace.isEmpty()) MagicSpells.error("ReplaceSpell " + internalName + " has empty replace-blocks list!");
-		if (replaceWith.isEmpty()) MagicSpells.error("ReplaceSpell " + internalName + " has empty replace-with list!");
+		if (replace.isEmpty()) MagicSpells.error("ReplaceSpell '" + internalName + "' has empty 'replace-blocks' list!");
+		if (replaceWith.isEmpty()) MagicSpells.error("ReplaceSpell '" + internalName + "' has empty 'replace-with' list!");
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -471,9 +471,12 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 			if (data.caster() instanceof Player player) entity.customName(player.displayName());
 			else entity.customName(data.caster().name());
 			entity.setCustomNameVisible(true);
-		} else if (nameplateText != null) {
-			entity.customName(nameplateText.get(data));
-			entity.setCustomNameVisible(true);
+		} else {
+			Component nameplateText = this.nameplateText.get(data);
+			if (nameplateText != null) {
+				entity.customName(nameplateText);
+				entity.setCustomNameVisible(true);
+			}
 		}
 
 		if (setOwner.get(data) && entity instanceof Tameable tameable && tameable.isTamed() && data.caster() instanceof AnimalTamer tamer)

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -59,6 +59,8 @@ public class Util {
 	private static final Pattern COLOR_PATTERN = Pattern.compile("[&§]([0-9a-fk-or])", Pattern.CASE_INSENSITIVE);
 	private static final Pattern HEX_PATTERN = Pattern.compile("[&§](#[0-9a-f]{6})", Pattern.CASE_INSENSITIVE);
 
+	private static final MiniMessage STRICT_SERIALIZER = MiniMessage.builder().strict(true).build();
+
 	public static int getRandomInt(int bound) {
 		return random.nextInt(bound);
 	}
@@ -759,6 +761,10 @@ public class Util {
 
 	public static String getStringFromComponent(Component component) {
 		return component == null ? "" : MiniMessage.miniMessage().serialize(component);
+	}
+
+	public static String getStrictStringFromComponent(Component component) {
+		return component == null ? "" : STRICT_SERIALIZER.serialize(component);
 	}
 
 	public static String colorize(String string) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -29,7 +29,8 @@ public class StringData implements ConfigData<String> {
 		(arg:(\\d+):(\\w+))|\
 		((papi|casterpapi|targetpapi):([^%]+))|\
 		(playerpapi:([a-zA-Z0-9_]{3,16}):([^%]+))\
-		)%""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+		)%|\
+		(%[at])""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	private final List<ConfigData<String>> values;
 	private final List<String> fragments;
@@ -127,7 +128,11 @@ public class StringData implements ConfigData<String> {
 			return new PlayerPAPIData(matcher.group(), papiPlaceholder, player);
 		}
 
-		return null;
+		return switch (matcher.group(18)) {
+			case "%a" -> new CasterNameData();
+			case "%t" -> new TargetNameData();
+			default -> null;
+		};
 	}
 
 	@Override
@@ -395,6 +400,34 @@ public class StringData implements ConfigData<String> {
 		public String get(@NotNull SpellData data) {
 			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return placeholder;
 			return PlaceholderAPI.setPlaceholders(Bukkit.getOfflinePlayer(player), papiPlaceholder);
+		}
+
+	}
+
+	public static class CasterNameData extends PlaceholderData {
+
+		public CasterNameData() {
+			super("%a");
+		}
+
+		@Override
+		public String get(@NotNull SpellData data) {
+			if (!data.hasCaster()) return placeholder;
+			return MagicSpells.getTargetName(data.caster());
+		}
+
+	}
+
+	public static class TargetNameData extends PlaceholderData {
+
+		public TargetNameData() {
+			super("%t");
+		}
+
+		@Override
+		public String get(@NotNull SpellData data) {
+			if (!data.hasTarget()) return placeholder;
+			return MagicSpells.getTargetName(data.target());
 		}
 
 	}


### PR DESCRIPTION
Mostly fixes for bugs introducted by #755.

- Fixed an issue where `OrbitSpell` would cause an exception when casted with `require-entity-target: true`.
- Fixed an issue where `max-duration` on `OrbitSpell` was milliseconds, instead of seconds.
- Fixed an issue where `ParticleCloudSpell` would not cast at a location if `can-target-entities: true` and no entity was targeted.
- Fixed an issue where an entity spawned with `SpawnEntitySpell` would always have its custom name visible.
- Fixed an issue where `ParticleProjectileSpell` subspells would always print out an error.
- `%a` and `%t` can now be used in areas that use config data string replacement.
- Names from `%a` and `%t` are now serialized in strict form, preventing formatting from bleeding.