### PR TITLE
Add food regen meta variables

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VariableStringEqualsCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/VariableStringEqualsCondition.java
@@ -21,7 +21,7 @@ public class VariableStringEqualsCondition extends Condition {
 
 	@Override
 	public boolean initialize(@NotNull String var) {
-		String[] split = var.split(":",2);
+		String[] split = var.split("[:=]",2);
 
 		//Were two parts of this modifier created?
 		if (split.length != 2) return false;

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
@@ -173,7 +173,7 @@ public class SpellUtil {
 				MoneyHandler handler = MagicSpells.getMoneyHandler();
 				if (handler != null) {
 					if (moneyCost > 0) handler.removeMoney(player, moneyCost);
-					else handler.addMoney(player, moneyCost);
+					else handler.addMoney(player, -moneyCost);
 				}
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -156,6 +156,10 @@ public class VariableManager {
 		addMetaVariableType("max_fire_ticks", new MaxFireTicksVariable());
 		addMetaVariableType("forwards_movement", new ForwardsMovementVariable());
 		addMetaVariableType("sideways_movement", new SidewaysMovementVariable());
+		addMetaVariableType("exhaustion", new ExhaustionVariable());
+		addMetaVariableType("starvation_rate", new StarvationRateVariable());
+		addMetaVariableType("saturated_regen_rate", new SaturatedRegenRateVariable());
+		addMetaVariableType("unsaturated_regen_rate", new UnsaturatedRegenRateVariable());
 
 		// meta variable attribute types
 		for (Attribute attribute : Attribute.values()) {

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/ExhaustionVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/ExhaustionVariable.java
@@ -1,0 +1,23 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class ExhaustionVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) return p.getExhaustion();
+		return 0;
+	}
+
+	@Override
+	public void set(String player, double amount) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) p.setExhaustion((float) amount);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/SaturatedRegenRateVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/SaturatedRegenRateVariable.java
@@ -1,0 +1,23 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class SaturatedRegenRateVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) return p.getSaturatedRegenRate();
+		return 0;
+	}
+
+	@Override
+	public void set(String player, double amount) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) p.setSaturatedRegenRate((int) amount);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/StarvationRateVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/StarvationRateVariable.java
@@ -1,0 +1,23 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class StarvationRateVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) return p.getStarvationRate();
+		return 0;
+	}
+
+	@Override
+	public void set(String player, double amount) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) p.setStarvationRate((int) amount);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/UnsaturatedRegenRateVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/UnsaturatedRegenRateVariable.java
@@ -1,0 +1,23 @@
+package com.nisovin.magicspells.variables.meta;
+
+import org.bukkit.Bukkit;
+import org.bukkit.entity.Player;
+
+import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
+
+public class UnsaturatedRegenRateVariable extends MetaVariable {
+
+	@Override
+	public double getValue(String player) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) return p.getUnsaturatedRegenRate();
+		return 0;
+	}
+
+	@Override
+	public void set(String player, double amount) {
+		Player p = Bukkit.getPlayerExact(player);
+		if (p != null) p.setUnsaturatedRegenRate((int) amount);
+	}
+
+}


### PR DESCRIPTION
- Allowed `variablestringequals` to use `=` for splitting instead of just `:`.
- Added `meta_exhaustion` (read [wiki](https://minecraft.wiki/w/Hunger#Mechanics)), `meta_starvation_rate`, `meta_saturated_regen_rate`, and `meta_unsaturated_regen_rate`.