### PR TITLE
Add freeze ticks, max freeze ticks and max fire ticks meta variables

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -130,6 +130,9 @@ public class VariableManager {
 		addMetaVariableType("mana", new ManaVariable());
 		addMetaVariableType("max_mana", new MaxManaVariable());
 		addMetaVariableType("mana_regen", new ManaRegenVariable());
+		addMetaVariableType("freeze_ticks", new FreezeTicksVariable());
+		addMetaVariableType("max_freeze_ticks", new MaxFreezeTicksVariable());
+		addMetaVariableType("max_fire_ticks", new MaxFireTicksVariable());
 
 		// meta variable attribute types
 		addMetaVariableType("attribute_generic_max_health_base", new AttributeBaseValueVariable("GENERIC_MAX_HEALTH"));

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/FreezeTicksVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/FreezeTicksVariable.java
@@ -1,0 +1,22 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class FreezeTicksVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = PlayerNameUtils.getPlayerExact(player);
+		return p == null ? 0 : p.getFreezeTicks();
+	}
+
+	@Override
+	public void set(String player, double amount) {
+		Player p = PlayerNameUtils.getPlayerExact(player);
+		if (p != null) p.setFreezeTicks((int) amount);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/MaxFireTicksVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/MaxFireTicksVariable.java
@@ -1,0 +1,16 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class MaxFireTicksVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = PlayerNameUtils.getPlayerExact(player);
+		return p == null ? 0 : p.getMaxFireTicks();
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/MaxFreezeTicksVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/MaxFreezeTicksVariable.java
@@ -1,0 +1,16 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class MaxFreezeTicksVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = PlayerNameUtils.getPlayerExact(player);
+		return p == null ? 0 : p.getMaxFreezeTicks();
+	}
+
+}


### PR DESCRIPTION
Added the `meta_freeze_tick`, `meta_max_freeze_ticks`, and `meta_max_fire_ticks` meta variables. Currently the max freeze/fire ticks aren't very useful, as the values are the same for all players, but may be used in the future whenever variables work for all living entities.