### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -846,49 +846,51 @@ public enum ModifierType {
 			}
 
 		}
-		
-		private void setVariable(Player player, StringData data) {
-			data.variable.parseAndSet(player, data.value);
+
+		private void setVariable(CustomData customData, SpellData spellData) {
+			if (!customData.isValid()) return;
+			StringData data = (StringData) customData;
+
+			if (!(spellData.caster() instanceof Player caster)) return;
+
+			String value = MagicSpells.doReplacements(data.value, spellData);
+			MagicSpells.getVariableManager().set(data.variable, caster.getName(), value);
 		}
 
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
-			if (!(event.getCaster() instanceof Player caster)) return false;
-			if (check) setVariable(caster, (StringData) customData);
+			if (check) setVariable(customData, event.getSpellData());
 			return true;
 		}
 
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
-			if (check) setVariable(event.getPlayer(), (StringData) customData);
+			if (check) setVariable(customData, new SpellData(event.getPlayer()));
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
-			if (!(event.getCaster() instanceof Player caster)) return false;
-			if (check) setVariable(caster, (StringData) customData);
+			if (check) setVariable(customData, event.getSpellData());
 			return true;
 		}
 
 		@Override
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
-			if (!(event.getCaster() instanceof Player caster)) return false;
-			if (check) setVariable(caster, (StringData) customData);
+			if (check) setVariable(customData, event.getSpellData());
 			return true;
 		}
 
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
-			if (check) setVariable(event.getPlayer(), (StringData) customData);
+			if (check) setVariable(customData, new SpellData(event.getPlayer()));
 			return true;
 		}
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, ModifierResult result, CustomData customData) {
-			if (!(caster instanceof Player player)) return result.check() ? new ModifierResult(result.data(), false) : result;
 			if (result.check()) {
-				setVariable(player, (StringData) customData);
+				setVariable(customData, result.data());
 				return result;
 			}
 			return new ModifierResult(result.data(), true);
@@ -896,9 +898,8 @@ public enum ModifierType {
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, LivingEntity target, ModifierResult result, CustomData customData) {
-			if (!(caster instanceof Player player)) return result.check() ? new ModifierResult(result.data(), false) : result;
 			if (result.check()) {
-				setVariable(player, (StringData) customData);
+				setVariable(customData, result.data());
 				return result;
 			}
 			return new ModifierResult(result.data(), true);
@@ -906,9 +907,8 @@ public enum ModifierType {
 
 		@Override
 		public ModifierResult apply(LivingEntity caster, Location target, ModifierResult result, CustomData customData) {
-			if (!(caster instanceof Player player)) return result.check() ? new ModifierResult(result.data(), false) : result;
 			if (result.check()) {
-				setVariable(player, (StringData) customData);
+				setVariable(customData, result.data());
 				return result;
 			}
 			return new ModifierResult(result.data(), true);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -23,9 +23,9 @@ import com.nisovin.magicspells.events.MagicSpellsGenericPlayerEvent;
 import com.nisovin.magicspells.castmodifiers.customdata.CustomDataFloat;
 
 public enum ModifierType {
-	
+
 	REQUIRED(false, "required", "require") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (!check) event.setCancelled(true);
@@ -72,9 +72,9 @@ public enum ModifierType {
 		}
 
 	},
-	
+
 	DENIED(false, "denied", "deny") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.setCancelled(true);
@@ -121,9 +121,9 @@ public enum ModifierType {
 		}
 
 	},
-	
+
 	POWER(true, "power", "empower", "multiply") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.increasePower((CustomDataFloat.from(customData, event)));
@@ -192,11 +192,11 @@ public enum ModifierType {
 		public CustomData buildCustomActionData(String text) {
 			return new CustomDataFloat(text);
 		}
-		
+
 	},
-	
+
 	ADD_POWER(true, "addpower", "add") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.setPower(event.getPower() + CustomDataFloat.from(customData, event));
@@ -264,11 +264,11 @@ public enum ModifierType {
 		public CustomData buildCustomActionData(String text) {
 			return new CustomDataFloat(text);
 		}
-		
+
 	},
-	
+
 	COOLDOWN(true, "cooldown") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.setCooldown(CustomDataFloat.from(customData, event));
@@ -314,11 +314,11 @@ public enum ModifierType {
 		public CustomData buildCustomActionData(String text) {
 			return new CustomDataFloat(text);
 		}
-		
+
 	},
-	
+
 	REAGENTS(true, "reagents") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.setReagents(event.getReagents().multiply(CustomDataFloat.from(customData, event)));
@@ -364,11 +364,11 @@ public enum ModifierType {
 		public CustomData buildCustomActionData(String text) {
 			return new CustomDataFloat(text);
 		}
-		
+
 	},
-	
+
 	CAST_TIME(true, "casttime") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (check) event.setCastTime((int) CustomDataFloat.from(customData, event));
@@ -414,11 +414,11 @@ public enum ModifierType {
 		public CustomData buildCustomActionData(String text) {
 			return new CustomDataFloat(text);
 		}
-		
+
 	},
-	
+
 	STOP(false, "stop") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			return !check;
@@ -460,9 +460,9 @@ public enum ModifierType {
 		}
 
 	},
-	
+
 	CONTINUE(false, "continue") {
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			return check;
@@ -504,7 +504,7 @@ public enum ModifierType {
 		}
 
 	},
-	
+
 	CAST(true, "cast") {
 
 		static class CastData extends CustomData {
@@ -597,7 +597,7 @@ public enum ModifierType {
 		}
 
 	},
-	
+
 	CAST_INSTEAD(true, "castinstead") {
 
 		static class CustomInsteadData extends CustomData {
@@ -701,11 +701,11 @@ public enum ModifierType {
 	},
 
 	VARIABLE_MODIFY(true, "variable") {
-		
+
 		static class VariableModData extends CustomData {
 
 			private String invalidText = "Variable action is invalid.";
-			
+
 			public VariableOwner variableOwner;
 			public Variable variable;
 			public VariableMod mod;
@@ -823,15 +823,15 @@ public enum ModifierType {
 			if (data.variable == null) data.invalidText = "Variable does not exist.";
 			return data;
 		}
-		
+
 	},
-	
+
 	STRING(true, "string") {
-		
+
 		static class StringData extends CustomData {
 
 			public String invalidText;
-			
+
 			public Variable variable;
 			public String value;
 
@@ -850,34 +850,34 @@ public enum ModifierType {
 		private void setVariable(Player player, StringData data) {
 			data.variable.parseAndSet(player, data.value);
 		}
-		
+
 		@Override
 		public boolean apply(SpellCastEvent event, boolean check, CustomData customData) {
 			if (!(event.getCaster() instanceof Player caster)) return false;
 			if (check) setVariable(caster, (StringData) customData);
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(ManaChangeEvent event, boolean check, CustomData customData) {
 			if (check) setVariable(event.getPlayer(), (StringData) customData);
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(SpellTargetEvent event, boolean check, CustomData customData) {
 			if (!(event.getCaster() instanceof Player caster)) return false;
 			if (check) setVariable(caster, (StringData) customData);
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(SpellTargetLocationEvent event, boolean check, CustomData customData) {
 			if (!(event.getCaster() instanceof Player caster)) return false;
 			if (check) setVariable(caster, (StringData) customData);
 			return true;
 		}
-		
+
 		@Override
 		public boolean apply(MagicSpellsGenericPlayerEvent event, boolean check, CustomData customData) {
 			if (check) setVariable(event.getPlayer(), (StringData) customData);
@@ -921,32 +921,32 @@ public enum ModifierType {
 				data.invalidText = "Data is invalid.";
 				return data;
 			}
-			
+
 			String[] splits = text.split(" ", 2);
 			data.variable = MagicSpells.getVariableManager().getVariable(splits[0]);
 			if (data.variable == null) data.invalidText = "Variable does not exist.";
 			data.value = splits[1];
 			return data;
 		}
-		
+
 	}
-	
+
 	;
-	
+
 	private final String[] keys;
 	private static boolean initialized = false;
-	
+
 	private final boolean usesCustomData;
-	
+
 	ModifierType(boolean usesCustomData, String... keys) {
 		this.keys = keys;
 		this.usesCustomData = usesCustomData;
 	}
-	
+
 	public boolean usesCustomData() {
 		return usesCustomData;
 	}
-	
+
 	public abstract boolean apply(SpellCastEvent event, boolean check, CustomData customData);
 	public abstract boolean apply(ManaChangeEvent event, boolean check, CustomData customData);
 	public abstract boolean apply(SpellTargetEvent event, boolean check, CustomData customData);
@@ -960,9 +960,9 @@ public enum ModifierType {
 	public CustomData buildCustomActionData(String text) {
 		return null;
 	}
-	
+
 	static Map<String, ModifierType> nameMap;
-	
+
 	static void initialize() {
 		nameMap = new HashMap<>();
 		for (ModifierType type : ModifierType.values()) {
@@ -972,10 +972,10 @@ public enum ModifierType {
 		}
 		initialized = true;
 	}
-	
+
 	public static ModifierType getModifierTypeByName(String name) {
 		if (!initialized) initialize();
 		return nameMap.get(name.toLowerCase());
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DayCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/DayCondition.java
@@ -28,8 +28,7 @@ public class DayCondition extends Condition {
 	}
 
 	private boolean checkTime(Location location) {
-		long time = location.getWorld().getTime();
-		return !(time > 13000 && time < 23000);
+		return location.getWorld().isDayTime();
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NightCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/NightCondition.java
@@ -28,8 +28,7 @@ public class NightCondition extends Condition {
 	}
 
 	private boolean night(Location location) {
-		long time = location.getWorld().getTime();
-		return time > 13000 && time < 23000;
+		return !location.getWorld().isDayTime();
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnSameTeamCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnSameTeamCondition.java
@@ -2,10 +2,9 @@ package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.scoreboard.ScoreboardManager;
+import org.bukkit.scoreboard.Scoreboard;
 
 import com.nisovin.magicspells.castmodifiers.Condition;
 
@@ -32,13 +31,10 @@ public class OnSameTeamCondition extends Condition {
 	}
 
 	private boolean checkTeam(LivingEntity caster, LivingEntity target) {
-		if (caster instanceof Player c && target instanceof Player t) {
-			ScoreboardManager manager = Bukkit.getScoreboardManager();
-			Team team1 = manager.getMainScoreboard().getEntryTeam(c.getName());
-			Team team2 = manager.getMainScoreboard().getEntryTeam(t.getName());
-			return (team1 != null && team2 != null) && team1.equals(team2);
-		}
-		return false;
+		Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
+		Team team1 = scoreboard.getEntryTeam(caster.getName());
+		Team team2 = scoreboard.getEntryTeam(target.getName());
+		return (team1 != null && team2 != null) && team1.equals(team2);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnTeamCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OnTeamCondition.java
@@ -2,7 +2,6 @@ package com.nisovin.magicspells.castmodifiers.conditions;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.entity.Player;
 import org.bukkit.scoreboard.Team;
 import org.bukkit.entity.LivingEntity;
 
@@ -34,8 +33,7 @@ public class OnTeamCondition extends Condition {
 	}
 
 	private boolean onTeam(LivingEntity target) {
-		if (!(target instanceof Player pl)) return false;
-		Team team = Bukkit.getScoreboardManager().getMainScoreboard().getEntryTeam(pl.getName());
+		Team team = Bukkit.getScoreboardManager().getMainScoreboard().getEntryTeam(target.getName());
 		return team != null && team.getName().equals(teamName);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SignTextCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/SignTextCondition.java
@@ -2,10 +2,13 @@ package com.nisovin.magicspells.castmodifiers.conditions;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
 import org.bukkit.block.Block;
+import org.bukkit.block.sign.Side;
 import org.bukkit.entity.LivingEntity;
 
 import net.kyori.adventure.text.Component;
@@ -15,53 +18,71 @@ import com.nisovin.magicspells.util.MagicLocation;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.castmodifiers.Condition;
 
+/*
+ * Format: side;world,x,y,z,line__1\nline__2
+ * "side" is optional and can be "front" (def) or "back".
+ * world,x,y,z is optional, "x,y,z" must be integers.
+ * "lines" should follow strict MiniMessage format.
+ */
 public class SignTextCondition extends Condition {
 
-	//world,x,y,z,text
+	private static final Pattern FORMAT = Pattern.compile("(?:(?<side>front|back);)?(?:(?<world>[^,]+),(?<x>-?\\d+),(?<y>-?\\d+),(?<z>-?\\d+),)?(?<lines>.+)", Pattern.DOTALL);
 
+	private Side side = Side.FRONT;
 	private MagicLocation location;
-	private List<Component> text;
+	private final List<String> text = new ArrayList<>();
 
 	@Override
 	public boolean initialize(String var) {
-		try {
-			String[] vars = var.split(",");
-			location = new MagicLocation(vars[0], Integer.parseInt(vars[1]), Integer.parseInt(vars[2]), Integer.parseInt(vars[3]));
+		Matcher matcher = FORMAT.matcher(var);
+		if (!matcher.find()) return false;
+		String sideName = matcher.group("side");
+		String world = matcher.group("world");
+		String x = matcher.group("x");
+		String y = matcher.group("y");
+		String z = matcher.group("z");
+		String lines = matcher.group("lines");
 
-			text = new ArrayList<>();
-			for (String line : vars[4].split("\\\\n")) {
-				text.add(Util.getLegacyFromString(line.replaceAll("__", " ")));
+		if (sideName != null && sideName.equals("back")) side = Side.BACK;
+		if (world != null && x != null && y != null && z != null) {
+			try {
+				location = new MagicLocation(world, Integer.parseInt(x), Integer.parseInt(y), Integer.parseInt(z));
+			} catch (NumberFormatException e) {
+				DebugHandler.debugNumberFormat(e);
+				return false;
 			}
-			return true;
-		} catch (Exception e) {
-			DebugHandler.debugGeneral(e);
-			return false;
 		}
+		for (String line : lines.split("\\\\n|\\n")) {
+			text.add(line.replaceAll("__", " "));
+		}
+		return true;
 	}
 
 	@Override
 	public boolean check(LivingEntity caster) {
-		return checkSignText();
+		return checkSignText(caster.getLocation());
 	}
 
 	@Override
 	public boolean check(LivingEntity caster, LivingEntity target) {
-		return checkSignText();
+		return checkSignText(target.getLocation());
 	}
 
 	@Override
 	public boolean check(LivingEntity caster, Location location) {
-		return checkSignText();
+		return checkSignText(location);
 	}
 
-	public boolean checkSignText() {
-		Block block = location.getLocation().getBlock();
+	public boolean checkSignText(Location targetedLocation) {
+		Location signLocation = location == null ? targetedLocation : location.getLocation();
+		Block block = signLocation.getBlock();
 		if (!block.getType().name().contains("SIGN")) return false;
 
-		Sign sign = (Sign) block.getState();
-		List<Component> lines = sign.lines();
+		List<Component> lines = ((Sign) block.getState()).getSide(side).lines();
 		for (int i = 0; i < lines.size(); i++) {
-			if (lines.get(i).equals(text.get(i))) continue;
+			String signLine = Util.getStrictStringFromComponent(lines.get(i));
+			String checkLine = text.size() - 1 >= i ? text.get(i) : "";
+			if (signLine.equals(checkLine)) continue;
 			return false;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -50,7 +50,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 	public MenuSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		title = getConfigDataComponent("title", Component.text("Window Title" + spellName));
+		title = getConfigDataComponent("title", Component.text("Window Title " + spellName));
 		delay = getConfigDataInt("delay", 0);
 		filler = createItem("filler");
 		stayOpenNonOption = getConfigDataBoolean("stay-open-non-option", false);

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -242,7 +242,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	@EventHandler
 	public void onItemClick(InventoryClickEvent event) {
 		Inventory inventory = event.getClickedInventory();
-		if (!(inventory.getHolder() instanceof PlayerMenuInventory menu) || menu.getSpell() != this) return;
+		if (inventory == null || !(inventory.getHolder() instanceof PlayerMenuInventory menu) || menu.getSpell() != this) return;
 
 		event.setCancelled(true);
 		if (!(event.getWhoClicked() instanceof Player opener)) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -51,16 +51,20 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	private final ConfigData<Boolean> castSpellsOnTarget;
 
 	private final String spellRangeName;
-	private final String spellOnLeftName;
 	private final String spellOfflineName;
+	private final String spellOnLeftName;
 	private final String spellOnRightName;
+	private final String spellOnDropName;
+	private final String spellOnSwapName;
 	private final String spellOnSneakLeftName;
 	private final String spellOnSneakRightName;
 
-	private Subspell spellOffline;
 	private Subspell spellRange;
+	private Subspell spellOffline;
 	private Subspell spellOnLeft;
 	private Subspell spellOnRight;
+	private Subspell spellOnDrop;
+	private Subspell spellOnSwap;
 	private Subspell spellOnSneakLeft;
 	private Subspell spellOnSneakRight;
 
@@ -92,9 +96,11 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		castSpellsOnTarget = getConfigDataBoolean("cast-spells-on-target", true);
 
 		spellRangeName = getConfigString("spell-range", "");
-		spellOnLeftName = getConfigString("spell-on-left", "");
 		spellOfflineName = getConfigString("spell-offline", "");
+		spellOnLeftName = getConfigString("spell-on-left", "");
 		spellOnRightName = getConfigString("spell-on-right", "");
+		spellOnDropName = getConfigString("spell-on-drop", "");
+		spellOnSwapName = getConfigString("spell-on-swap", "");
 		spellOnSneakLeftName = getConfigString("spell-on-sneak-left", "");
 		spellOnSneakRightName = getConfigString("spell-on-sneak-right", "");
 
@@ -117,10 +123,12 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		super.initialize();
 
 		String error = "PlayerMenuSpell '" + internalName + "' has an invalid ";
-		spellOffline = initSubspell(spellOfflineName, error + "spell-offline defined!");
 		spellRange = initSubspell(spellRangeName, error + "spell-range defined!");
+		spellOffline = initSubspell(spellOfflineName, error + "spell-offline defined!");
 		spellOnLeft = initSubspell(spellOnLeftName, error + "spell-on-left defined!");
 		spellOnRight = initSubspell(spellOnRightName, error + "spell-on-right defined!");
+		spellOnDrop = initSubspell(spellOnDropName, error + "spell-on-drop defined!");
+		spellOnSwap = initSubspell(spellOnSwapName, error + "spell-on-swap defined!");
 		spellOnSneakLeft = initSubspell(spellOnSneakLeftName, error + "spell-on-sneak-left defined!");
 		spellOnSneakRight = initSubspell(spellOnSneakRightName, error + "spell-on-sneak-right defined!");
 	}
@@ -301,6 +309,8 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		switch (event.getClick()) {
 			case LEFT -> processClickSpell(spellOnLeft, targetPlayer, menu);
 			case RIGHT -> processClickSpell(spellOnRight, targetPlayer, menu);
+			case DROP -> processClickSpell(spellOnDrop, targetPlayer, menu);
+			case SWAP_OFFHAND -> processClickSpell(spellOnSwap, targetPlayer, menu);
 			case SHIFT_LEFT -> processClickSpell(spellOnSneakLeft, targetPlayer, menu);
 			case SHIFT_RIGHT -> processClickSpell(spellOnSneakRight, targetPlayer, menu);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -54,7 +54,6 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	private final String spellOnLeftName;
 	private final String spellOfflineName;
 	private final String spellOnRightName;
-	private final String spellOnMiddleName;
 	private final String spellOnSneakLeftName;
 	private final String spellOnSneakRightName;
 
@@ -62,7 +61,6 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	private Subspell spellRange;
 	private Subspell spellOnLeft;
 	private Subspell spellOnRight;
-	private Subspell spellOnMiddle;
 	private Subspell spellOnSneakLeft;
 	private Subspell spellOnSneakRight;
 
@@ -97,7 +95,6 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		spellOnLeftName = getConfigString("spell-on-left", "");
 		spellOfflineName = getConfigString("spell-offline", "");
 		spellOnRightName = getConfigString("spell-on-right", "");
-		spellOnMiddleName = getConfigString("spell-on-middle", "");
 		spellOnSneakLeftName = getConfigString("spell-on-sneak-left", "");
 		spellOnSneakRightName = getConfigString("spell-on-sneak-right", "");
 
@@ -124,7 +121,6 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		spellRange = initSubspell(spellRangeName, error + "spell-range defined!");
 		spellOnLeft = initSubspell(spellOnLeftName, error + "spell-on-left defined!");
 		spellOnRight = initSubspell(spellOnRightName, error + "spell-on-right defined!");
-		spellOnMiddle = initSubspell(spellOnMiddleName, error + "spell-on-middle defined!");
 		spellOnSneakLeft = initSubspell(spellOnSneakLeftName, error + "spell-on-sneak-left defined!");
 		spellOnSneakRight = initSubspell(spellOnSneakRightName, error + "spell-on-sneak-right defined!");
 	}
@@ -305,7 +301,6 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 		switch (event.getClick()) {
 			case LEFT -> processClickSpell(spellOnLeft, targetPlayer, menu);
 			case RIGHT -> processClickSpell(spellOnRight, targetPlayer, menu);
-			case MIDDLE -> processClickSpell(spellOnMiddle, targetPlayer, menu);
 			case SHIFT_LEFT -> processClickSpell(spellOnSneakLeft, targetPlayer, menu);
 			case SHIFT_RIGHT -> processClickSpell(spellOnSneakRight, targetPlayer, menu);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
@@ -84,11 +84,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 		String item = getConfigString("block-type", "stone");
 		MagicItem magicItem = MagicItems.getMagicItemFromString(item);
 		if (magicItem != null && magicItem.getItemStack() != null) headItem = magicItem.getItemStack();
-		else {
-			Material material = Util.getMaterial(item);
-			if (material != null && material.isBlock()) headItem = new ItemStack(material);
-			else MagicSpells.error("BlockBeamSpell '" + internalName + "' has an invalid block-type defined!");
-		}
+		else MagicSpells.error("BlockBeamSpell '" + internalName + "' has an invalid 'block-type' defined!");
 
 		relativeOffset = getConfigDataVector("relative-offset", new Vector(0, 0.5, 0));
 		targetRelativeOffset = getConfigDataVector("target-relative-offset", new Vector(0, 0.5, 0));

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaEffectSpell.java
@@ -183,7 +183,9 @@ public class AreaEffectSpell extends TargetedSpell implements TargetedLocationSp
 		if (ignoreRadius) Bukkit.getWorlds().forEach(world -> entities.addAll(world.getLivingEntities()));
 		else entities.addAll(location.getWorld().getNearbyLivingEntities(location, hRadius, vRadius, hRadius));
 
-		if (!circleShape) entities.removeAll(location.getWorld().getNearbyLivingEntities(location, minHRadius, minVRadius, minHRadius));
+		if (!circleShape && (minHRadius != 0 || minVRadius != 0)) {
+			entities.removeAll(location.getWorld().getNearbyLivingEntities(location, minHRadius, minVRadius, minHRadius));
+		}
 
 		if (useProximity) {
 			// check world before distance

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -492,12 +492,14 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				equipment.setLeggings(leggings);
 				equipment.setBoots(boots);
 
-				equipment.setItemInMainHandDropChance(mainHandItemDropChance.get(data) / 100);
-				equipment.setItemInOffHandDropChance(offHandItemDropChance.get(data) / 100);
-				equipment.setHelmetDropChance(helmetDropChance.get(data) / 100);
-				equipment.setChestplateDropChance(chestplateDropChance.get(data) / 100);
-				equipment.setLeggingsDropChance(leggingsDropChance.get(data) / 100);
-				equipment.setBootsDropChance(bootsDropChance.get(data) / 100);
+				if (livingEntity instanceof Mob) {
+					equipment.setItemInMainHandDropChance(mainHandItemDropChance.get(data) / 100);
+					equipment.setItemInOffHandDropChance(offHandItemDropChance.get(data) / 100);
+					equipment.setHelmetDropChance(helmetDropChance.get(data) / 100);
+					equipment.setChestplateDropChance(chestplateDropChance.get(data) / 100);
+					equipment.setLeggingsDropChance(leggingsDropChance.get(data) / 100);
+					equipment.setBootsDropChance(bootsDropChance.get(data) / 100);
+				}
 			}
 
 			if (potionEffects != null) livingEntity.addPotionEffects(potionEffects);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -133,6 +133,8 @@ public class VariableManager {
 		addMetaVariableType("freeze_ticks", new FreezeTicksVariable());
 		addMetaVariableType("max_freeze_ticks", new MaxFreezeTicksVariable());
 		addMetaVariableType("max_fire_ticks", new MaxFireTicksVariable());
+		addMetaVariableType("forwards_movement", new ForwardsMovementVariable());
+		addMetaVariableType("sideways_movement", new SidewaysMovementVariable());
 
 		// meta variable attribute types
 		addMetaVariableType("attribute_generic_max_health_base", new AttributeBaseValueVariable("GENERIC_MAX_HEALTH"));

--- a/core/src/main/java/com/nisovin/magicspells/util/recipes/CustomRecipe.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/recipes/CustomRecipe.java
@@ -18,6 +18,7 @@ import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.ConfigReaderUtil;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
@@ -163,6 +164,20 @@ public abstract class CustomRecipe {
 		if (object instanceof Map<?, ?> map) {
 			ConfigurationSection config = ConfigReaderUtil.mapToSection(map);
 			return MagicItems.getMagicItemFromSection(config);
+		}
+		return null;
+	}
+
+	protected <T extends Enum<T>> T resolveEnum(Class<T> enumClass, String path, T def) {
+		String received = config.getString(path);
+		if (received == null) return def;
+		try {
+			return Enum.valueOf(enumClass, received.toUpperCase());
+		}
+		catch (IllegalArgumentException e) {
+			// DebugHandler sends a sufficient error message.
+			error(path, "");
+			DebugHandler.debugBadEnumValue(enumClass, received);
 		}
 		return null;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomCookingRecipe.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomCookingRecipe.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.util.recipes.types;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.CookingRecipe;
+import org.bukkit.inventory.recipe.CookingBookCategory;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.recipes.CustomRecipe;
@@ -12,18 +13,21 @@ public abstract class CustomCookingRecipe extends CustomRecipe {
 	protected final RecipeChoice ingredient;
 	protected final float experience;
 	protected final int cookingTime;
+	private final CookingBookCategory category;
 
 	public CustomCookingRecipe(ConfigurationSection config) {
 		super(config);
 		ingredient = resolveRecipeChoice("ingredient");
 		experience = (float) config.getDouble("experience", 0);
 		cookingTime = config.getInt("cooking-time", 0);
+		category = resolveEnum(CookingBookCategory.class, "category", CookingBookCategory.MISC);
 	}
 
 	@Override
 	public Recipe build() {
 		CookingRecipe<?> recipe = buildCooking();
 		recipe.setGroup(group);
+		recipe.setCategory(category);
 		return recipe;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomShapedRecipe.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomShapedRecipe.java
@@ -8,6 +8,7 @@ import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 
 import com.nisovin.magicspells.util.recipes.CustomRecipe;
 
@@ -15,10 +16,12 @@ public class CustomShapedRecipe extends CustomRecipe {
 
 	private final List<String> shape;
 	private final Map<Character, RecipeChoice> ingredients = new HashMap<>();
+	private final CraftingBookCategory category;
 
 	public CustomShapedRecipe(ConfigurationSection config) {
 		super(config);
 		shape = config.getStringList("shape");
+		category = resolveEnum(CraftingBookCategory.class, "category" , CraftingBookCategory.MISC);
 
 		ConfigurationSection ingredientConfig = config.getConfigurationSection("ingredients");
 		if (ingredientConfig == null) {
@@ -42,6 +45,7 @@ public class CustomShapedRecipe extends CustomRecipe {
 		recipe.setGroup(group);
 		recipe.shape(shape.toArray(new String[0]));
 		ingredients.forEach(recipe::setIngredient);
+		recipe.setCategory(category);
 		return recipe;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomShapelessRecipe.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/recipes/types/CustomShapelessRecipe.java
@@ -6,16 +6,19 @@ import java.util.ArrayList;
 import org.bukkit.inventory.Recipe;
 import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapelessRecipe;
+import org.bukkit.inventory.recipe.CraftingBookCategory;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.recipes.CustomRecipe;
 
 public class CustomShapelessRecipe extends CustomRecipe {
 
+	private final CraftingBookCategory category;
 	private final List<RecipeChoice> ingredients = new ArrayList<>();
 
 	public CustomShapelessRecipe(ConfigurationSection config) {
 		super(config);
+		category = resolveEnum(CraftingBookCategory.class, "category" , CraftingBookCategory.MISC);
 
 		String path = "ingredients";
 		ConfigurationSection ingredientsConfig;
@@ -44,6 +47,7 @@ public class CustomShapelessRecipe extends CustomRecipe {
 	public Recipe build() {
 		ShapelessRecipe recipe = new ShapelessRecipe(namespaceKey, result);
 		recipe.setGroup(group);
+		recipe.setCategory(category);
 		ingredients.forEach(recipe::addIngredient);
 		return recipe;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/ForwardsMovementVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/ForwardsMovementVariable.java
@@ -1,0 +1,17 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class ForwardsMovementVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String p) {
+		Player player = PlayerNameUtils.getPlayerExact(p);
+		if (player == null) return 0D;
+		return player.getForwardsMovement();
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/SidewaysMovementVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/SidewaysMovementVariable.java
@@ -1,0 +1,17 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.util.PlayerNameUtils;
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class SidewaysMovementVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String p) {
+		Player player = PlayerNameUtils.getPlayerExact(p);
+		if (player == null) return 0D;
+		return player.getSidewaysMovement();
+	}
+
+}


### PR DESCRIPTION
* Fixed `onteam` and `onsameteam` conditions requiring player targets.
* `moonphase` condition now accepts [PaperMC's moon phases](<https://jd.papermc.io/paper/1.20/io/papermc/paper/world/MoonPhase.html#enum-constant-summary>). Legacy grouped phases are still supported: `full`, `waning`, `new`, `waxing`.
* `string` modifier action now supports [string expressions](<https://github.com/TheComputerGeek2/MagicSpells/wiki/Expression#string>).
* Fixed AOE spell removing possible targets located at the center/source of the AOE while `min-x-radius` was 0 (default value).
* Added `meta_forwards_movement` and `meta_sideways_movement` meta variables.
* Fixed SpawnEntity spell throwing spawn chance errors when using non-Mob entities.
* PlayerMenu spell no longer has `spell-middle` because it can no longer be detected and added `spell-drop` and `spell-swap`.
* Fixed PlayerMenu spell throwing errors when the opener clicked outside the inventory.
* Added custom recipe `category` option:
    - [Cooking book category](<https://jd.papermc.io/paper/1.20/org/bukkit/inventory/recipe/CookingBookCategory.html#enum-constant-summary>) for `blasting`, `campfire`, `furnace`, and `smoking` recipe types.
    - [Crafing book category](<https://jd.papermc.io/paper/1.20/org/bukkit/inventory/recipe/CraftingBookCategory.html#enum-constant-summary>) for `shaped` and `shapeless` recipe types.
 * Fixed `signtext` modifier condition not comparing text properly. Its format has also changed to `side;world,x,y,z,line__1\nline__2`:
     - `side;` is optional and can be `front;` (default) or `back;`
     - `world,x,y,z` is also optional. If omitted, it'll use the caster's or target's location.
     - Text lines can be split by `\\n` or `\n`, spaces can be represented with `__`.