### PR TITLE
Attribute conditions, add operator support to loop conditions, add totemactive and pulseractive conditions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeBaseCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeBaseCondition.java
@@ -1,0 +1,67 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.attribute.AttributeInstance;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.AttributeUtil;
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+@Name("attributebase")
+public class AttributeBaseCondition extends OperatorCondition {
+
+	private static final Pattern ATTRIBUTE_NAME_PATTERN = Pattern.compile("[-.\\w]+");
+
+	private Attribute attribute;
+	private double value;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Matcher matcher = ATTRIBUTE_NAME_PATTERN.matcher(var);
+		if (!matcher.find()) return false;
+
+		String attributeName = matcher.group();
+
+		attribute = AttributeUtil.getAttribute(attributeName);
+		if (attribute == null) return false;
+
+		String number = var.substring(attributeName.length());
+		if (number.length() < 2 || !super.initialize(number)) return false;
+
+		try {
+			value = Double.parseDouble(number.substring(1));
+		} catch (NumberFormatException e) {
+			DebugHandler.debugNumberFormat(e);
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		AttributeInstance instance = caster.getAttribute(attribute);
+		if (instance == null) return false;
+
+		return compare(instance.getBaseValue(), value);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeCondition.java
@@ -1,0 +1,67 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.attribute.AttributeInstance;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.AttributeUtil;
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+@Name("attribute")
+public class AttributeCondition extends OperatorCondition {
+
+	private static final Pattern ATTRIBUTE_NAME_PATTERN = Pattern.compile("[-.\\w]+");
+
+	private Attribute attribute;
+	private double value;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Matcher matcher = ATTRIBUTE_NAME_PATTERN.matcher(var);
+		if (!matcher.find()) return false;
+
+		String attributeName = matcher.group();
+
+		attribute = AttributeUtil.getAttribute(attributeName);
+		if (attribute == null) return false;
+
+		String number = var.substring(attributeName.length());
+		if (number.length() < 2 || !super.initialize(number)) return false;
+
+		try {
+			value = Double.parseDouble(number.substring(1));
+		} catch (NumberFormatException e) {
+			DebugHandler.debugNumberFormat(e);
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		AttributeInstance instance = caster.getAttribute(attribute);
+		if (instance == null) return false;
+
+		return compare(instance.getValue(), value);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeDefaultCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeDefaultCondition.java
@@ -1,0 +1,67 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Location;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.entity.LivingEntity;
+import org.bukkit.attribute.AttributeInstance;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.AttributeUtil;
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+@Name("attributedefault")
+public class AttributeDefaultCondition extends OperatorCondition {
+
+	private static final Pattern ATTRIBUTE_NAME_PATTERN = Pattern.compile("[-.\\w]+");
+
+	private Attribute attribute;
+	private double value;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Matcher matcher = ATTRIBUTE_NAME_PATTERN.matcher(var);
+		if (!matcher.find()) return false;
+
+		String attributeName = matcher.group();
+
+		attribute = AttributeUtil.getAttribute(attributeName);
+		if (attribute == null) return false;
+
+		String number = var.substring(attributeName.length());
+		if (number.length() < 2 || !super.initialize(number)) return false;
+
+		try {
+			value = Double.parseDouble(number.substring(1));
+		} catch (NumberFormatException e) {
+			DebugHandler.debugNumberFormat(e);
+			return false;
+		}
+
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		AttributeInstance instance = caster.getAttribute(attribute);
+		if (instance == null) return false;
+
+		return compare(instance.getDefaultValue(), value);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LoopActiveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LoopActiveCondition.java
@@ -1,5 +1,8 @@
 package com.nisovin.magicspells.castmodifiers.conditions;
 
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 
@@ -8,42 +11,64 @@ import org.jetbrains.annotations.NotNull;
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.castmodifiers.Condition;
 import com.nisovin.magicspells.spells.targeted.LoopSpell;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
 
 @Name("loopactive")
-public class LoopActiveCondition extends Condition {
+public class LoopActiveCondition extends OperatorCondition {
 
-	private LoopSpell loop;
+	private static final Pattern OPERATORS = Pattern.compile("[:=<>]");
+
+	protected LoopSpell loop;
+	protected int value;
 
 	@Override
 	public boolean initialize(@NotNull String var) {
 		Spell spell = MagicSpells.getSpellByInternalName(var);
 		if (spell instanceof LoopSpell loopSpell) {
 			loop = loopSpell;
+			moreThan = true;
+			value = 0;
+
 			return true;
 		}
 
-		return false;
+		Matcher matcher = OPERATORS.matcher(var);
+		while (matcher.find()) {
+			spell = MagicSpells.getSpellByInternalName(var.substring(0, matcher.start()));
+			if (!(spell instanceof LoopSpell loopSpell)) continue;
+
+			String number = var.substring(matcher.start());
+			if (number.length() < 2 || !super.initialize(number)) continue;
+
+			try {
+				value = Integer.parseInt(number.substring(1));
+			} catch (NumberFormatException e) {
+				continue;
+			}
+
+			loop = loopSpell;
+
+			return true;
+		}
+
+		return loop != null;
 	}
 
 	@Override
 	public boolean check(LivingEntity caster) {
-		return loopActive(caster);
+		int count = loop.getActiveLoops().get(caster.getUniqueId()).size();
+		return compare(count, value);
 	}
 
 	@Override
 	public boolean check(LivingEntity caster, LivingEntity target) {
-		return loopActive(target);
+		return check(target);
 	}
 
 	@Override
 	public boolean check(LivingEntity caster, Location location) {
 		return false;
-	}
-
-	private boolean loopActive(LivingEntity target) {
-		return loop.isActive(target);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OwnedLoopActiveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/OwnedLoopActiveCondition.java
@@ -2,55 +2,29 @@ package com.nisovin.magicspells.castmodifiers.conditions;
 
 import java.util.Collection;
 
-import org.bukkit.Location;
 import org.bukkit.entity.LivingEntity;
 
-import org.jetbrains.annotations.NotNull;
-
-import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.Name;
-import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.castmodifiers.Condition;
-import com.nisovin.magicspells.spells.targeted.LoopSpell;
 import com.nisovin.magicspells.spells.targeted.LoopSpell.Loop;
 
 @Name("ownedloopactive")
-public class OwnedLoopActiveCondition extends Condition {
-
-	private LoopSpell loopSpell;
-
-	@Override
-	public boolean initialize(@NotNull String var) {
-		Spell spell = MagicSpells.getSpellByInternalName(var);
-		if (spell instanceof LoopSpell loop) {
-			loopSpell = loop;
-			return true;
-		}
-
-		return false;
-	}
+public class OwnedLoopActiveCondition extends LoopActiveCondition {
 
 	@Override
 	public boolean check(LivingEntity caster) {
-		return checkLoop(caster, caster);
+		return check(caster, caster);
 	}
 
 	@Override
 	public boolean check(LivingEntity caster, LivingEntity target) {
-		return checkLoop(caster, target);
-	}
+		int count = 0;
 
-	@Override
-	public boolean check(LivingEntity caster, Location location) {
-		return false;
-	}
+		Collection<Loop> loops = loop.getActiveLoops().get(target.getUniqueId());
+		for (Loop loop : loops)
+			if (caster.equals(loop.getCaster()))
+				count++;
 
-	private boolean checkLoop(LivingEntity caster, LivingEntity target) {
-		Collection<Loop> loops = loopSpell.getActiveLoops().get(target.getUniqueId());
-		for (Loop loop : loops) {
-			if (caster.equals(loop.getCaster())) return true;
-		}
-		return false;
+		return compare(count, value);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PulserActiveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/PulserActiveCondition.java
@@ -1,0 +1,83 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.targeted.PulserSpell;
+import com.nisovin.magicspells.spells.targeted.PulserSpell.Pulser;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+@Name("pulseractive")
+public class PulserActiveCondition extends OperatorCondition {
+
+	private static final Pattern OPERATORS = Pattern.compile("[:=<>]");
+
+	protected PulserSpell pulser;
+	protected int value;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Spell spell = MagicSpells.getSpellByInternalName(var);
+		if (spell instanceof PulserSpell pulserSpell) {
+			pulser = pulserSpell;
+			moreThan = true;
+			value = 0;
+
+			return true;
+		}
+
+		Matcher matcher = OPERATORS.matcher(var);
+		while (matcher.find()) {
+			spell = MagicSpells.getSpellByInternalName(var.substring(0, matcher.start()));
+			if (!(spell instanceof PulserSpell pulserSpell)) continue;
+
+			String number = var.substring(matcher.start());
+			if (number.length() < 2 || !super.initialize(number)) continue;
+
+			try {
+				value = Integer.parseInt(number.substring(1));
+			} catch (NumberFormatException e) {
+				continue;
+			}
+
+			pulser = pulserSpell;
+
+			return true;
+		}
+
+		return pulser != null;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		int count = 0;
+
+		Map<Block, Pulser> pulsers = pulser.getPulsers();
+		for (Pulser pulser : pulsers.values())
+			if (caster.equals(pulser.getCaster()))
+				count++;
+
+		return compare(count, value);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TotemActiveCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/TotemActiveCondition.java
@@ -1,0 +1,74 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.targeted.TotemSpell;
+import com.nisovin.magicspells.castmodifiers.conditions.util.OperatorCondition;
+
+@Name("totemactive")
+public class TotemActiveCondition extends OperatorCondition {
+
+	private static final Pattern OPERATORS = Pattern.compile("[:=<>]");
+
+	protected TotemSpell totem;
+	protected int value;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Spell spell = MagicSpells.getSpellByInternalName(var);
+		if (spell instanceof TotemSpell totemSpell) {
+			totem = totemSpell;
+			moreThan = true;
+			value = 0;
+
+			return true;
+		}
+
+		Matcher matcher = OPERATORS.matcher(var);
+		while (matcher.find()) {
+			spell = MagicSpells.getSpellByInternalName(var.substring(0, matcher.start()));
+			if (!(spell instanceof TotemSpell totemSpell)) continue;
+
+			String number = var.substring(matcher.start());
+			if (number.length() < 2 || !super.initialize(number)) continue;
+
+			try {
+				value = Integer.parseInt(number.substring(1));
+			} catch (NumberFormatException e) {
+				continue;
+			}
+
+			totem = totemSpell;
+
+			return true;
+		}
+
+		return totem != null;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		int count = totem.getTotems().get(caster.getUniqueId()).size();
+		return compare(count, value);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		return check(target);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/util/OperatorCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/util/OperatorCondition.java
@@ -30,4 +30,11 @@ public abstract class OperatorCondition extends Condition {
 		return false;
 	}
 
+	protected boolean compare(long a, long b) {
+		if (equals) return a == b;
+		else if (moreThan) return a > b;
+		else if (lessThan) return a < b;
+		return false;
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -8,6 +8,7 @@ import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
+import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.EventPriority;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.block.data.BlockData;
@@ -251,13 +252,17 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		});
 	}
 
+	public Map<Block, Pulser> getPulsers() {
+		return pulsers;
+	}
+
 	@Override
 	public void turnOff() {
 		for (Pulser pulser : pulsers.values()) pulser.stop(false);
 		pulsers.clear();
 	}
 
-	private class Pulser implements Runnable {
+	public class Pulser implements Runnable {
 
 		private final Block block;
 		private final Material type;
@@ -291,6 +296,10 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 			pulseCount = 0;
 
 			taskId = MagicSpells.scheduleRepeatingTask(this, 0, interval.get(data));
+		}
+
+		public LivingEntity getCaster() {
+			return data.caster();
 		}
 
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -271,6 +271,10 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 	}
 
+	public Multimap<UUID, Totem> getTotems() {
+		return totems;
+	}
+
 	public boolean hasTotem(LivingEntity caster) {
 		return !totems.get(caster.getUniqueId()).isEmpty();
 	}
@@ -280,7 +284,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		removed.forEach(totem -> totem.stop(false));
 	}
 
-	private class Totem implements Runnable {
+	public class Totem implements Runnable {
 
 		private final ArmorStand armorStand;
 		private final Location totemLocation;

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -208,6 +208,8 @@ public class ConditionManager {
 		addCondition(AttributeCondition.class);
 		addCondition(AttributeBaseCondition.class);
 		addCondition(AttributeDefaultCondition.class);
+		addCondition(PulserActiveCondition.class);
+		addCondition(TotemActiveCondition.class);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -205,6 +205,9 @@ public class ConditionManager {
 		addCondition(FixedPoseCondition.class);
 		addCondition(SilentCondition.class);
 		addCondition(ClientBrandNameCondition.class);
+		addCondition(AttributeCondition.class);
+		addCondition(AttributeBaseCondition.class);
+		addCondition(AttributeDefaultCondition.class);
 	}
 
 }


### PR DESCRIPTION
- Added the `attribute`, `attributebase` and `attributedefault` conditions. Each are operator conditions that check the value, base value and default value of the target's attributes, respectively.
- The `loopactive` and `ownedloopactive` conditions now allow optionally specifying an operator and value. Example: `loopactive loop-spell>1 denied`.
- Added the `totemactive` and `pulseractive` condition. Checks how many pulsers/totems the target has, respectively. Operator and value are optional. Examples: `totemactive totem-spell>4 denied`, `pulseractive pulser-spell required`.