### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,13 @@
 <div align="center">
     <br>
-    <img src="https://media.discordapp.net/attachments/335237931633606656/595352328341684427/Untitled.png" alt="MagicSpells Icon">
+    <img src="https://files.jasperlorelai.eu/magicspells/images/readme_icon.png" alt="MagicSpells Icon">
     <hr>
     <h2><i>Magic without writing Java</i></h2>
-    <a href="https://github.com/TheComputerGeek2/MagicSpells/actions"><img src="https://img.shields.io/github/actions/workflow/status/TheComputerGeek2/MagicSpells/build.yml" alt="Build Status"></a>
-    <a href="https://discord.magicspells.dev"><img src="https://img.shields.io/discord/335237931633606656?color=5562e9&logo=discord&logoColor=white" alt="Discord Server"></a>
-    <a href="https://github.com/TheComputerGeek2/MagicSpells/releases">
-        <img src="https://img.shields.io/github/downloads/TheComputerGeek2/MagicSpells/total.svg" alt="Github Downloads">
-        <img src="https://img.shields.io/github/downloads-pre/TheComputerGeek2/MagicSpells/latest/total.svg" alt="Github Downloads Latest">
-    </a>
-    <img src="https://img.shields.io/github/license/TheComputerGeek2/MagicSpells" alt="Licence">
-    <a href="https://bstats.org/plugin/bukkit/MagicSpells/892"><img src="https://img.shields.io/bstats/servers/892" alt="In MC servers"></a>
+    <a href="https://github.com/TheComputerGeek2/MagicSpells/actions"><img src="https://img.shields.io/github/actions/workflow/status/TheComputerGeek2/MagicSpells/build.yml?style=for-the-badge&logo=github" alt="Build Status"></a>
+    <a href="https://discord.magicspells.dev"><img src="https://img.shields.io/discord/335237931633606656?color=5562e9&logo=discord&logoColor=white&style=for-the-badge" alt="Discord Server"></a>
+    <a href="https://github.com/TheComputerGeek2/MagicSpells/releases"><img src="https://img.shields.io/github/downloads/TheComputerGeek2/MagicSpells/total.svg?style=for-the-badge&logo=github" alt="Github Downloads"></a>
+    <img src="https://img.shields.io/github/license/TheComputerGeek2/MagicSpells?style=for-the-badge&logo=github" alt="Licence">
+    <a href="https://bstats.org/plugin/bukkit/MagicSpells/892"><img src="https://img.shields.io/bstats/servers/892?style=for-the-badge" alt="In MC servers"></a>
 </div>
 
 [//]: # (These links are here for easier hyperlink referencing and less clutter in the actual text below.)
@@ -27,7 +24,7 @@
 [PaperMC]: https://papermc.io/
 [Modrinth]: https://modrinth.com/plugin/magicspells
 [DiscordBadge]: https://img.shields.io/badge/Join%20our%20Discord-blue?style=for-the-badge&color=586ff2
-[WelcomeChannel]: https://media.discordapp.net/attachments/423551934784339968/957725621503541288/unknown.png
+[WelcomeChannel]: https://files.jasperlorelai.eu/magicspells/images/readme_discord_screenshot.png
 
 MagicSpells is a [PaperMC] plugin which gives its users the ability to modify their Minecraft servers by configuring existing features without writing Java code. It provides you with the tools for playing with blocks of logic, bringing other plugins together, playing fantastic special effects, making your own new mechanics, and more.
 
@@ -48,7 +45,7 @@ Check out more examples of what this plugin can do in our [Discord server] (in t
 ---
 ## Classical MagicSpells ⭐
 
-This plugin was originally created by [Nisovin], and published on [Bukkit]. After some time TheComputerGeek2 took over the project and published it on [Spigot]. Since then we dropped support for Spigot and moved to [PaperMC], and the plugin was published on [Modrinth].
+This plugin was originally created by [Nisovin], and published on [Bukkit]. After some time TheComputerGeek2 took over the project and published it on [Spigot]. Since then, we dropped support for Spigot and moved to [PaperMC], and the plugin was published on [Modrinth].
 
 
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
@@ -332,7 +332,7 @@ public abstract class SpellEffect {
 		if (delay <= 0) return playEntityEffectLocationReal(location, data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEffectLibLocationReal(location, finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> playEntityEffectLocationReal(location, finalData), delay);
 
 		return null;
 	}
@@ -354,7 +354,7 @@ public abstract class SpellEffect {
 		if (delay <= 0) return playArmorStandEffectLocationReal(location, data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEffectLibLocationReal(location, finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> playArmorStandEffectLocationReal(location, finalData), delay);
 
 		return null;
 	}


### PR DESCRIPTION
Discord is enforcing an expiry on attachment links. Our readme and the one on our [Modrinth](https://modrinth.com/plugin/magicspells) had some images uploaded through Discord. This PR uses images uploaded through my own webserver because I don't know what service could be a better home atm.

Note: while this PR fixes our GitHub readme, Modrinth still needs to be updated. I have [a repo here](https://github.com/JasperLorelai/MagicSpells-readme/) which has readmes converted into various formats. Spigot could also use an update, but it's a bit of a different story (no Spigot support).

This PR also fixes delayed `armorstand` and `entity` effects.