### PR TITLE
Use Location#setDirection instead, change notify defaults

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BlockBreakEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/BlockBreakEffect.java
@@ -4,6 +4,7 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.configuration.ConfigurationSection;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
@@ -11,29 +12,24 @@ import com.nisovin.magicspells.util.config.ConfigDataUtil;
 
 public class BlockBreakEffect extends SpellEffect {
 
-	private static final int VANILLA_RADIUS = 32;
-
 	private static int sourceId = 0;
 
 	private ConfigData<Integer> range;
 	private ConfigData<Integer> stage;
-
 	@Override
 	public void loadFromConfig(ConfigurationSection config) {
-		range = ConfigDataUtil.getInteger(config, "range", VANILLA_RADIUS);
-		stage = ConfigDataUtil.getInteger(config, "stage", 1);
+		range = ConfigDataUtil.getInteger(config, "range", 32);
+		stage = ConfigDataUtil.getInteger(config, "stage", 0);
 	}
 
 	@Override
 	public Runnable playEffectLocation(Location location, SpellData data) {
-		if (data == null) return null;
-		if (location.getBlock().getType().isAir()) return null;
+		int stage = this.stage.get(data);
+		float progress = (stage >= 0 && stage <= 9) ? Math.min((stage + 1) / 10f, 1) : 0f;
 
-		double radius = Math.min(range.get(data), VANILLA_RADIUS);
-		float progress = Math.max(0, Math.min(1, stage.get(data) / 10F));
-		for (Player player : location.getNearbyPlayers(radius)) {
-			player.sendBlockDamage(location, progress, sourceId++);
-		}
+		double range = Math.min(this.range.get(data), MagicSpells.getGlobalRadius());
+		for (Player player : location.getNearbyPlayers(range))
+			player.sendBlockDamage(location, progress, --sourceId);
 
 		return null;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -58,8 +58,8 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 		preventCast = getConfigBoolean("prevent-cast", true);
 		preventChat = getConfigBoolean("prevent-chat", false);
 		preventCommands = getConfigBoolean("prevent-commands", false);
-		notifyHelperSpells = getConfigBoolean("notify-helper-spells", false);
-		notifyPassiveSpells = getConfigBoolean("notify-passive-spells", false);
+		notifyHelperSpells = getConfigBoolean("notify-helper-spells", true);
+		notifyPassiveSpells = getConfigBoolean("notify-passive-spells", true);
 		powerAffectsDuration = getConfigDataBoolean("power-affects-duration", true);
 
 		preventCastSpellName = getConfigString("spell-on-denied-cast", "");

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -172,15 +172,12 @@ public class Util {
 
 	public static void setFacing(Player player, Vector vector) {
 		Location loc = player.getLocation();
-		setLocationFacingFromVector(loc, vector);
+		loc.setDirection(vector);
 		player.teleportAsync(loc);
 	}
 
 	public static void setLocationFacingFromVector(Location location, Vector vector) {
-		double yaw = getYawOfVector(vector);
-		double pitch = AccurateMath.toDegrees(-AccurateMath.asin(vector.getY()));
-		location.setYaw((float) yaw);
-		location.setPitch((float) pitch);
+		location.setDirection(vector);
 	}
 
 	public static double getYawOfVector(Vector vector) {

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -418,7 +418,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 		for (Block b : nearBlocks) {
 			if (!groundMaterials.contains(b.getType()) || disallowedGroundMaterials.contains(b.getType())) continue;
 			if (hitGround && groundSpell != null) {
-				Util.setLocationFacingFromVector(previousLocation, currentVelocity);
+				previousLocation.setDirection(currentVelocity);
 				groundSpell.subcast(data.location(previousLocation));
 				if (spell != null) spell.playEffects(EffectPosition.TARGET, currentLocation, data);
 			}


### PR DESCRIPTION
- Changed the default value of `notify-passive-spells` and `notify-helper-spells` in `SilenceSpell` to `true`, to match previous behavior.
- The `stage` option in the `blockbreak` spell effect now more closely matches the block destruction stage as specified in the [protocol](https://wiki.vg/Protocol#Set_Block_Destroy_Stage).