### PR TITLE
Entity data equipment support, bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -51,6 +51,7 @@ public class EntityEffect extends SpellEffect {
 			entity.addScoreboardTag(ENTITY_TAG);
 			entity.setGravity(gravity.get(data));
 			entity.setSilent(silent.get(data));
+			entity.setPersistent(false);
 
 			if (entity instanceof LivingEntity livingEntity) livingEntity.setAI(enableAI.get(data));
 		});
@@ -59,6 +60,8 @@ public class EntityEffect extends SpellEffect {
 	@Override
 	public Runnable playEffectLocation(Location location, SpellData data) {
 		Entity entity = playEntityEffectLocation(location, data);
+		if (entity == null) return null;
+
 		entities.add(entity);
 
 		int duration = this.duration.get(data);
@@ -66,14 +69,13 @@ public class EntityEffect extends SpellEffect {
 			entities.remove(entity);
 			entity.remove();
 		}, duration);
+
 		return null;
 	}
 
 	@Override
 	public void turnOff() {
-		for (Entity entity : entities) {
-			entity.remove();
-		}
+		for (Entity entity : entities) entity.remove();
 		entities.clear();
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
@@ -38,27 +38,36 @@ public final class MultiSpell extends InstantSpell {
 	@Override
 	public void initialize() {
 		super.initialize();
-		if (spellList != null) {
-			for (String s : spellList) {
-				String[] parts = s.split(":");
-				double chance = parts.length == 2 ? Double.parseDouble(parts[1]) : 0.0D;
-				s = parts[0];
-				if (RANGED_DELAY_PATTERN.asMatchPredicate().test(s)) {
-					String[] splits = s.split(" ");
-					int minDelay = Integer.parseInt(splits[1]);
-					int maxDelay = Integer.parseInt(splits[2]);
-					actions.add(new ActionChance(new Action(minDelay, maxDelay), chance));
-				} else if (BASIC_DELAY_PATTERN.asMatchPredicate().test(s)) {
-					int delay = Integer.parseInt(s.split(" ")[1]);
-					actions.add(new ActionChance(new Action(delay), chance));
-				} else {
-					Subspell spell = new Subspell(s);
-					if (spell.process()) actions.add(new ActionChance(new Action(spell), chance));
-					else
-						MagicSpells.error("MultiSpell '" + internalName + "' has an invalid spell '" + s + "' defined!");
+
+		if (spellList == null) return;
+
+		for (String spellString : spellList) {
+			int chanceIndex = spellString.lastIndexOf(':');
+
+			double chance = 0d;
+			if (chanceIndex != -1) {
+				try {
+					chance = Double.parseDouble(spellString.substring(chanceIndex + 1));
+					spellString = spellString.substring(0, chanceIndex);
+				} catch (NumberFormatException ignored) {
 				}
 			}
+
+			if (RANGED_DELAY_PATTERN.asMatchPredicate().test(spellString)) {
+				String[] splits = spellString.split(" ");
+				int minDelay = Integer.parseInt(splits[1]);
+				int maxDelay = Integer.parseInt(splits[2]);
+				actions.add(new ActionChance(new Action(minDelay, maxDelay), chance));
+			} else if (BASIC_DELAY_PATTERN.asMatchPredicate().test(spellString)) {
+				int delay = Integer.parseInt(spellString.split(" ")[1]);
+				actions.add(new ActionChance(new Action(delay), chance));
+			} else {
+				Subspell spell = new Subspell(spellString);
+				if (spell.process()) actions.add(new ActionChance(new Action(spell), chance));
+				else MagicSpells.error("MultiSpell '" + internalName + "' has an invalid spell '" + spellString + "' defined!");
+			}
 		}
+
 		spellList = null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -185,9 +185,9 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 			removeDelay = VolleySpell.this.removeDelay.get(subData);
 			knockbackStrength = VolleySpell.this.knockbackStrength.get(subData);
 
-			speed = VolleySpell.this.speed.get(subData);
+			speed = VolleySpell.this.speed.get(subData) / 10;
 			if (powerAffectsSpeed.get(subData)) speed *= subData.power();
-			spread = VolleySpell.this.spread.get(subData);
+			spread = VolleySpell.this.spread.get(subData) / 10;
 
 			damage = VolleySpell.this.damage.get(subData);
 		}


### PR DESCRIPTION
- Added the `equipment` section to entity data. Supports the options `main-hand`, `off-hand`, `helmet`, `chestplate`, `leggings` and `boots`, which take a string-based magic item to equip the entity with in the options' respective equipment slot. Also supports the options `main-hand-drop-chance`, `off-hand-drop-chance`, `helmet-drop-chance`, `chestplate-drop-chance`, `leggings-drop-chance` and `boots-drop-chance`, which controls the drop chance for each slot.
- Fixed an issue where the `spread` and `speed` options of `VolleySpell` were not properly divided by 10.
- Fixed an issue with `MultiSpell` that caused an error when using a subspell containing a `:`.
- Fixed an issue where an error would occur if the `entity` effect did not spawn an entity due to invalid configuration.
- The entities spawned by the `entity` effect no longer persist.