### PR TITLE
Magic Item Adjustments, Bugfixes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         run: echo "sha_short=$(git rev-parse --short ${{github.sha}})" >> $GITHUB_OUTPUT
       - name: Get version
         id: version
-        run: echo "version=$(grep version gradle.properties | cut -d"=" -f2)" >> $GITHUB_OUTPUT
+        run: echo "version=$(grep version gradle.properties | cut -d"=" -f2 | xargs)" >> $GITHUB_OUTPUT
       - name: Setup Java
         uses: actions/setup-java@v3
         with:

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -555,7 +555,7 @@ public class MagicCommand extends BaseCommand {
 		if (player == null) player = getPlayerFromIssuer(issuer);
 		if (player == null) return;
 
-		ItemStack item = magicItem.getItemStack();
+		ItemStack item = magicItem.getItemStack().clone();
 		item.setAmount(amount);
 		player.getInventory().addItem(item);
 		issuer.sendMessage(MagicSpells.getTextColor() + player.getName() + " received a magic item (" + args[0] + " x" + amount + ").");

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ReachSpell.java
@@ -136,7 +136,7 @@ public class ReachSpell extends BuffSpell {
 			}
 
 			addUseAndChargeCost(player);
-		} else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK && airBlock.getType().isAir()) {
+		} else if (action == Action.RIGHT_CLICK_AIR || action == Action.RIGHT_CLICK_BLOCK && airBlock.isReplaceable()) {
 			// Place
 			ItemStack item = player.getInventory().getItemInMainHand();
 			if (item.isEmpty()) return;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
@@ -58,6 +58,10 @@ public class ItemSerializeSpell extends CommandSpell {
 		}
 
 		ConfigurationSection section = AlternativeReaderManager.serialize(serializerKey.get(data), item);
+		if (section == null) {
+			sendMessage("Unable to serialize item.", caster);
+			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
+		}
 
 		YamlConfiguration config = new YamlConfiguration();
 		config.set("magic-items." + System.currentTimeMillis(), section);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/BuildSpell.java
@@ -12,6 +12,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.block.BlockState;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.RayTraceResult;
+import org.bukkit.block.data.BlockData;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
@@ -110,8 +111,13 @@ public class BuildSpell extends TargetedSpell implements TargetedLocationSpell {
 	}
 
 	private boolean build(Player player, Block block, Block against, ItemStack item, int slot, SpellData data) {
+		if (!block.isReplaceable()) return false;
+
+		BlockData blockData = item.getType().createBlockData();
+		if (!block.canPlace(blockData)) return false;
+
 		BlockState previousState = block.getState();
-		block.setType(item.getType());
+		block.setBlockData(blockData);
 
 		if (checkPlugins.get(data)) {
 			MagicSpellsBlockPlaceEvent event = new MagicSpellsBlockPlaceEvent(block, previousState, against, player.getEquipment().getItemInMainHand(), player, true);

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/LoreHandler.java
@@ -21,15 +21,15 @@ public class LoreHandler {
 
 		List<Component> lore = new ArrayList<>();
 		if (config.isList(CONFIG_NAME)) {
-			for (String line : config.getStringList(CONFIG_NAME)) {
+			for (String line : config.getStringList(CONFIG_NAME))
 				lore.add(Util.getMiniMessage(line));
-			}
 		} else if (config.isString(CONFIG_NAME)) {
 			lore.add(Util.getMiniMessage(config.getString(CONFIG_NAME)));
 		}
 		if (lore.isEmpty()) return;
+
 		meta.lore(lore);
-		data.setAttribute(LORE, lore);
+		data.setAttribute(LORE, meta.lore());
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/SkullHandler.java
@@ -74,14 +74,7 @@ public class SkullHandler {
 		if (data.hasAttribute(SKULL_OWNER)) skullOwner = (String) data.getAttribute(SKULL_OWNER);
 		if (data.hasAttribute(SIGNATURE)) signature = (String) data.getAttribute(SIGNATURE);
 		if (data.hasAttribute(TEXTURE)) texture = (String) data.getAttribute(TEXTURE);
-
-		if (data.hasAttribute(MagicItemAttribute.UUID)) {
-			try {
-				uuid = UUID.fromString((String) data.getAttribute(MagicItemAttribute.UUID));
-			} catch (IllegalArgumentException e) {
-				DebugHandler.debugIllegalArgumentException(e);
-			}
-		}
+		if (data.hasAttribute(MagicItemAttribute.UUID)) uuid = (UUID) data.getAttribute(MagicItemAttribute.UUID);
 
 		if ((uuid != null || skullOwner != null) && texture != null) {
 			PlayerProfile profile = Bukkit.createProfile(uuid, skullOwner);
@@ -98,7 +91,7 @@ public class SkullHandler {
 		if (profile == null) return;
 
 		UUID id = profile.getId();
-		if (id != null) data.setAttribute(MagicItemAttribute.UUID, id.toString());
+		if (id != null) data.setAttribute(MagicItemAttribute.UUID, id);
 
 		String name = profile.getName();
 		if (name != null) data.setAttribute(SKULL_OWNER, name);

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/WrittenBookHandler.java
@@ -25,60 +25,52 @@ public class WrittenBookHandler {
 		if (!(meta instanceof BookMeta bookMeta)) return;
 
 		if (config.isString(TITLE_CONFIG_NAME)) {
-			String title = Util.colorize(config.getString(TITLE_CONFIG_NAME));
+			Component title = Util.getMiniMessage(config.getString(TITLE_CONFIG_NAME));
 
-			bookMeta.setTitle(title);
-			data.setAttribute(TITLE, title);
+			bookMeta.title(title);
+			data.setAttribute(TITLE, bookMeta.title());
 		}
 
 		if (config.isString(AUTHOR_CONFIG_NAME)) {
-			String author = Util.colorize(config.getString(AUTHOR_CONFIG_NAME));
+			Component author = Util.getMiniMessage(config.getString(AUTHOR_CONFIG_NAME));
 
-			bookMeta.setAuthor(author);
-			data.setAttribute(AUTHOR, author);
+			bookMeta.author(author);
+			data.setAttribute(AUTHOR, bookMeta.author());
 		}
 
 		if (config.isList(PAGES_CONFIG_NAME)) {
 			List<Component> pages = new ArrayList<>();
-			for (String page : config.getStringList(PAGES_CONFIG_NAME)) {
-				pages.add(Util.getMiniMessage(page));
-			}
+			for (String page : config.getStringList(PAGES_CONFIG_NAME)) pages.add(Util.getMiniMessage(page));
 
 			if (pages.isEmpty()) return;
+
 			bookMeta.pages(pages);
-			data.setAttribute(PAGES, pages);
+			data.setAttribute(PAGES, bookMeta.pages());
 		}
 	}
 
 	public static void processItemMeta(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BookMeta bookMeta)) return;
 
-		if (data.hasAttribute(TITLE)) bookMeta.setTitle((String) data.getAttribute(TITLE));
-		if (data.hasAttribute(AUTHOR)) bookMeta.setAuthor((String) data.getAttribute(AUTHOR));
+		if (data.hasAttribute(TITLE)) bookMeta.title((Component) data.getAttribute(TITLE));
+		if (data.hasAttribute(AUTHOR)) bookMeta.author((Component) data.getAttribute(AUTHOR));
 		if (data.hasAttribute(PAGES)) bookMeta.pages((List<Component>) data.getAttribute(PAGES));
 	}
 
 	public static void processMagicItemData(ItemMeta meta, MagicItemData data) {
 		if (!(meta instanceof BookMeta bookMeta)) return;
 
-		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.getAuthor());
-		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.getTitle());
-		if (bookMeta.hasPages()) {
-			List<Component> pages = bookMeta.pages();
-			if (!pages.isEmpty()) data.setAttribute(PAGES, pages);
-		}
+		if (bookMeta.hasAuthor()) data.setAttribute(AUTHOR, bookMeta.author());
+		if (bookMeta.hasTitle()) data.setAttribute(TITLE, bookMeta.title());
+		if (bookMeta.hasPages()) data.setAttribute(PAGES, bookMeta.pages());
 	}
 
-	public static String getTitle(ItemMeta meta) {
-		if (!(meta instanceof BookMeta)) return null;
-
-		return ((BookMeta) meta).getTitle();
+	public static Component getTitle(ItemMeta meta) {
+		return meta instanceof BookMeta bookMeta ? bookMeta.title() : null;
 	}
 
-	public static String getAuthor(ItemMeta meta) {
-		if (!(meta instanceof BookMeta)) return null;
-
-		return ((BookMeta) meta).getAuthor();
+	public static Component getAuthor(ItemMeta meta) {
+		return meta instanceof BookMeta bookMeta ? bookMeta.author() : null;
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/AlternativeReaderManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/AlternativeReaderManager.java
@@ -18,6 +18,7 @@ public class AlternativeReaderManager {
 	
 	static {
 		register(new SpigotReader());
+		register(new VanillaReader());
 	}
 	
 	public static ItemConfigTransformer getReader(String type) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/VanillaReader.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/VanillaReader.java
@@ -1,0 +1,47 @@
+package com.nisovin.magicspells.util.itemreader.alternative;
+
+import org.bukkit.Bukkit;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.configuration.file.YamlConfiguration;
+
+public class VanillaReader implements ItemConfigTransformer {
+
+	@Override
+	public ItemStack deserialize(ConfigurationSection section) {
+		if (section == null) return null;
+
+		String data = section.getString("data");
+		if (data == null) return null;
+
+		ItemStack item;
+		try {
+			item = Bukkit.getItemFactory().createItemStack(data);
+		} catch (IllegalArgumentException e) {
+			return null;
+		}
+
+		item.setAmount(section.getInt("amount", 1));
+
+		return item;
+	}
+
+	@Override
+	public ConfigurationSection serialize(ItemStack itemStack) {
+		YamlConfiguration configuration = new YamlConfiguration();
+
+		String data = itemStack.getType().getKey().toString();
+		if (itemStack.hasItemMeta()) data += itemStack.getItemMeta().getAsString();
+
+		configuration.set("data", data);
+		configuration.set("amount", itemStack.getAmount());
+
+		return configuration;
+	}
+
+	@Override
+	public String getReaderKey() {
+		return "external::vanilla";
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -26,13 +26,12 @@ import org.bukkit.enchantments.Enchantment;
 import org.bukkit.attribute.AttributeModifier;
 
 import com.nisovin.magicspells.util.Util;
-import com.nisovin.magicspells.util.TxtUtil;
 
 public class MagicItemData {
 
-	private final EnumMap<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
-	private final EnumSet<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
-	private final EnumSet<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+	private final Map<MagicItemAttribute, Object> itemAttributes = new EnumMap<>(MagicItemAttribute.class);
+	private final Set<MagicItemAttribute> blacklistedAttributes = EnumSet.noneOf(MagicItemAttribute.class);
+	private final Set<MagicItemAttribute> ignoredAttributes = EnumSet.noneOf(MagicItemAttribute.class);
 
 	private boolean strictEnchantLevel = true;
 	private boolean strictDurability = true;
@@ -58,11 +57,11 @@ public class MagicItemData {
 		return itemAttributes.containsKey(atr);
 	}
 
-	public EnumSet<MagicItemAttribute> getBlacklistedAttributes() {
+	public Set<MagicItemAttribute> getBlacklistedAttributes() {
 		return blacklistedAttributes;
 	}
 
-	public EnumSet<MagicItemAttribute> getIgnoredAttributes() {
+	public Set<MagicItemAttribute> getIgnoredAttributes() {
 		return ignoredAttributes;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemData.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.util.magicitems;
 import java.util.Map;
 import java.util.Set;
 import java.util.List;
+import java.util.UUID;
 import java.util.EnumMap;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -16,7 +17,7 @@ import com.google.gson.JsonObject;
 import net.kyori.adventure.text.Component;
 
 import org.bukkit.*;
-import org.bukkit.potion.PotionData;
+import org.bukkit.potion.PotionType;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.block.banner.Pattern;
@@ -162,6 +163,12 @@ public class MagicItemData {
 				case ATTRIBUTES -> {
 					if (!hasEqualAttributes(data)) return false;
 				}
+				case AUTHOR, NAME, TITLE -> {
+					String legacySelf = Util.getLegacyFromComponent((Component) itemAttributes.get(attr));
+					String legacyOther = Util.getLegacyFromComponent((Component) data.itemAttributes.get(attr));
+
+					if (!legacySelf.equals(legacyOther)) return false;
+				}
 				case BLOCK_DATA -> {
 					BlockData blockDataSelf = (BlockData) itemAttributes.get(attr);
 					BlockData blockDataOther = (BlockData) data.itemAttributes.get(attr);
@@ -205,22 +212,17 @@ public class MagicItemData {
 						if (strictEnchantLevel ? compare != 0 : compare > 0) return false;
 					}
 				}
-				case NAME -> {
-					Component nameSelf = (Component) itemAttributes.get(attr);
-					Component nameOther = (Component) data.itemAttributes.get(attr);
-					return Util.getLegacyFromComponent(nameSelf).equals(Util.getLegacyFromComponent(nameOther));
-				}
-				case LORE -> {
-					List<Component> loreSelf = (List<Component>) itemAttributes.get(attr);
-					List<Component> loreOther = (List<Component>) data.itemAttributes.get(attr);
-					if (loreSelf.size() != loreOther.size()) return false;
+				case LORE, PAGES -> {
+					List<Component> componentsSelf = (List<Component>) itemAttributes.get(attr);
+					List<Component> componentsOther = (List<Component>) data.itemAttributes.get(attr);
+					if (componentsSelf.size() != componentsOther.size()) return false;
 
-					for (int i = 0; i < loreSelf.size(); i++) {
-						String self = Util.getLegacyFromComponent(loreSelf.get(i));
-						String other = Util.getLegacyFromComponent(loreOther.get(i));
-						if (!self.equals(other)) return false;
+					for (int i = 0; i < componentsSelf.size(); i++) {
+						String legacySelf = Util.getLegacyFromComponent(componentsSelf.get(i));
+						String legacyOther = Util.getLegacyFromComponent(componentsOther.get(i));
+
+						if (!legacySelf.equals(legacyOther)) return false;
 					}
-					return true;
 				}
 				default -> {
 					if (!itemAttributes.get(attr).equals(data.itemAttributes.get(attr))) return false;
@@ -268,12 +270,12 @@ public class MagicItemData {
 		UNBREAKABLE(Boolean.class),
 		HIDE_TOOLTIP(Boolean.class),
 		FAKE_GLINT(Boolean.class),
-		POTION_DATA(PotionData.class),
+		POTION_TYPE(PotionType.class),
 		COLOR(Color.class),
 		FIREWORK_EFFECT(FireworkEffect.class),
-		TITLE(String.class),
-		AUTHOR(String.class),
-		UUID(String.class),
+		TITLE(Component.class),
+		AUTHOR(Component.class),
+		UUID(UUID.class),
 		TEXTURE(String.class),
 		SIGNATURE(String.class),
 		SKULL_OWNER(String.class),
@@ -338,14 +340,9 @@ public class MagicItemData {
 			magicItem.addProperty("color", Integer.toHexString(color.asRGB()));
 		}
 
-		if (hasAttribute(MagicItemAttribute.POTION_DATA)) {
-			PotionData potionData = (PotionData) getAttribute(MagicItemAttribute.POTION_DATA);
-
-			String potionDataString = potionData.getType().toString();
-			if (potionData.isExtended()) potionDataString += " extended";
-			else if (potionData.isUpgraded()) potionDataString += " upgraded";
-
-			magicItem.addProperty("potion-data", potionDataString);
+		if (hasAttribute(MagicItemAttribute.POTION_TYPE)) {
+			PotionType potionType = (PotionType) getAttribute(MagicItemAttribute.POTION_TYPE);
+			magicItem.addProperty("potion-type", potionType.getKey().getKey());
 		}
 
 		if (hasAttribute(MagicItemAttribute.FIREWORK_EFFECT)) {
@@ -390,13 +387,13 @@ public class MagicItemData {
 			magicItem.addProperty("skull-owner", (String) getAttribute(MagicItemAttribute.SKULL_OWNER));
 
 		if (hasAttribute(MagicItemAttribute.TITLE))
-			magicItem.addProperty("title", (String) getAttribute(MagicItemAttribute.TITLE));
+			magicItem.addProperty("title", Util.getStringFromComponent((Component) getAttribute(MagicItemAttribute.TITLE)));
 
 		if (hasAttribute(MagicItemAttribute.AUTHOR))
-			magicItem.addProperty("author", (String) getAttribute(MagicItemAttribute.AUTHOR));
+			magicItem.addProperty("author", Util.getStringFromComponent((Component) getAttribute(MagicItemAttribute.AUTHOR)));
 
 		if (hasAttribute(MagicItemAttribute.UUID))
-			magicItem.addProperty("uuid", (String) getAttribute(MagicItemAttribute.UUID));
+			magicItem.addProperty("uuid", getAttribute(MagicItemAttribute.UUID).toString());
 
 		if (hasAttribute(MagicItemAttribute.TEXTURE))
 			magicItem.addProperty("texture", (String) getAttribute(MagicItemAttribute.TEXTURE));

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -1,12 +1,6 @@
 package com.nisovin.magicspells.util.magicitems;
 
-import java.util.Map;
-import java.util.Set;
-import java.util.List;
-import java.util.EnumSet;
-import java.util.HashMap;
-import java.util.ArrayList;
-
+import java.util.*;
 import java.io.IOException;
 import java.io.StringReader;
 
@@ -30,7 +24,6 @@ import org.bukkit.Bukkit;
 import org.bukkit.DyeColor;
 import org.bukkit.Material;
 import org.bukkit.FireworkEffect;
-import org.bukkit.potion.PotionData;
 import org.bukkit.potion.PotionType;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.attribute.Attribute;
@@ -46,6 +39,7 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.AttributeUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.handlers.EnchantmentHandler;
+import com.nisovin.magicspells.util.itemreader.PotionHandler;
 import com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute;
 import static com.nisovin.magicspells.util.magicitems.MagicItemData.MagicItemAttribute.*;
 
@@ -152,6 +146,7 @@ public class MagicItemDataParser {
 							data.setAttribute(HIDE_TOOLTIP, value.getAsBoolean());
 							break;
 						case "color":
+						case "potion-color":
 							try {
 								Color color = Color.fromRGB(Integer.parseInt(value.getAsString().replace("#", ""), 16));
 								data.setAttribute(COLOR, color);
@@ -165,23 +160,15 @@ public class MagicItemDataParser {
 						case "potiontype":
 						case "potion-type":
 						case "potion_type":
-							String[] potionDataArgs = value.getAsString().split(" ");
+							String potionTypeString = value.getAsString();
 
-							try {
-								PotionType potionType = PotionType.valueOf(potionDataArgs[0].toUpperCase());
-								boolean extended = false, upgraded = false;
-
-								if (potionDataArgs.length > 1) {
-									if (potionDataArgs[1].equalsIgnoreCase("extended")) extended = true;
-									else if (potionDataArgs[1].equalsIgnoreCase("upgraded")) upgraded = true;
-								}
-
-								PotionData potionData = new PotionData(potionType, extended, upgraded);
-
-								data.setAttribute(POTION_DATA, potionData);
-							} catch (IllegalArgumentException e) {
-								DebugHandler.debugIllegalArgumentException(e);
+							PotionType potionType = PotionHandler.getPotionType(potionTypeString);
+							if (potionType == null) {
+								MagicSpells.error("Invalid potion type '" + potionTypeString + "'.");
+								continue;
 							}
+
+							data.setAttribute(POTION_TYPE, potionType);
 							break;
 						case "fireworkeffect":
 						case "firework-effect":
@@ -217,13 +204,20 @@ public class MagicItemDataParser {
 							data.setAttribute(SKULL_OWNER, value.getAsString());
 							break;
 						case "title":
-							data.setAttribute(TITLE, Util.colorize(value.getAsString()));
+							data.setAttribute(TITLE, Util.getMiniMessage(value.getAsString()));
 							break;
 						case "author":
-							data.setAttribute(AUTHOR, Util.colorize(value.getAsString()));
+							data.setAttribute(AUTHOR, Util.getMiniMessage(value.getAsString()));
 							break;
 						case "uuid":
-							data.setAttribute(UUID, value.getAsString());
+							String uuidString = value.getAsString();
+							try {
+								java.util.UUID uuid = java.util.UUID.fromString(uuidString);
+								data.setAttribute(UUID, uuid);
+							} catch (IllegalArgumentException e) {
+								MagicSpells.error("Invalid UUID '" + uuidString + "'.");
+								continue;
+							}
 							break;
 						case "texture":
 							data.setAttribute(TEXTURE, value.getAsString());

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -416,7 +416,7 @@ public class MagicItemDataParser {
 						case "ignored-attributes":
 						case "ignored_attributes":
 							if (!value.isJsonArray()) continue;
-							EnumSet<MagicItemAttribute> ignoredAttributes = data.getIgnoredAttributes();
+							Set<MagicItemAttribute> ignoredAttributes = data.getIgnoredAttributes();
 							JsonArray ignoredAttributeStrings = value.getAsJsonArray();
 
 							for (JsonElement element : ignoredAttributeStrings) {
@@ -432,7 +432,7 @@ public class MagicItemDataParser {
 						case "blacklisted-attributes":
 						case "blacklisted_attributes":
 							if (!value.isJsonArray()) continue;
-							EnumSet<MagicItemAttribute> blacklistedAttributes = data.getBlacklistedAttributes();
+							Set<MagicItemAttribute> blacklistedAttributes = data.getBlacklistedAttributes();
 							JsonArray blacklistedAttributeStrings = value.getAsJsonArray();
 
 							for (JsonElement element : blacklistedAttributeStrings) {

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -188,16 +188,13 @@ public class MagicItemDataParser {
 						case "firework_effect":
 							String[] effectString = value.getAsString().split(" ");
 
-							if (effectString.length >= 4) {
+							if (effectString.length >= 3 && effectString.length <= 5) {
 								try {
 									FireworkEffect.Type fireworkType = FireworkEffect.Type.valueOf(effectString[0].toUpperCase());
 									boolean trail = Boolean.parseBoolean(effectString[1]);
 									boolean flicker = Boolean.parseBoolean(effectString[2]);
-									Color[] colors = Util.getColorsFromString(effectString[3]);
-									Color[] fadeColors = null;
-
-									if (effectString.length > 4) fadeColors = Util.getColorsFromString(effectString[4]);
-									if (fadeColors == null) fadeColors = new Color[0];
+									Color[] colors = effectString.length > 3 ? Util.getColorsFromString(effectString[3]) : new Color[0];
+									Color[] fadeColors = effectString.length > 4 ? Util.getColorsFromString(effectString[4]) : new Color[0];
 
 									FireworkEffect effect = FireworkEffect.builder()
 										.flicker(flicker)
@@ -389,16 +386,13 @@ public class MagicItemDataParser {
 							for (JsonElement eff : fireworkEffectStrings) {
 								String[] effString = eff.getAsString().split(" ");
 
-								if (effString.length == 4 || effString.length == 5) {
+								if (effString.length >= 3 && effString.length <= 5) {
 									try {
 										FireworkEffect.Type fireworkType = FireworkEffect.Type.valueOf(effString[0].toUpperCase());
 										boolean trail = Boolean.parseBoolean(effString[1]);
 										boolean flicker = Boolean.parseBoolean(effString[2]);
-										Color[] colors = Util.getColorsFromString(effString[3]);
-										Color[] fadeColors = null;
-
-										if (effString.length > 4) fadeColors = Util.getColorsFromString(effString[4]);
-										if (fadeColors == null) fadeColors = new Color[0];
+										Color[] colors = effString.length > 3 ? Util.getColorsFromString(effString[3]) : new Color[0];
+										Color[] fadeColors = effString.length > 4 ? Util.getColorsFromString(effString[4]) : new Color[0];
 
 										FireworkEffect effect = FireworkEffect.builder()
 											.flicker(flicker)

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItems.java
@@ -303,7 +303,7 @@ public class MagicItems {
 				MagicItem magicItem = new MagicItem(item, getMagicItemDataFromItemStack(item));
 
 				if (section.isList("ignored-attributes")) {
-					EnumSet<MagicItemAttribute> ignoredAttributes = magicItem.getMagicItemData().getIgnoredAttributes();
+					Set<MagicItemAttribute> ignoredAttributes = magicItem.getMagicItemData().getIgnoredAttributes();
 					List<String> ignoredAttributeStrings = section.getStringList("ignored-attributes");
 
 					for (String attr : ignoredAttributeStrings) {
@@ -316,7 +316,7 @@ public class MagicItems {
 				}
 
 				if (section.isList("blacklisted-attributes")) {
-					EnumSet<MagicItemAttribute> blacklistedAttributes = magicItem.getMagicItemData().getBlacklistedAttributes();
+					Set<MagicItemAttribute> blacklistedAttributes = magicItem.getMagicItemData().getBlacklistedAttributes();
 					List<String> blacklistedAttributeStrings = section.getStringList("blacklisted-attributes");
 
 					for (String attr : blacklistedAttributeStrings) {
@@ -512,7 +512,7 @@ public class MagicItems {
 
 			if (section.isList("ignored-attributes")) {
 				List<String> ignoredAttributeStrings = section.getStringList("ignored-attributes");
-				EnumSet<MagicItemAttribute> ignoredAttributes = itemData.getIgnoredAttributes();
+				Set<MagicItemAttribute> ignoredAttributes = itemData.getIgnoredAttributes();
 
 				for (String attr : ignoredAttributeStrings) {
 					try {
@@ -525,7 +525,7 @@ public class MagicItems {
 
 			if (section.isList("blacklisted-attributes")) {
 				List<String> blacklistedAttributeStrings = section.getStringList("blacklisted-attributes");
-				EnumSet<MagicItemAttribute> blacklistedAttributes = itemData.getBlacklistedAttributes();
+				Set<MagicItemAttribute> blacklistedAttributes = itemData.getBlacklistedAttributes();
 
 				for (String attr : blacklistedAttributeStrings) {
 					try {


### PR DESCRIPTION
## Additions
- The `title` and `author` options of magic items now support MiniMessage.
- Magic items now support the `external::vanilla` serialization type. This format for items is the same as the vanilla `/give` command.

## Changes
- `ReachSpell` now supports placing blocks in blocks tagged as replaceable, instead of just air blocks.
- `BuildSpell` and `PulserSpell` now check if the block they attempt to set is placeable in the target location.
- The `potion-color` option of magic items has been replaced by the `color` option, for consistency.
- The `potion-data` option of magic items has been replaced by the `potion-type` option. The previous format, `<potion type> [extended/upgraded]`, is now just `<potion type>`, as extended/upgraded potion types are now their own, separate values.

## Bugfixes
- Fixed an issue where the `/ms magicitem` command modified the stored item stack version of a magic item.
- Fixed an issue with the `uuid` option of magic items that could cause an error.
- Fixed an issue that caused magic items using the `name` or `lore` options to match improperly.