### PR TITLE
Support an interval of 0 in LoopSpell, bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -2526,6 +2526,14 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			this.data = data;
 		}
 
+		public boolean success() {
+			return state == SpellCastState.NORMAL && action != PostCastAction.ALREADY_HANDLED;
+		}
+
+		public boolean fail() {
+			return state != SpellCastState.NORMAL || action == PostCastAction.ALREADY_HANDLED;
+		}
+
 	}
 
 	public class DelayedSpellCast implements Runnable, Listener {

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -345,12 +345,12 @@ public class Subspell {
 			return fail(data);
 		}
 
+		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+
 		if (mode != CastMode.HARD && !(passTargeting || this.passTargeting)) {
 			ValidTargetList canTarget = spell.getValidTargetList();
 			if (!canTarget.canTarget(data.caster(), data.target())) return wrapResult(spell.noTarget(data));
 		}
-
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
 
 		double chance = this.chance.get(data);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return fail(data);
@@ -517,12 +517,12 @@ public class Subspell {
 	private SpellCastResult castAtEntityFromLocation(SpellData data, boolean passTargeting) {
 		if (!isTargetedEntityFromLocation) return fail(data);
 
+		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+
 		if (mode != CastMode.HARD && !(passTargeting || this.passTargeting)) {
 			ValidTargetList canTarget = spell.getValidTargetList();
 			if (!canTarget.canTarget(data.caster(), data.target())) return wrapResult(spell.noTarget(data));
 		}
-
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
 
 		double chance = this.chance.get(data);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return fail(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/RandomSpell.java
@@ -76,8 +76,8 @@ public class RandomSpell extends InstantSpell {
 		Subspell spell = set.choose();
 		if (spell == null) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
-		CastResult result = spell.subcast(data);
-		return new CastResult(result.action() != PostCastAction.ALREADY_HANDLED ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED, data);
+		SpellCastResult result = spell.subcast(data);
+		return new CastResult(result.success() ? PostCastAction.HANDLE_NORMALLY : PostCastAction.ALREADY_HANDLED, data);
 	}
 
 	private static class SpellOption {

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -119,7 +119,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 				if (action.isSpell()) {
 					spell = action.getSpell();
 					if (delay == 0) {
-						boolean ok = spell.subcast(data, passTargeting).action() != PostCastAction.ALREADY_HANDLED;
+						boolean ok = spell.subcast(data, passTargeting).success();
 						if (ok) somethingWasDone = true;
 						else if (stopOnFail) break;
 						continue;
@@ -133,7 +133,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			}
 		} else {
 			Action action = actions.get(random.nextInt(actions.size()));
-			if (action.isSpell()) somethingWasDone = action.getSpell().subcast(data).action() != PostCastAction.ALREADY_HANDLED;
+			if (action.isSpell()) somethingWasDone = action.getSpell().subcast(data).success();
 		}
 
 		if (somethingWasDone) playSpellEffects(data);
@@ -203,7 +203,7 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 			if (cancelled) return;
 
 			if (!data.hasCaster() || data.caster().isValid()) {
-				boolean ok = spell.subcast(data, passTargeting).action() != PostCastAction.ALREADY_HANDLED;
+				boolean ok = spell.subcast(data, passTargeting).success();
 				delayedSpells.remove(this);
 				if (!ok && stopOnFail) cancelAll();
 			} else cancelAll();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -418,7 +418,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		}
 
 		private boolean cast(Subspell spell) {
-			boolean success = spell.subcast(data, passTargeting).action() != PostCastAction.ALREADY_HANDLED;
+			boolean success = spell.subcast(data, passTargeting).success();
 			if (stopOnSuccess && success || stopOnFail && !success) {
 				cancel();
 				return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -295,15 +295,15 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private final boolean skipFirstLoopLocationModifiers;
 		private final boolean skipFirstVariableModsTargetLoop;
 
-		private final long iterations;
 		private final int taskId;
+		private final long iterations;
 
 		private long count;
+		private boolean cancelled;
 
 		private Loop(SpellData data) {
 			this.data = data;
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, delay.get(data), interval.get(data));
 			iterations = LoopSpell.this.iterations.get(data);
 
 			stopOnFail = LoopSpell.this.stopOnFail.get(data);
@@ -317,8 +317,28 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			skipFirstLoopLocationModifiers = LoopSpell.this.skipFirstLoopLocationModifiers.get(data);
 			skipFirstVariableModsTargetLoop = LoopSpell.this.skipFirstVariableModsTargetLoop.get(data);
 
-			long dur = duration.get(data);
-			if (dur > 0) MagicSpells.scheduleDelayedTask(this::cancel, dur);
+			long interval = LoopSpell.this.interval.get(data);
+			long delay = LoopSpell.this.delay.get(data);
+
+			if (interval <= 0) {
+				taskId = -1;
+
+				if (delay < 0) {
+					for (int i = 0; i < iterations && !cancelled; i++) run();
+					return;
+				}
+
+				MagicSpells.scheduleDelayedTask(() -> {
+					for (int i = 0; i < iterations && !cancelled; i++) run();
+				}, delay);
+
+				return;
+			}
+
+			taskId = MagicSpells.scheduleRepeatingTask(this, delay, interval);
+
+			long duration = LoopSpell.this.duration.get(data);
+			if (duration > 0) MagicSpells.scheduleDelayedTask(this::cancel, duration);
 		}
 
 		@Override
@@ -420,6 +440,10 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		}
 
 		private void cancel(boolean remove) {
+			if (cancelled) return;
+
+			cancelled = true;
+
 			MagicSpells.cancelTask(taskId);
 
 			if (remove) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -301,8 +301,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 		private boolean activate() {
 			boolean activated = false;
-			for (Subspell spell : spells)
-				activated = spell.subcast(data).action() != PostCastAction.ALREADY_HANDLED || activated;
+			for (Subspell spell : spells) activated = spell.subcast(data).success() || activated;
 
 			playSpellEffects(EffectPosition.DELAYED, location, data);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -378,8 +378,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
 		private boolean activate() {
 			boolean activated = false;
-			for (Subspell spell : spells)
-				activated = spell.subcast(data).action() != PostCastAction.ALREADY_HANDLED || activated;
+			for (Subspell spell : spells) activated = spell.subcast(data).success() || activated;
 
 			playSpellEffects(EffectPosition.SPECIAL, totemLocation, data);
 			if (totalPulses > 0 && (activated || !onlyCountOnSuccess)) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells.util.config;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import com.nisovin.magicspells.util.SpellData;
 
@@ -10,6 +11,11 @@ public interface ConfigData<T> {
 
 	default T get() {
 		return get(SpellData.NULL);
+	}
+
+	default T getOr(@NotNull SpellData data, @Nullable T fallback) {
+		T value = get(data);
+		return value == null ? fallback : value;
 	}
 
 	default boolean isConstant() {


### PR DESCRIPTION
- The `interval` option of `LoopSpell` now supports values `<=0`. When `interval: 0` or less, all iterations of the loop are ran sequentially with no delay.
- Fixed an issue where `LoopSpell` could cancel twice if `duration` was used.
- `Subspell#subcast` now returns `SpellCastResult` instead of `CastResult`. This change also fixes several issues with spells that check if a subspell casts properly.
- The `pass-targeting` subspell cast argument now supports replacement. Additionally, if the value is set, the set value is now used regardless of the value of any spells with a `pass-targeting` option.