### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
@@ -26,11 +26,8 @@ public class CleanseSpell extends TargetedSpell implements TargetedEntitySpell {
 	@Override
 	public void initialize() {
 		super.initialize();
-		try {
-			cleansers = new Cleansers(cleanseList);
-		} catch (IllegalArgumentException exception) {
-			MagicSpells.error("CleanseSpell '" + internalName + "' has an invalid item listed under 'remove': '" + exception.getMessage() + "'");
-		}
+
+		cleansers = new Cleansers(cleanseList, internalName);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -70,8 +70,6 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		if (preventChat) silenced = new ConcurrentHashMap<>();
 		else silenced = new HashMap<>();
-
-		validTargetList = new ValidTargetList(true, false);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/Cleansers.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/Cleansers.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.LivingEntity;
 
 import org.jetbrains.annotations.NotNull;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.handlers.DebugHandler;
 import com.nisovin.magicspells.util.ValidTargetChecker;
 import com.nisovin.magicspells.spells.targeted.cleanse.*;
@@ -34,7 +35,7 @@ public class Cleansers {
 
 	private Cleansers() {}
 
-	public Cleansers(List<String> toCleanse) throws IllegalArgumentException {
+	public Cleansers(List<String> toCleanse, String spellName) {
 		try {
 			for (Class<? extends Cleanser> clazz : cleanserClasses) {
 				cleansers.add(clazz.getDeclaredConstructor().newInstance());
@@ -52,14 +53,13 @@ public class Cleansers {
 			return false;
 		};
 
+		outer:
 		for (String string : toCleanse) {
-			boolean added = false;
-			for (Cleanser cleanser : cleansers) {
-				added = cleanser.add(string);
-				if (added) break;
-			}
-			if (added) continue;
-			throw new IllegalArgumentException(string);
+			for (Cleanser cleanser : cleansers)
+				if (cleanser.add(string))
+					continue outer;
+
+			MagicSpells.error("CleanseSpell '" + spellName + "' has an invalid cleanser '" + string + "' defined in 'remove'.");
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/ValidTargetList.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ValidTargetList.java
@@ -129,6 +129,9 @@ public class ValidTargetList {
 	public ValidTargetList(boolean targetPlayers, boolean targetNonPlayers) {
 		this.targetPlayers = targetPlayers;
 		this.targetNonPlayers = targetNonPlayers;
+
+		gameModes.add(GameMode.SURVIVAL);
+		gameModes.add(GameMode.ADVENTURE);
 	}
 	
 	public boolean canTarget(LivingEntity caster, Entity target) {


### PR DESCRIPTION
- Fixed an issue that caused targeting to fail on players if `can-target` was not specified.
- `SilenceSpell` no longer overrides its targeting to always target players.
- Fixed an issue that caused invalid entries in `remove` on `CleanseSpell` to cause an error.