### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
@@ -89,8 +89,8 @@ public class WindglideSpell extends BuffSpell {
 		boolean constantHeight = this.constantHeight.get(data);
 		boolean constantVelocity = this.constantVelocity.get(data);
 
-		double height = constantHeight ? this.height.get(data) / 10 : 0;
-		double velocity = constantVelocity ? this.velocity.get(data) : 0;
+		double height = constantHeight ? this.height.get(data) : 0;
+		double velocity = constantVelocity ? this.velocity.get(data) / 10 : 0;
 
 		entities.put(data.target().getUniqueId(), new GlideData(
 			data,
@@ -211,7 +211,7 @@ public class WindglideSpell extends BuffSpell {
 				SpellData subData = data.spellData.location(location);
 
 				double height = data.constantHeight ? data.height : WindglideSpell.this.height.get(subData);
-				double velocity = data.constantVelocity ? data.velocity : WindglideSpell.this.velocity.get(subData);
+				double velocity = data.constantVelocity ? data.velocity : WindglideSpell.this.velocity.get(subData) / 10;
 
 				Vector v = location.getDirection().multiply(velocity);
 				v.setY(v.getY() + height);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ExplodeSpell.java
@@ -33,7 +33,7 @@ public class ExplodeSpell extends TargetedSpell implements TargetedLocationSpell
 	private final ConfigData<Boolean> powerAffectsDamageMultiplier;
 
 	private SpellData currentData = null;
-	private long currentTick = 0;
+	private long currentTick = -1;
 
 	public ExplodeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -86,7 +86,7 @@ public class ExplodeSpell extends TargetedSpell implements TargetedLocationSpell
 			data = data.location(location);
 		}
 
-		currentTick = Bukkit.getWorlds().get(0).getFullTime();
+		currentTick = Bukkit.getCurrentTick();
 		currentData = data;
 
 		boolean success = location.createExplosion(data.caster(), explosionSize, addFire.get(data), !preventBlockDamage.get(data));
@@ -99,7 +99,7 @@ public class ExplodeSpell extends TargetedSpell implements TargetedLocationSpell
 	public void onEntityDamage(EntityDamageByEntityEvent event) {
 		if (event.getCause() != DamageCause.ENTITY_EXPLOSION) return;
 
-		if (currentTick != Bukkit.getWorlds().get(0).getFullTime() || !currentData.caster().equals(event.getDamager()))
+		if (currentTick != Bukkit.getCurrentTick() || !currentData.caster().equals(event.getDamager()))
 			return;
 
 		SpellData data = currentData.target(event.getEntity() instanceof LivingEntity le ? le : null);


### PR DESCRIPTION
- Fixed an issue where the `height` option of `VelocitySpell` was divided by `10`.
- Fixed an issue where the `velocity` option of `VelocitySpell` wasn't divided by `10`.
- Use the current tick for tracking in `ExplodeSpell`, rather than the time of the main world.