### PR TITLE
Raytrace, cleanup

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -25,12 +25,9 @@ import org.jetbrains.annotations.NotNull;
 
 import co.aikar.commands.PaperCommandManager;
 
-import org.bukkit.Bukkit;
-import org.bukkit.Material;
-import org.bukkit.ChatColor;
+import org.bukkit.*;
 import org.bukkit.event.Event;
 import org.bukkit.entity.Player;
-import org.bukkit.OfflinePlayer;
 import org.bukkit.event.Listener;
 import org.bukkit.entity.EntityType;
 import org.bukkit.event.HandlerList;
@@ -195,6 +192,10 @@ public class MagicSpells extends JavaPlugin {
 
 	private ChatColor textColor;
 
+	private double losRaySize;
+	private boolean losIgnorePassableBlocks;
+	private FluidCollisionMode losFluidCollisionMode;
+
 	// Strings
 	private String strCantCast;
 	private String strCantBind;
@@ -318,6 +319,13 @@ public class MagicSpells extends JavaPlugin {
 			losTransparentBlocks.add(Material.AIR);
 			losTransparentBlocks.add(Material.VOID_AIR);
 			losTransparentBlocks.add(Material.CAVE_AIR);
+		}
+		losRaySize = config.getDouble(path + "los-ray-size", 0.2);
+		losIgnorePassableBlocks = config.getBoolean(path + "los-ignore-passable-blocks", true);
+		try {
+			losFluidCollisionMode = FluidCollisionMode.valueOf(config.getString(path + "los-fluid-collision-mode", "ALWAYS").toUpperCase());
+		} catch (IllegalArgumentException e) {
+			losFluidCollisionMode = FluidCollisionMode.ALWAYS;
 		}
 		globalRadius = config.getInt(path + "global-radius", 500);
 		globalCooldown = config.getInt(path + "global-cooldown", 500);
@@ -962,6 +970,18 @@ public class MagicSpells extends JavaPlugin {
 	 */
 	public static Set<Material> getTransparentBlocks() {
 		return plugin.losTransparentBlocks;
+	}
+
+	public static double getLosRaySize() {
+		return plugin.losRaySize;
+	}
+
+	public static boolean isIgnoringPassableBlocks() {
+		return plugin.losIgnorePassableBlocks;
+	}
+
+	public static FluidCollisionMode getFluidCollisionMode() {
+		return plugin.losFluidCollisionMode;
 	}
 
 	/**

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -10,18 +10,16 @@ import java.util.concurrent.ThreadLocalRandom;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.LinkedListMultimap;
 
-import org.bukkit.Bukkit;
-import org.bukkit.GameMode;
-import org.bukkit.Material;
-import org.bukkit.Location;
+import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 import org.bukkit.block.Block;
 import org.bukkit.event.Listener;
 import org.bukkit.scoreboard.Team;
+import org.bukkit.util.BoundingBox;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.EventHandler;
-import org.bukkit.util.BlockIterator;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.EventPriority;
 import org.bukkit.block.data.BlockData;
@@ -35,15 +33,13 @@ import org.bukkit.configuration.ConfigurationSection;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
-import com.nisovin.magicspells.events.*;
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.events.*;
 import com.nisovin.magicspells.util.config.*;
 import com.nisovin.magicspells.spelleffects.*;
 import com.nisovin.magicspells.mana.ManaHandler;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.spells.PassiveSpell;
-import com.nisovin.magicspells.util.compat.EventUtil;
-import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.spelleffects.effecttypes.*;
@@ -51,6 +47,7 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 import com.nisovin.magicspells.spelleffects.trackers.EffectTracker;
+import com.nisovin.magicspells.spelleffects.effecttypes.EntityEffect;
 import com.nisovin.magicspells.spelleffects.util.EffectlibSpellEffect;
 import com.nisovin.magicspells.spelleffects.trackers.AsyncEffectTracker;
 
@@ -165,6 +162,10 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	protected DamageCause targetDamageCause;
 
 	protected ValidTargetList validTargetList;
+
+	protected ConfigData<Double> losRaySize;
+	protected ConfigData<Boolean> losIgnorePassableBlocks;
+	protected ConfigData<FluidCollisionMode> losFluidCollisionMode;
 
 	protected long nextCastServer;
 
@@ -341,6 +342,9 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			losTransparentBlocks.add(Material.CAVE_AIR);
 			losTransparentBlocks.add(Material.VOID_AIR);
 		}
+		losRaySize = getConfigDataDouble("los-ray-size", MagicSpells.getLosRaySize());
+		losIgnorePassableBlocks = getConfigDataBoolean("los-ignore-passable-blocks", MagicSpells.isIgnoringPassableBlocks());
+		losFluidCollisionMode = getConfigDataEnum("los-fluid-collision-mode", FluidCollisionMode.class, MagicSpells.getFluidCollisionMode());
 		targetSelf = getConfigDataBoolean("target-self", false);
 		alwaysActivate = getConfigDataBoolean("always-activate", false);
 		playFizzleSound = getConfigDataBoolean("play-fizzle-sound", false);
@@ -1479,6 +1483,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	protected TargetInfo<LivingEntity> getTargetedEntity(SpellData data, boolean forceTargetPlayers, ValidTargetChecker checker) {
 		LivingEntity caster = data.caster();
+
 		if (targetSelf.get(data) || validTargetList.canTargetSelf()) {
 			if (checker != null && !checker.isValidTarget(caster)) return new TargetInfo<>(null, data, false);
 
@@ -1486,136 +1491,76 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 			return new TargetInfo<>(event.callEvent() ? event.getTarget() : null, event.getSpellData(), event.isCastCancelled());
 		}
 
-		int currentRange = getRange(data);
-		List<Entity> nearbyEntities = caster.getNearbyEntities(currentRange, currentRange, currentRange);
+		World world = caster.getWorld();
 
-		// Get valid targets
-		List<LivingEntity> entities;
-		if (MagicSpells.checkWorldPvpFlag() && validTargetList.canTargetPlayers() && !isBeneficial() && !caster.getWorld().getPVP()) {
-			entities = validTargetList.filterTargetListCastingAsLivingEntities(caster, nearbyEntities, false);
-		} else if (forceTargetPlayers) {
-			entities = validTargetList.filterTargetListCastingAsLivingEntities(caster, nearbyEntities, true);
-		} else {
-			entities = validTargetList.filterTargetListCastingAsLivingEntities(caster, nearbyEntities);
+		boolean targetPlayers = forceTargetPlayers || validTargetList.canTargetPlayers();
+		if (targetPlayers && MagicSpells.checkWorldPvpFlag() && caster instanceof Player && !isBeneficial() && !world.getPVP()){
+			if (forceTargetPlayers) return new TargetInfo<>(null, data, false);
+			targetPlayers = false;
 		}
 
-		if (checker != null) entities.removeIf(entity -> !checker.isValidTarget(entity));
+		Location startLocation = caster.getEyeLocation();
+		Vector direction = startLocation.getDirection();
+		Vector start = startLocation.toVector();
 
-		// Find target
-		BlockIterator blockIterator;
-		try {
-			blockIterator = new BlockIterator(caster, currentRange);
-		} catch (IllegalStateException e) {
-			DebugHandler.debugIllegalState(e);
-			return new TargetInfo<>(null, data, false);
+		double range = getRange(data), raySize = losRaySize.get(data);
+		if (obeyLos) {
+			RayTraceResult blockHit = world.rayTraceBlocks(startLocation, direction, range, losFluidCollisionMode.get(data), losIgnorePassableBlocks.get(data), block -> !losTransparentBlocks.contains(block.getType()));
+			if (blockHit != null) range = blockHit.getHitPosition().distance(start);
 		}
 
-		Block block;
-		Location location;
+		Collection<Entity> nearbyEntities = world.getNearbyEntities(BoundingBox.of(start, start).expand(direction, range).expand(raySize));
+		List<LivingEntity> potentialTargets = new ArrayList<>();
 
-		int blockX;
-		int blockY;
-		int blockZ;
+		for (Entity entity : nearbyEntities) {
+			if (!(entity instanceof LivingEntity target)) continue;
+			if (!validTargetList.canTarget(caster, target, targetPlayers)) continue;
+			if (checker != null && !checker.isValidTarget(target)) continue;
 
-		double entityX;
-		double entityY;
-		double entityZ;
-
-		// How far can a target be from the line of sight along the x, y, and z directions
-		double xLower = 0.75;
-		double xUpper = 1.75;
-		double yLower = 1;
-		double yUpper = 2.5;
-		double zLower = 0.75;
-		double zUpper = 1.75;
-
-		// Do min range
-		for (int i = 0, minRange = this.minRange.get(data); i < minRange && blockIterator.hasNext(); i++) {
-			blockIterator.next();
+			potentialTargets.add(target);
 		}
 
-		Set<Entity> blacklistedEntities = new HashSet<>();
+		potentialTargets.sort(Comparator.comparingDouble(e -> e.getLocation().distanceSquared(startLocation)));
 
-		// Loop through player's line of sight
-		while (blockIterator.hasNext()) {
-			block = blockIterator.next();
-			blockX = block.getX();
-			blockY = block.getY();
-			blockZ = block.getZ();
+		int minRangeSq = this.minRange.get(data);
+		minRangeSq *= minRangeSq;
 
-			// Line of sight is broken, stop without target
-			if (obeyLos && !BlockUtils.isTransparent(this, block)) break;
+		for (LivingEntity target : potentialTargets) {
+			Location targetLocation = target.getLocation();
+			if (targetLocation.distanceSquared(startLocation) < minRangeSq) continue;
 
-			// Check for entities near this block in the line of sight
-			for (LivingEntity target : entities) {
-				if (blacklistedEntities.contains(target)) continue;
-				location = target.getLocation();
-				entityX = location.getX();
-				entityY = location.getY();
-				entityZ = location.getZ();
+			BoundingBox boundingBox = target.getBoundingBox().expand(raySize);
+			if (boundingBox.rayTrace(start, direction, range) == null) continue;
 
-				if (!(blockX - xLower <= entityX && entityX <= blockX + xUpper)) continue;
-				if (!(blockY - yLower <= entityY && entityY <= blockY + yUpper)) continue;
-				if (!(blockZ - zLower <= entityZ && entityZ <= blockZ + zUpper)) continue;
+			if (MagicSpells.getNoMagicZoneManager() != null && MagicSpells.getNoMagicZoneManager().willFizzle(targetLocation, this))
+				continue;
 
-				// Check for invalid target
-				if (target instanceof Player pl && (pl.getGameMode() == GameMode.CREATIVE || pl.getGameMode() == GameMode.SPECTATOR)) {
-					blacklistedEntities.add(target);
-					continue;
-				}
+			if (MagicSpells.checkScoreboardTeams()) {
+				Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
 
-				// Check for no-magic-zone
-				if (MagicSpells.getNoMagicZoneManager() != null && MagicSpells.getNoMagicZoneManager().willFizzle(target.getLocation(), this)) {
-					blacklistedEntities.add(target);
-					continue;
-				}
+				Team casterTeam = scoreboard.getEntityTeam(caster);
+				Team targetTeam = scoreboard.getEntityTeam(target);
 
-				// Check for teams
-				if (target instanceof Player && MagicSpells.checkScoreboardTeams()) {
-					Scoreboard scoreboard = Bukkit.getScoreboardManager().getMainScoreboard();
-
-					Team playerTeam = null;
-					if (caster instanceof Player) playerTeam = scoreboard.getEntryTeam(caster.getName());
-					Team targetTeam = scoreboard.getEntryTeam(target.getName());
-
-					if (playerTeam != null && targetTeam != null) {
-						if (playerTeam.equals(targetTeam)) {
-							if (!playerTeam.allowFriendlyFire() && !isBeneficial()) {
-								blacklistedEntities.add(target);
-								continue;
-							}
-						} else if (isBeneficial()) {
-							blacklistedEntities.add(target);
-							continue;
-						}
-					}
-				}
-
-				// Call event listeners
-				SpellTargetEvent targetEvent = new SpellTargetEvent(this, data, target);
-				targetEvent.callEvent();
-
-				if (targetEvent.isCastCancelled()) return new TargetInfo<>(null, targetEvent.getSpellData(), true);
-				else if (targetEvent.isCancelled()) {
-					blacklistedEntities.add(target);
-					continue;
-				} else {
-					target = targetEvent.getTarget();
-				}
-
-				// Call damage event
-				if (targetDamageCause != null) {
-					EntityDamageByEntityEvent entityDamageEvent = new MagicSpellsEntityDamageByEntityEvent(caster, target, targetDamageCause, targetDamageAmount, this);
-					EventUtil.call(entityDamageEvent);
-					if (entityDamageEvent.isCancelled()) {
-						blacklistedEntities.add(target);
+				if (casterTeam != null && targetTeam != null) {
+					if (casterTeam.equals(targetTeam) ? !casterTeam.allowFriendlyFire() && !isBeneficial() : isBeneficial())
 						continue;
-
-					}
 				}
-
-				return new TargetInfo<>(target, targetEvent.getSpellData(), false);
 			}
+
+			SpellTargetEvent targetEvent = new SpellTargetEvent(this, data, target);
+			targetEvent.callEvent();
+
+			if (targetEvent.isCastCancelled()) return new TargetInfo<>(null, targetEvent.getSpellData(), true);
+			else if (targetEvent.isCancelled()) continue;
+
+			target = targetEvent.getTarget();
+
+			if (targetDamageCause != null) {
+				EntityDamageByEntityEvent entityDamageEvent = new MagicSpellsEntityDamageByEntityEvent(caster, target, targetDamageCause, targetDamageAmount, this);
+				if (!entityDamageEvent.callEvent()) continue;
+			}
+
+			return new TargetInfo<>(target, targetEvent.getSpellData(), false);
 		}
 
 		return new TargetInfo<>(null, data, false);

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -5,6 +5,7 @@ import de.slikey.effectlib.Effect;
 import net.kyori.adventure.text.Component;
 
 import java.util.*;
+import java.util.function.Predicate;
 import java.util.concurrent.ThreadLocalRandom;
 
 import com.google.common.collect.Multimap;
@@ -1664,6 +1665,21 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	public boolean isTransparent(Block block) {
 		return losTransparentBlocks.contains(block.getType());
+	}
+
+	public Predicate<Location> isTransparent(SpellData data) {
+		FluidCollisionMode losFluidCollisionMode = this.losFluidCollisionMode.get(data);
+		boolean losIgnorePassableBlocks = this.losIgnorePassableBlocks.get(data);
+
+		return location -> {
+			Block block = location.getBlock();
+			if (losTransparentBlocks.contains(block.getType())) return true;
+
+			// FIXME: Cannot check if block is a source block or not.
+			if (block.isLiquid()) return losFluidCollisionMode == FluidCollisionMode.NEVER;
+
+			return losIgnorePassableBlocks && block.isPassable();
+		};
 	}
 
 	protected void playSpellEffects(SpellData data) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LookingAtBlockCondition.java
@@ -1,12 +1,15 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
+import java.util.Set;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
-import org.bukkit.block.Block;
+import org.bukkit.Material;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.block.data.BlockData;
 
-import com.nisovin.magicspells.util.BlockUtils;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.castmodifiers.Condition;
 
 public class LookingAtBlockCondition extends Condition {
@@ -53,10 +56,13 @@ public class LookingAtBlockCondition extends Condition {
 	}
 
 	private boolean lookingAt(LivingEntity target) {
-		Block block = BlockUtils.getTargetBlock(null, target, dist);
-		if (block == null) return false;
+		Set<Material> transparent = MagicSpells.getTransparentBlocks();
+		Location location = target.getEyeLocation();
 
-		return block.getBlockData().matches(blockData);
+		RayTraceResult result = location.getWorld().rayTraceBlocks(location, location.getDirection(), dist, MagicSpells.getFluidCollisionMode(), MagicSpells.isIgnoringPassableBlocks(), block -> !transparent.contains(block.getType()));
+		if (result == null) return false;
+
+		return result.getHitBlock().getBlockData().matches(blockData);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
@@ -15,6 +15,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.block.Action;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.event.block.BlockBreakEvent;
@@ -122,7 +123,8 @@ public class SpellbookSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Block target = getTargetedBlock(data);
+		RayTraceResult result = rayTraceBlocks(data);
+		Block target = result == null ? null : result.getHitBlock();
 		if (target == null || !spellbookBlock.equals(target.getType())) {
 			sendMessage(strNoTarget, player, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.spells.instant;
 
 import java.util.Set;
 import java.util.HashSet;
+import java.util.function.Predicate;
 
 import org.apache.commons.math4.core.jdkmath.AccurateMath;
 
@@ -228,6 +229,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 		boolean stopOnHitEntity = this.stopOnHitEntity.get(data);
 		boolean stopOnHitGround = this.stopOnHitGround.get(data);
 
+		Predicate<Location> transparent = isTransparent(data);
 		Set<Entity> immune = new HashSet<>();
 		float d = 0;
 
@@ -249,7 +251,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 			if (zoneManager.willFizzle(loc, this)) break;
 
 			//check block collision
-			if (!isTransparent(loc.getBlock())) {
+			if (!transparent.test(loc)) {
 				playSpellEffects(EffectPosition.DISABLED, loc, locData);
 				if (groundSpell != null) groundSpell.subcast(locData);
 				if (stopOnHitGround) break;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
@@ -4,6 +4,7 @@ import java.util.Set;
 import java.util.List;
 import java.util.HashSet;
 import java.util.ArrayList;
+import java.util.function.Predicate;
 
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -246,6 +247,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 		boolean stopOnHitEntity = this.stopOnHitEntity.get(data);
 		boolean stopOnHitGround = this.stopOnHitGround.get(data);
 
+		Predicate<Location> transparent = isTransparent(data);
 		List<LivingEntity> armorStandList = new ArrayList<>();
 		HashSet<Entity> immune = new HashSet<>();
 		float d = 0;
@@ -267,7 +269,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 			locData = locData.location(loc);
 
 			//check block collision
-			if (!isTransparent(loc.getBlock())) {
+			if (!transparent.test(loc)) {
 				playSpellEffects(EffectPosition.DISABLED, loc, locData);
 				if (groundSpell != null) groundSpell.subcast(locData);
 				if (stopOnHitGround) break;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/WallSpell.java
@@ -14,6 +14,7 @@ import org.bukkit.event.Listener;
 import org.bukkit.block.BlockState;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.event.block.BlockBreakEvent;
 
 import com.nisovin.magicspells.util.*;
@@ -116,11 +117,16 @@ public class WallSpell extends TargetedSpell implements TargetedLocationSpell {
 	public CastResult cast(SpellData data) {
 		if (checkAtCap(data)) return noTarget(strAtCap, data);
 
-		Block block = getTargetedBlock(data);
-		if (!block.getType().isAir()) return noTarget(data);
+		int range = getRange(data);
 
-		Location location = block.getLocation();
-		location.setDirection(location.toVector().subtract(data.caster().getLocation().toVector()));
+		RayTraceResult result = rayTraceBlocks(data, range);
+		if (result != null) return noTarget(data);
+
+		Location location = data.caster().getEyeLocation();
+		Vector start = location.toVector();
+
+		location.add(location.getDirection().multiply(range));
+		location.setDirection(location.toVector().subtract(start));
 
 		SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(this, data, location);
 		if (!targetEvent.callEvent()) return noTarget(targetEvent);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BlinkSpell.java
@@ -1,13 +1,12 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import java.util.List;
 
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.util.RayTraceResult;
 
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.CastResult;
-import com.nisovin.magicspells.util.BlockUtils;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
@@ -30,27 +29,19 @@ public class BlinkSpell extends TargetedSpell implements TargetedLocationSpell {
 
 	@Override
 	public CastResult cast(SpellData data) {
-		List<Block> blocks = getLastTwoTargetedBlocks(data);
-		if (blocks.isEmpty()) return noTarget(strCantBlink, data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(strCantBlink, data);
 
-		Block prev, found;
-		if (blocks.size() == 1) {
-			prev = null;
-			found = blocks.get(0);
-		} else {
-			prev = blocks.get(0);
-			found = blocks.get(1);
-		}
-
-		if (BlockUtils.isTransparent(this, found)) return noTarget(strCantBlink, data);
+		Block found = result.getHitBlock();
+		Block prev = found.getRelative(result.getHitBlockFace());
 
 		Location loc = null;
 		if (!passThroughCeiling.get(data) && found.getRelative(0, -1, 0).equals(prev) && prev.isPassable()) {
 			Block under = prev.getRelative(0, -1, 0);
 			if (under.isPassable()) loc = under.getLocation().add(0.5, 0, 0.5);
 		} else if (found.getRelative(0, 1, 0).isPassable() && found.getRelative(0, 2, 0).isPassable()) {
-			loc = found.getLocation().add(0, 1, 0).add(0.5, 0, 0.5);
-		} else if (prev != null && prev.isPassable() && prev.getRelative(0, 1, 0).isPassable()) {
+			loc = found.getLocation().add(0.5, 1, 0.5);
+		} else if (prev.isPassable() && prev.getRelative(0, 1, 0).isPassable()) {
 			loc = prev.getLocation().add(0.5, 0, 0.5);
 		}
 		if (loc == null) return noTarget(strCantBlink, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BombSpell.java
@@ -7,6 +7,7 @@ import java.util.HashSet;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
+import org.bukkit.util.RayTraceResult;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
@@ -63,10 +64,11 @@ public class BombSpell extends TargetedSpell implements TargetedLocationSpell {
 
 	@Override
 	public CastResult cast(SpellData data) {
-		List<Block> blocks = getLastTwoTargetedBlocks(data);
-		if (blocks.size() != 2 || !blocks.get(1).getType().isSolid()) return noTarget(data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(data);
 
-		Location target = blocks.get(0).getLocation().add(0.5, 0, 0.5);
+		Location target = result.getHitBlock().getRelative(result.getHitBlockFace()).getLocation().add(0.5, 0, 0.5);
+
 		SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, data, target);
 		if (!event.callEvent()) return noTarget(event);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -11,6 +11,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
+import org.bukkit.util.RayTraceResult;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
@@ -78,11 +79,11 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 		ItemStack item = player.getInventory().getItem(slot);
 		if (item == null || isDenied(item.getType())) return noTarget(strInvalidBlock, data);
 
-		List<Block> blocks = getLastTwoTargetedBlocks(data);
-		if (blocks.size() != 2 || blocks.get(1).getType().isAir()) return noTarget(strCantBuild, data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(strCantBuild, data);
 
-		Block block = blocks.get(0);
-		Block against = blocks.get(1);
+		Block against = result.getHitBlock();
+		Block block = against.getRelative(result.getHitBlockFace());
 		data = data.location(block.getLocation());
 
 		boolean built = build(player, block, against, item, slot, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -122,10 +122,7 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 		}
 
-		if (playBreakEffect.get(data)) {
-			if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-			else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
-		}
+		if (playBreakEffect.get(data)) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 
 		if (consumeBlock.get(data)) {
 			int amt = item.getAmount() - 1;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -209,14 +209,18 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				TargetInfo<LivingEntity> info = getTargetedEntity(data);
 				if (info.noTarget()) return noTarget(info);
 				data = info.spellData();
-			} else if (pointBlank.get(data)) {
-				SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(this, data, data.caster().getLocation());
-				if (!targetEvent.callEvent()) return noTarget(targetEvent);
-				data = targetEvent.getSpellData();
 			} else {
-				TargetInfo<Location> info = getTargetedBlockLocation(data, 0.5, yOffset.get(data) + 0.5, 0.5);
-				if (info.noTarget()) return noTarget(info);
-				data = info.spellData();
+				if (pointBlank.get(data)) {
+					SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(this, data, data.caster().getLocation());
+					if (!targetEvent.callEvent()) return noTarget(targetEvent);
+					data = targetEvent.getSpellData();
+				} else {
+					TargetInfo<Location> info = getTargetedBlockLocation(data, 0.5, 0.5, 0.5);
+					if (info.noTarget()) return noTarget(info);
+					data = info.spellData();
+				}
+
+				data = data.location(data.location().add(0, yOffset.get(data), 0));
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -343,10 +343,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 			playSpellEffectsTrail(player.getLocation(), block.getLocation(), data);
 		}
 
-		if (playBreakEffect) {
-			if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-			else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
-		}
+		if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 		if (removeBlocks) blocks.add(block);
 
 		if (resetDelay > 0 && !falling) {
@@ -361,10 +358,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 					}
 					block.setType(Material.AIR);
 					playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
-					if (playBreakEffect) {
-						if (Effect.STEP_SOUND.getData() == Material.class) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getType());
-						else block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
-					}
+					if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 				}
 			}, resetDelay);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -12,6 +12,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.util.RayTraceResult;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
@@ -142,20 +143,11 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 	public CastResult cast(SpellData data) {
 		if (!(data.caster() instanceof Player caster)) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
-		List<Block> lastTwo;
-		try {
-			lastTwo = getLastTwoTargetedBlocks(data);
-		} catch (IllegalStateException e) {
-			DebugHandler.debugIllegalState(e);
-			lastTwo = null;
-		}
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(data);
 
-		if (lastTwo == null || lastTwo.size() != 2) return noTarget(data);
-		if (!BlockUtils.isAir(lastTwo.get(0).getType()) || BlockUtils.isAir(lastTwo.get(1).getType()))
-			return noTarget(data);
-
-		Block block = lastTwo.get(0);
-		Block against = lastTwo.get(1);
+		Block against = result.getHitBlock();
+		Block block = against.getRelative(result.getHitBlockFace());
 
 		SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, data, block.getLocation());
 		if (!event.callEvent()) return noTarget(strFailed, event);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.Map;
 import java.util.Set;
 import java.util.HashSet;
+import java.util.function.Predicate;
 
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -181,6 +182,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		private final BoundingBox box;
 		private final Vector currentDirection;
 		private final Location currentLocation;
+		private final Predicate<Location> transparent;
 
 		private final Set<LivingEntity> immune;
 		private final Set<ArmorStand> armorStandSet;
@@ -243,6 +245,8 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 
 			this.data = data;
 
+			transparent = isTransparent(data);
+
 			immune = new HashSet<>();
 
 			entityMap = playSpellEntityEffects(EffectPosition.PROJECTILE, currentLocation, data);
@@ -268,7 +272,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			Location loc = getLocation();
 			data = data.location(loc);
 
-			if (!isTransparent(loc.getBlock())) {
+			if (!transparent.test(loc)) {
 				if (groundSpell != null) groundSpell.subcast(data.noTarget());
 				if (stopOnHitGround) {
 					stop(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -9,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
@@ -110,10 +111,10 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			}
 		}
 
-		List<Block> lastTwo = getLastTwoTargetedBlocks(data);
-		if (lastTwo.size() != 2) return noTarget(data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(data);
 
-		Block block = lastTwo.get(0);
+		Block block = result.getHitBlock().getRelative(result.getHitBlockFace());
 
 		int yOffset = this.yOffset.get(data);
 		if (yOffset != 0) block = block.getRelative(0, yOffset, 0);
@@ -128,7 +129,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		Location location = block.getLocation().add(0.5, 0.5, 0.5);
 		location.setDirection(location.toVector().subtract(data.caster().getLocation().toVector()));
 
-		SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, data, block.getLocation().add(0.5, 0.5, 0.5));
+		SpellTargetLocationEvent event = new SpellTargetLocationEvent(this, data, location);
 		if (!event.callEvent()) return noTarget(event);
 
 		event.setTargetLocation(event.getTargetLocation().toCenterLocation());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -15,6 +15,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.potion.PotionEffect;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.potion.PotionEffectType;
 import org.bukkit.inventory.EntityEquipment;
@@ -276,9 +277,10 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 					data = targetEvent.getSpellData();
 				}
 				case "target" -> {
-					Block block = getTargetedBlock(data);
-					if (block.getType().isAir()) return noTarget(data);
+					RayTraceResult result = rayTraceBlocks(data);
+					if (result == null) return noTarget(data);
 
+					Block block = result.getHitBlock();
 					if (!block.isPassable()) {
 						Block upper = block.getRelative(BlockFace.UP);
 						if (!upper.isPassable()) return noTarget(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnTntSpell.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.spells.targeted;
 
 import java.util.Map;
-import java.util.List;
 import java.util.HashMap;
 
 import org.bukkit.Location;
@@ -10,6 +9,7 @@ import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.TNTPrimed;
 import org.bukkit.event.EventHandler;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.event.entity.EntityExplodeEvent;
 
 import com.nisovin.magicspells.util.*;
@@ -64,11 +64,11 @@ public class SpawnTntSpell extends TargetedSpell implements TargetedLocationSpel
 
 	@Override
 	public CastResult cast(SpellData data) {
-		List<Block> blocks = getLastTwoTargetedBlocks(data);
-		if (blocks.size() != 2) return noTarget(data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(data);
 
-		Block prev = blocks.get(0), last = blocks.get(1);
-		if (!last.isSolid()) return noTarget(data);
+		Block last = result.getHitBlock();
+		Block prev = last.getRelative(result.getHitBlockFace());
 
 		Location location = prev.getLocation().add(0.5, 0, 0.5);
 		location.setDirection(location.toVector().subtract(data.caster().getLocation().toVector()));

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -8,10 +8,10 @@ import java.util.HashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.Sign;
-import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.command.CommandSender;
 import org.bukkit.event.player.PlayerCommandPreprocessEvent;
 
@@ -66,10 +66,10 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 			targetName = data.args()[0];
 			landLoc = data.caster().getLocation().add(0, .25, 0);
 		} else {
-			Block block = getTargetedBlock(data.power(10));
-			if (block != null && block.getState() instanceof Sign sign) {
+			RayTraceResult result = rayTraceBlocks(data.power(10));
+			if (result != null && result.getHitBlock().getState() instanceof Sign sign) {
 				targetName = Util.getStringFromComponent(sign.line(0));
-				landLoc = block.getLocation().add(.5, .25, .5);
+				landLoc = sign.getLocation().add(.5, .25, .5);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TelekinesisSpell.java
@@ -1,20 +1,22 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import java.util.HashSet;
-
 import org.bukkit.Tag;
+import org.bukkit.World;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
+import org.bukkit.util.Vector;
 import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.Event.Result;
 import org.bukkit.event.block.Action;
+import org.bukkit.util.RayTraceResult;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
+import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 import com.nisovin.magicspells.events.MagicSpellsPlayerInteractEvent;
 
 public class TelekinesisSpell extends TargetedSpell implements TargetedLocationSpell {
@@ -25,17 +27,35 @@ public class TelekinesisSpell extends TargetedSpell implements TargetedLocationS
 		super(config, spellName);
 
 		checkPlugins = getConfigDataBoolean("check-plugins", true);
-
-		losTransparentBlocks = new HashSet<>(losTransparentBlocks);
-		losTransparentBlocks.removeIf(type -> type == Material.LEVER || Tag.BUTTONS.isTagged(type) || Tag.PRESSURE_PLATES.isTagged(type));
 	}
 
 	@Override
 	public CastResult cast(SpellData data) {
-		TargetInfo<Location> info = getTargetedBlockLocation(data);
-		if (info.noTarget()) return noTarget(info);
+		Location start = data.caster().getEyeLocation();
+		Vector direction = start.getDirection();
+		World world = start.getWorld();
 
-		return castAtLocation(info.spellData());
+		boolean losIgnorePassableBlocks = this.losIgnorePassableBlocks.get(data);
+		int range = getRange(data);
+
+		RayTraceResult result = world.rayTraceBlocks(start, direction, range, losFluidCollisionMode.get(data), false,
+			block -> {
+				Material type = block.getType();
+				return checkType(type) || !losIgnorePassableBlocks || !block.isPassable() || !losTransparentBlocks.contains(type);
+			}
+		);
+		if (result == null) return noTarget(data);
+
+		Block block = result.getHitBlock();
+		if (!checkType(block.getType())) {
+			block = block.getRelative(result.getHitBlockFace());
+			if (!checkType(block.getType())) return noTarget(data);
+		}
+
+		SpellTargetLocationEvent targetEvent = new SpellTargetLocationEvent(this, data, block.getLocation());
+		if (!targetEvent.callEvent()) return noTarget(targetEvent);
+
+		return activate(targetEvent.getTargetLocation().getBlock(), targetEvent.getSpellData());
 	}
 
 	@Override
@@ -43,9 +63,12 @@ public class TelekinesisSpell extends TargetedSpell implements TargetedLocationS
 		Block block = data.location().getBlock();
 
 		Material type = block.getType();
-		if (type != Material.LEVER && !Tag.BUTTONS.isTagged(type) && !Tag.PRESSURE_PLATES.isTagged(type))
-			return noTarget(data);
+		if (!checkType(type)) return noTarget(data);
 
+		return activate(block, data);
+	}
+
+	private CastResult activate(Block block, SpellData data) {
 		if (checkPlugins.get(data) && data.caster() instanceof Player caster) {
 			MagicSpellsPlayerInteractEvent event = new MagicSpellsPlayerInteractEvent(caster, Action.RIGHT_CLICK_BLOCK, caster.getEquipment().getItemInMainHand(), block, BlockFace.SELF);
 			event.callEvent();
@@ -57,6 +80,10 @@ public class TelekinesisSpell extends TargetedSpell implements TargetedLocationS
 		playSpellEffects(data);
 
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	private boolean checkType(Material type) {
+		return type == Material.LEVER || Tag.BUTTONS.isTagged(type) || Tag.PRESSURE_PLATES.isTagged(type);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.ArmorStand;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerArmorStandManipulateEvent;
@@ -194,9 +195,8 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			}
 		}
 
-		List<Block> lastTwo = getLastTwoTargetedBlocks(data);
-		if (lastTwo.size() != 2) return noTarget(data);
-		Block target = lastTwo.get(0);
+		RayTraceResult result = rayTraceBlocks(data);
+		Block target = result.getHitBlock().getRelative(result.getHitBlockFace());
 
 		int yOffset = this.yOffset.get(data);
 		if (yOffset != 0) target = target.getRelative(0, yOffset, 0);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VinesSpell.java
@@ -1,13 +1,13 @@
 package com.nisovin.magicspells.spells.targeted;
 
 import java.util.Set;
-import java.util.List;
 import java.util.TreeSet;
 
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.block.BlockFace;
 import org.bukkit.block.BlockState;
+import org.bukkit.util.RayTraceResult;
 import org.bukkit.block.data.MultipleFacing;
 
 import com.nisovin.magicspells.util.*;
@@ -32,11 +32,14 @@ public class VinesSpell extends TargetedSpell {
 
 	@Override
 	public CastResult cast(SpellData data) {
-		List<Block> target = getLastTwoTargetedBlocks(data);
-		if (target.size() != 2) return noTarget(data);
+		RayTraceResult result = rayTraceBlocks(data);
+		if (result == null) return noTarget(data);
 
-		Block air = target.get(0), solid = target.get(1);
-		if (!air.getType().isAir() || !solid.isSolid()) return noTarget(data);
+		Block solid = result.getHitBlock();
+		if (!solid.isSolid()) return noTarget(data);
+
+		Block air = solid.getRelative(result.getHitBlockFace());
+		if (!air.getType().isAir()) return noTarget(data);
 
 		return growVines(data, air, solid);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ZapSpell.java
@@ -84,10 +84,7 @@ public class ZapSpell extends TargetedSpell implements TargetedLocationSpell {
 			if (!event.callEvent()) return noTarget(strCantZap, data);
 		}
 
-		if (playBreakEffect.get(data)) {
-			if (Effect.STEP_SOUND.getData() == Material.class) target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getType());
-			else target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getBlockData());
-		}
+		if (playBreakEffect.get(data)) target.getWorld().playEffect(target.getLocation(), Effect.STEP_SOUND, target.getBlockData());
 
 		if (dropBlock.get(data)) {
 			if (dropNormal.get(data)) target.breakNaturally();

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -97,29 +97,10 @@ ignore-cast-item-durability:
 check-world-pvp-flag: true
 check-scoreboard-teams: false
 show-str-cost-on-missing-reagents: true
-los-transparent-blocks:
-    - "air"
-    - "cave_air"
-    - "void_air"
-    - "powered_rail"
-    - "detector_rail"
-    - "grass"
-    - "fern"
-    - "dead_bush"
-    - "dandelion"
-    - "poppy"
-    - "brown_mushroom"
-    - "red_mushroom"
-    - "torch"
-    - "fire"
-    - "redstone_wire"
-    - "ladder"
-    - "rail"
-    - "lever"
-    - "redstone_torch"
-    - "repeater"
-    - "vine"
-    - "lily_pad"
+los-transparent-blocks: []
+los-ray-size: 0.2
+los-ignore-passable-blocks: true
+los-fluid-collision-mode: always
 global-radius: 500
 global-cooldown: 500
 cast-on-animate: false


### PR DESCRIPTION
- Entity and block/location target checks now take into account accurate hitboxes and shapes of entities/blocks.
  + Added the `los-ray-size` option to `general.yml`. Defaults to `0.2`. Determines the size of the ray used for checking line of sight to entities when retrieving an entity target.
  + Added the `los-ignore-passable-blocks` option to `general.yml`. Defaults to `true`. When `true`, passable blocks (blocks that do not have any colliding parts that stop movement) are ignored for entity/location targeting. For example, air and tall grass are passable.
  + Added the `los-fluid-collision-mode` option to `general.yml`. Defaults to `never`, and has the values `always`, `never` and `source_only` as according to [here](https://jd.papermc.io/paper/1.20/org/bukkit/FluidCollisionMode.html). Determines whether or not fluids are collided with when retrieving entity/location targets.
  + `los-transparent-blocks` now defaults to an empty list. The `AIR`, `CAVE_AIR` and `VOID_AIR` are still automatically added to an empty list for `los-transparent-blocks`, however.
  + Note: some spells still do not take into account accurate collision shapes. These spells include, but are not limited to, `BeamSpell`, `BlockBeamSpell`, `OrbitSpell`, `ParticleProjectileSpell` and `HomingMissileSpell`.

- Fixed an issue where `location-modifiers` for `LoopSpell` were checked after applying `y-offset` to the targeted location, instead of before.