### PR TITLE
Cleanup, TotemSpell and PulserSpell changes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -318,11 +318,14 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			MagicSpells.cancelTask(taskId);
 			taskId = -1;
 
-			block.getWorld().getChunkAtAsync(block).thenAccept(chunk -> block.setType(Material.AIR));
 			if (remove) pulsers.remove(block);
 
-			playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
-			if (spellOnBreak != null) spellOnBreak.subcast(data);
+			block.getWorld().getChunkAtAsync(block).thenAccept(chunk -> {
+				block.setType(Material.AIR);
+
+				playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
+				if (spellOnBreak != null) spellOnBreak.subcast(data);
+			});
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -16,6 +16,8 @@ import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.block.BlockPistonExtendEvent;
 
+import com.destroystokyo.paper.event.block.BlockDestroyEvent;
+
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
@@ -186,6 +188,17 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
 	public void onBlockBreak(BlockBreakEvent event) {
+		if (pulsers.isEmpty()) return;
+
+		Pulser pulser = pulsers.get(event.getBlock());
+		if (pulser == null) return;
+
+		event.setCancelled(true);
+		if (!pulser.unbreakable) pulser.stop();
+	}
+
+	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)
+	public void onBlockBreak(BlockDestroyEvent event) {
 		if (pulsers.isEmpty()) return;
 
 		Pulser pulser = pulsers.get(event.getBlock());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -329,6 +329,8 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 				totemEquipment.setChestplate(chestplate);
 				totemEquipment.setLeggings(leggings);
 				totemEquipment.setBoots(boots);
+
+				stand.setPersistent(false);
 			});
 
 			totemLocation = armorStand.getLocation();
@@ -380,11 +382,14 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 			MagicSpells.cancelTask(taskId);
 			taskId = -1;
 
-			totemLocation.getWorld().getChunkAtAsync(totemLocation).thenAccept(chunk -> armorStand.remove());
 			if (remove) totems.remove(data.hasCaster() ? data.caster().getUniqueId() : null, this);
 
-			playSpellEffects(EffectPosition.DISABLED, totemLocation, data);
-			if (spellOnBreak != null) spellOnBreak.subcast(data);
+			totemLocation.getWorld().getChunkAtAsync(totemLocation).thenAccept(chunk -> {
+				armorStand.remove();
+
+				playSpellEffects(EffectPosition.DISABLED, totemLocation, data);
+				if (spellOnBreak != null) spellOnBreak.subcast(data);
+			});
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/ParticleUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ParticleUtil.java
@@ -4,48 +4,42 @@ import java.util.Map;
 import java.util.HashMap;
 
 import org.bukkit.Particle;
+import org.bukkit.Registry;
+import org.bukkit.NamespacedKey;
 
 public enum ParticleUtil {
 
-	EXPLOSION_NORMAL("poof", "explode"),
-	EXPLOSION_LARGE("explosion", "largeexplode"),
-	EXPLOSION_HUGE("explosion_emitter", "hugeexplosion"),
-	WATER_BUBBLE("bubble"),
-	WATER_SPLASH("splash"),
-	WATER_WAKE("fishing", "wake"),
-	WATER_DROP("rain", "droplet"),
-	SPELL("effect"),
-	SPELL_INSTANT("instant_effect", "instantspell"),
-	SPELL_MOB("entity_effect", "mobspell"),
-	SPELL_MOB_AMBIENT("ambient_entity_effect", "mobspellambient"),
-	SPELL_WITCH("witch", "witchmagic"),
-	ITEM_CRACK("item", "iconcrack"),
+	EXPLOSION_NORMAL("explode"),
+	EXPLOSION_LARGE("largeexplode"),
+	EXPLOSION_HUGE("hugeexplosion"),
+	WATER_WAKE("wake"),
+	WATER_DROP("droplet"),
+	SPELL_INSTANT("instantspell"),
+	SPELL_MOB("mobspell"),
+	SPELL_MOB_AMBIENT("mobspellambient"),
+	SPELL_WITCH("witchmagic"),
+	ITEM_CRACK("iconcrack"),
 	BLOCK_CRACK("blockcrack"),
-	BLOCK_DUST("blockdust", "block"),
-	SMOKE_NORMAL("smoke"),
-	SMOKE_LARGE("large_smoke", "largesmoke"),
-	DRIP_WATER("dripping_water", "dripwater"),
-	DRIP_LAVA("dripping_lava", "driplava"),
-	VILLAGER_ANGRY("angry_villager", "angryvillager"),
-	VILLAGER_HAPPY("happy_villager", "happyvillager"),
-	FIREWORKS_SPARK("firework", "fireworksspark"),
-	SUSPENDED("underwater"),
+	BLOCK_DUST("blockdust"),
+	SMOKE_LARGE("largesmoke"),
+	DRIP_WATER("dripwater"),
+	DRIP_LAVA("driplava"),
+	VILLAGER_ANGRY("angryvillager"),
+	VILLAGER_HAPPY("happyvillager"),
+	FIREWORKS_SPARK("fireworksspark"),
 	SUSPENDED_DEPTH("depthsuspend"),
-	CRIT_MAGIC("enchanted_hit", "magiccrit"),
-	TOWN_AURA("mycelium", "townaura"),
-	ENCHANTMENT_TABLE("enchant", "enchantmenttable"),
-	REDSTONE("dust", "reddust"),
-	SNOWBALL("item_snowball", "snowballpoof"),
-	SLIME("item_slime"),
-	MOB_APPEARANCE("elder_guardian", "mobappearance"),
+	CRIT_MAGIC("magiccrit"),
+	TOWN_AURA("townaura"),
+	ENCHANTMENT_TABLE("enchantmenttable"),
+	REDSTONE("reddust"),
+	SNOWBALL("snowballpoof"),
+	MOB_APPEARANCE("mobappearance"),
 	SNOW_SHOVEL("snowshovel"),
 	DRAGON_BREATH("dragonbreath"),
 	END_ROD("endrod"),
 	DAMAGE_INDICATOR("damageindicator"),
 	SWEEP_ATTACK("sweepattack"),
-	FALLING_DUST("fallingdust"),
-	TOTEM("totem_of_undying")
-	;
+	FALLING_DUST("fallingdust");
 
 	private static final Map<String, Particle> namesToType = new HashMap<>();
 	private static boolean initialized = false;
@@ -84,14 +78,18 @@ public enum ParticleUtil {
 	public static Particle getParticle(String particleName) {
 		initialize();
 
-		Particle particle = namesToType.get(particleName.toLowerCase());
+		String lower = particleName.toLowerCase();
+
+		Particle particle = namesToType.get(lower);
 		if (particle != null) return particle;
 
 		try {
-			particle = Particle.valueOf(particleName.toUpperCase());
-		} catch (IllegalArgumentException ignored) {}
+			return Particle.valueOf(particleName.toUpperCase());
+		} catch (IllegalArgumentException ignored) {
+		}
 
-		return particle;
+		NamespacedKey key = NamespacedKey.fromString(lower);
+		return key != null ? Registry.PARTICLE_TYPE.get(key) : null;
 	}
 
 }


### PR DESCRIPTION
- `ParticleUtil` now also checks the particle registry for particle types.
- The totems and pulsers of `TotemSpell` and `PulserSpell` now tick individually. As such, the `interval` options on both spells now supports replacement.
- Fixed an issue that caused an error if `TotemSpell` could not find a targeted block.
- Fixed an issue that allowed `PulserSpell` to be broken normally in certain circumstances.