### PR TITLE
Allow non-player entities to use global variables and PAPI

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
@@ -24,6 +24,7 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.RegexUtil;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.variables.variabletypes.GlobalVariable;
 import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
@@ -298,10 +299,12 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!(data.recipient() instanceof Player player)) return 0d;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return 0d;
+
+			String player = data.recipient() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return 0d;
 
 			double value;
 			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
@@ -334,10 +337,12 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!(data.caster() instanceof Player player)) return 0d;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return 0d;
+
+			String player = data.caster() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return 0d;
 
 			double value;
 			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
@@ -370,10 +375,12 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!(data.target() instanceof Player player)) return 0d;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return 0d;
+
+			String player = data.target() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return 0d;
 
 			double value;
 			if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable) {
@@ -432,18 +439,17 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 	public static class DefaultPAPIData implements ConfigData<Double> {
 
-		private final String papiPlaceholder;
+		private final String placeholder;
 
-		public DefaultPAPIData(String papiPlaceholder) {
-			this.papiPlaceholder = papiPlaceholder;
+		public DefaultPAPIData(String placeholder) {
+			this.placeholder = placeholder;
 		}
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.recipient() instanceof Player player))
-				return 0d;
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return 0d;
 
-			String value = PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+			String value = PlaceholderAPI.setPlaceholders(data.recipient() instanceof Player p ? p : null, placeholder);
 
 			try {
 				return Double.parseDouble(value);
@@ -461,18 +467,18 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 	public static class CasterPAPIData implements ConfigData<Double> {
 
-		private final String papiPlaceholder;
+		private final String placeholder;
 
-		public CasterPAPIData(String papiPlaceholder) {
-			this.papiPlaceholder = papiPlaceholder;
+		public CasterPAPIData(String placeholder) {
+			this.placeholder = placeholder;
 		}
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.caster() instanceof Player player))
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"))
 				return 0d;
 
-			String value = PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+			String value = PlaceholderAPI.setPlaceholders(data.caster() instanceof Player p ? p : null, placeholder);
 
 			try {
 				return Double.parseDouble(value);
@@ -498,10 +504,10 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 
 		@Override
 		public Double get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.target() instanceof Player player))
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI"))
 				return 0d;
 
-			String value = PlaceholderAPI.setPlaceholders(player, placeholder);
+			String value = PlaceholderAPI.setPlaceholders(data.target() instanceof Player p ? p : null, placeholder);
 
 			try {
 				return Double.parseDouble(value);

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.TxtUtil;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.variables.variabletypes.GlobalVariable;
 import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
@@ -214,10 +215,12 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!(data.recipient() instanceof Player player)) return placeholder;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return placeholder;
+
+			String player = data.recipient() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return placeholder;
 
 			if (places >= 0) {
 				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
@@ -245,10 +248,12 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!(data.caster() instanceof Player player)) return placeholder;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return placeholder;
+
+			String player = data.caster() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return placeholder;
 
 			if (places >= 0) {
 				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
@@ -276,10 +281,12 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!(data.target() instanceof Player player)) return placeholder;
-
 			Variable var = MagicSpells.getVariableManager().getVariable(variable);
 			if (var == null) return placeholder;
+
+			String player = data.target() instanceof Player p ? p.getName() : null;
+			if (player == null && !(var instanceof GlobalVariable) && !(var instanceof GlobalStringVariable))
+				return placeholder;
 
 			if (places >= 0) {
 				if (var instanceof PlayerStringVariable || var instanceof GlobalStringVariable)
@@ -336,10 +343,8 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.recipient() instanceof Player player))
-				return placeholder;
-
-			return PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return placeholder;
+			return PlaceholderAPI.setPlaceholders(data.recipient() instanceof Player p ? p : null, papiPlaceholder);
 		}
 
 	}
@@ -356,10 +361,8 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.caster() instanceof Player player))
-				return placeholder;
-
-			return PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return placeholder;
+			return PlaceholderAPI.setPlaceholders(data.caster() instanceof Player p ? p : null, papiPlaceholder);
 		}
 
 	}
@@ -376,10 +379,8 @@ public class StringData implements ConfigData<String> {
 
 		@Override
 		public String get(@NotNull SpellData data) {
-			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI") || !(data.caster() instanceof Player player))
-				return placeholder;
-
-			return PlaceholderAPI.setPlaceholders(player, papiPlaceholder);
+			if (!Bukkit.getPluginManager().isPluginEnabled("PlaceholderAPI")) return placeholder;
+			return PlaceholderAPI.setPlaceholders(data.target() instanceof Player p ? p : null, papiPlaceholder);
 		}
 
 	}


### PR DESCRIPTION
- Global variable and PAPI placeholders will now be resolved by non-player entities.
- Fixed an issue where `%targetpapi` placeholders used the caster instead of the target in `StringData`.