### PR TITLE
Cleanup, bugfix

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -167,7 +167,7 @@ public class CastListener implements Listener {
 		else showIcon(player, MagicSpells.getSpellIconSlot(), null);
 	}
 
-	@EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerDrop(PlayerDropItemEvent event) {
 		noCastUntil.put(event.getPlayer().getName(), System.currentTimeMillis() + 150);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CaptureSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CaptureSpell.java
@@ -3,6 +3,8 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.List;
 import java.util.ArrayList;
 
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
 import org.bukkit.entity.Item;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -17,7 +19,7 @@ import com.nisovin.magicspells.spells.TargetedEntitySpell;
 
 public class CaptureSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private static final ValidTargetChecker CAPTURABLE = entity -> MobUtil.hasEggMaterialForEntityType(entity.getType());
+	private static final ValidTargetChecker CAPTURABLE = e -> Bukkit.getItemFactory().getSpawnEgg(e.getType()) != null;
 
 	private final String itemName;
 	private final List<String> itemLore;
@@ -49,8 +51,10 @@ public class CaptureSpell extends TargetedSpell implements TargetedEntitySpell {
 	public CastResult castAtEntity(SpellData data) {
 		LivingEntity target = data.target();
 
-		ItemStack item = MobUtil.getEggItemForEntityType(target.getType());
-		if (item == null) return noTarget(data);
+		Material material = Bukkit.getItemFactory().getSpawnEgg(target.getType());
+		if (material == null) return noTarget(data);
+
+		ItemStack item = new ItemStack(material);
 
 		if (powerAffectsQuantity.get(data)) {
 			int q = Math.round(data.power());

--- a/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MobUtil.java
@@ -3,15 +3,12 @@ package com.nisovin.magicspells.util;
 import java.util.Map;
 import java.util.HashMap;
 
-import org.bukkit.Material;
 import org.bukkit.entity.Mob;
 import org.bukkit.entity.EntityType;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.inventory.ItemStack;
 
 public class MobUtil {
 
-	private static final Map<EntityType, Material> entityToEggMaterial = new HashMap<>();
 	private static final Map<String, EntityType> entityTypeMap = new HashMap<>();
 
 	static {
@@ -23,9 +20,6 @@ public class MobUtil {
 
 			entityTypeMap.put(type.getKey().getKey(), type);
 			entityTypeMap.put(type.getKey().getKey().replace("_", ""), type);
-
-			Material material = Util.getMaterial(type.getKey().getKey() + "_SPAWN_EGG");
-			if (material != null) entityToEggMaterial.put(type, material);
 		}
 
 		Map<String, EntityType> types = new HashMap<>();
@@ -38,17 +32,6 @@ public class MobUtil {
 	public static EntityType getEntityType(String type) {
 		if (type.equalsIgnoreCase("player")) return EntityType.PLAYER;
 		return entityTypeMap.get(type.toLowerCase());
-	}
-
-	public static ItemStack getEggItemForEntityType(EntityType type) {
-		Material eggMaterial = entityToEggMaterial.get(type);
-		if (eggMaterial == null) return null;
-
-		return new ItemStack(eggMaterial);
-	}
-
-	public static boolean hasEggMaterialForEntityType(EntityType type) {
-		return entityToEggMaterial.containsKey(type);
 	}
 
 	public static void setTarget(LivingEntity mob, LivingEntity target) {


### PR DESCRIPTION
- Use `ItemFactory` to determine an entity's egg material for `CaptureSpell`.
- No longer ignore cancelled drops when preventing casting from the arm swing caused by dropping items.