### PR TITLE
Changes and bugfixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ subprojects {
   apply plugin: "org.jetbrains.kotlin.jvm"
 
   dependencies {
-    implementation(group: "io.papermc.paper", name: "paper-api", version: "1.20.2-R0.1-SNAPSHOT")
+    implementation(group: "io.papermc.paper", name: "paper-api", version: "1.19.4-R0.1-SNAPSHOT")
   }
 
   processResources {

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -284,9 +284,9 @@ public class MagicSpells extends JavaPlugin {
 
 		separatePlayerSpellsPerWorld = config.getBoolean(path + "separate-player-spells-per-world", false);
 		allowCycleToNoSpell = config.getBoolean(path + "allow-cycle-to-no-spell", false);
-		reverseBowCycleButtons = config.getBoolean(path + "reverse-bow-cycle-buttons", false);
+		reverseBowCycleButtons = config.getBoolean(path + "reverse-bow-cycle-buttons", true);
 		castBoundBowSpellsFromOffhand = config.getBoolean(path + "cast-bound-bow-spells-from-offhand", false);
-		bowCycleSpellsSneaking = config.getBoolean(path + "bow-cycle-spells-sneaking", false);
+		bowCycleSpellsSneaking = config.getBoolean(path + "bow-cycle-spells-sneaking", true);
 		alwaysShowMessageOnCycle = config.getBoolean(path + "always-show-message-on-cycle", false);
 		onlyCycleToCastableSpells = config.getBoolean(path + "only-cycle-to-castable-spells", true);
 		spellIconSlot = config.getInt(path + "spell-icon-slot", -1);

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -568,7 +568,7 @@ public class MagicSpells extends JavaPlugin {
 		log("Loading cast listeners...");
 		registerEvents(new MagicPlayerListener(this));
 		registerEvents(new MagicSpellListener(this));
-		registerEvents(new CastListener(this));
+		registerEvents(new CastListener());
 		if (!incantations.isEmpty()) registerEvents(new MagicChatListener());
 
 		LeftClickListener leftClickListener = new LeftClickListener();

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -162,16 +162,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() * CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() * CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);
@@ -181,16 +172,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() * CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() * CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);
@@ -200,16 +182,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() * CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() * CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);
@@ -261,16 +234,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() + CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() + CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);
@@ -280,16 +244,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() + CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() + CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);
@@ -299,16 +254,7 @@ public enum ModifierType {
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
 			if (result.check()) {
 				SpellData data = result.data();
-
-				return new ModifierResult(
-					new SpellData(
-						data.caster(),
-						data.target(),
-						data.power() + CustomDataFloat.from(customData, data),
-						data.args()
-					),
-					true
-				);
+				return new ModifierResult(data.power(data.power() + CustomDataFloat.from(customData, data)), true);
 			}
 
 			return new ModifierResult(result.data(), true);

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -14,7 +14,6 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.EquipmentSlot;
-import org.bukkit.event.inventory.ClickType;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.event.inventory.InventoryType;
 import org.bukkit.event.entity.EntityShootBowEvent;
@@ -23,7 +22,6 @@ import org.bukkit.event.player.PlayerDropItemEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
 import org.bukkit.event.player.PlayerAnimationEvent;
-import org.bukkit.event.inventory.InventoryClickEvent;
 
 import io.papermc.paper.event.player.PrePlayerAttackEntityEvent;
 
@@ -146,9 +144,8 @@ public class CastListener implements Listener {
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		Spell spell = spellbook.getActiveSpell(bow);
 
-		if (spell instanceof BowSpell bowSpell) {
-			if (bowSpell.canCastWithItem() && bowSpell.isBindRequired() && checkGlobalCooldown(player, spell)) bowSpell.handleBowCast(event);
-		} else castSpell(player, spell);
+		if (spell instanceof BowSpell bowSpell && bowSpell.canCastWithItem() && bowSpell.isBindRequired() && checkGlobalCooldown(player, spell))
+			bowSpell.handleBowCast(event);
 
 		event.getProjectile().setMetadata("bow-draw-strength", new FixedMetadataValue(MagicSpells.plugin, event.getForce()));
 	}
@@ -168,14 +165,6 @@ public class CastListener implements Listener {
 		Spell spell = spellbook.getActiveSpell(player.getInventory().getItem(event.getNewSlot()));
 		if (spell != null) showIcon(player, MagicSpells.getSpellIconSlot(), spell.getSpellIcon());
 		else showIcon(player, MagicSpells.getSpellIconSlot(), null);
-	}
-
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
-	public void onInventoryDrop(InventoryClickEvent event) {
-		ClickType type = event.getClick();
-		if (type != ClickType.DROP && type != ClickType.CONTROL_DROP) return;
-
-		noCastUntil.put(event.getWhoClicked().getName(), System.currentTimeMillis() + 150);
 	}
 
 	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)

--- a/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/TargetedMultiSpell.java
@@ -81,6 +81,8 @@ public final class TargetedMultiSpell extends TargetedSpell implements TargetedE
 		}
 
 		TargetInfo<Location> info = getTargetedBlockLocation(data, 0.5, 0, 0.5, false);
+		if (info.noTarget()) return noTarget(info);
+
 		return runSpells(info.spellData());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
@@ -130,7 +130,8 @@ public class ReachSpell extends BuffSpell {
 			EventUtil.call(evt);
 			if (evt.isCancelled()) return;
 			// Remove block
-			targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, targetBlock.getBlockData());
+			if (Effect.STEP_SOUND.getData() == Material.class) targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, targetBlock.getType());
+			else targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, targetBlock.getBlockData());
 			// Drop item
 			if (data.dropBlocks && player.getGameMode() == GameMode.SURVIVAL) targetBlock.breakNaturally();
 			else targetBlock.setType(Material.AIR);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
@@ -130,7 +130,7 @@ public class ReachSpell extends BuffSpell {
 			EventUtil.call(evt);
 			if (evt.isCancelled()) return;
 			// Remove block
-			targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, targetBlock.getType());
+			targetBlock.getWorld().playEffect(targetBlock.getLocation(), Effect.STEP_SOUND, targetBlock.getBlockData());
 			// Drop item
 			if (data.dropBlocks && player.getGameMode() == GameMode.SURVIVAL) targetBlock.breakNaturally();
 			else targetBlock.setType(Material.AIR);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -121,7 +121,10 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 		}
 
-		if (playBreakEffect.get(data)) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+		if (playBreakEffect.get(data)) {
+			if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+			else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+		}
 
 		if (consumeBlock.get(data)) {
 			int amt = item.getAmount() - 1;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -121,7 +121,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 		}
 
-		if (playBreakEffect.get(data)) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+		if (playBreakEffect.get(data)) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 
 		if (consumeBlock.get(data)) {
 			int amt = item.getAmount() - 1;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
@@ -113,7 +113,7 @@ public class ExplodeSpell extends TargetedSpell implements TargetedLocationSpell
 		else if (preventAnimalDamage && event.getEntity() instanceof Animals) event.setCancelled(true);
 		else if (damageMultiplier > 0) {
 			if (powerAffectsDamageMultiplier.get(data)) damageMultiplier *= data.power();
-			event.setDamage(damageMultiplier);
+			event.setDamage(event.getDamage() * damageMultiplier);
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -351,7 +351,10 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 			playSpellEffectsTrail(player.getLocation(), block.getLocation(), data);
 		}
 
-		if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+		if (playBreakEffect) {
+			if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+			else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+		}
 		if (removeBlocks) blocks.add(block);
 
 		if (resetDelay > 0 && !falling) {
@@ -366,8 +369,10 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 					}
 					block.setType(Material.AIR);
 					playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
-					if (playBreakEffect)
-						block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+					if (playBreakEffect) {
+						if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+						else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
+					}
 				}
 			}, resetDelay);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -351,7 +351,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 			playSpellEffectsTrail(player.getLocation(), block.getLocation(), data);
 		}
 
-		if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+		if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 		if (removeBlocks) blocks.add(block);
 
 		if (resetDelay > 0 && !falling) {
@@ -367,7 +367,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 					block.setType(Material.AIR);
 					playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
 					if (playBreakEffect)
-						block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
+						block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 				}
 			}, resetDelay);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
@@ -84,8 +84,10 @@ public class ZapSpell extends TargetedSpell implements TargetedLocationSpell {
 			if (!event.callEvent()) return noTarget(strCantZap, data);
 		}
 
-		if (playBreakEffect.get(data))
-			target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getBlockData());
+		if (playBreakEffect.get(data)) {
+			if (Effect.STEP_SOUND.getData() == Material.class) target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getType());
+			else target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getBlockData());
+		}
 
 		if (dropBlock.get(data)) {
 			if (dropNormal.get(data)) target.breakNaturally();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
@@ -85,7 +85,7 @@ public class ZapSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 
 		if (playBreakEffect.get(data))
-			target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getType());
+			target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getBlockData());
 
 		if (dropBlock.get(data)) {
 			if (dropNormal.get(data)) target.breakNaturally();

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellData.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.LivingEntity;
 public record SpellData(LivingEntity caster, LivingEntity target, Location location, LivingEntity recipient,
 						float power, String[] args) {
 
-	public static final SpellData NULL = new SpellData(null, null, null, 1f, null);
+	public static final SpellData NULL = new SpellData(null, null, null, null, 1f, null);
 
 	public SpellData(LivingEntity caster, LivingEntity target, Location location, LivingEntity recipient, float power, String[] args) {
 		this.caster = caster;

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
@@ -144,6 +144,10 @@ public class SpellFilter {
 				s = s.substring(4);
 				if (denied) deniedSpellTags.add(s);
 				else spellTags.add(s);
+			} else if (s.startsWith("#")) {
+				s = s.substring(1);
+				if (denied) deniedSpellTags.add(s);
+				else spellTags.add(s);
 			} else {
 				if (denied) deniedSpells.add(s);
 				else spells.add(s);

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -18,8 +18,8 @@ ignore-cast-perms: false
 enable-tempgrant-perms: true
 separate-player-spells-per-world: false
 allow-cycle-to-no-spell: false
-reverse-bow-cycle-buttons: false
-bow-cycle-spells-sneaking: false
+reverse-bow-cycle-buttons: true
+bow-cycle-spells-sneaking: true
 always-show-message-on-cycle: false
 only-cycle-to-castable-spells: true
 spell-icon-slot: -1


### PR DESCRIPTION
- `ReachSpell`, `BuildSpell`, `MaterializeSpell`, and `ZapSpell` now use block data instead of material for playing break effects.
- Fixed an issue with the `power` and `addpower` modifier actions stripping some data in certain circumstances.
- Refactored `CastListener`. Now also listens for `PrePlayerAttackEntityEvent`, in order to process cast/cycle actions when attacking entities with `cast-on-animate: false`. Additionally, shooting will now only cast `BowSpell` spells.
- Fixed an issue with `TargetedMultiSpell` not properly considering failed targeting with `point-blank: false` and `require-entity-target: false`.
- The `reverse-bow-cycle-buttons` and `bow-cycle-spells-sneaking` options are now true by default.
- Fixed an issue where the damage of explosions caused by `ExplodeSpell` was set to `damage-multiplier`, rather than multiplied by it.
- Added support for prepending `#` instead of `tag:` to specify tags in string-based spell filters.
- Downgraded the paper version from `1.20.2` to `1.19.4` in the parent `build.gradle`, to compile properly for versions 1.19.4 through 1.20.1.