### PR TITLE
Config-based projectile interactions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -547,26 +547,6 @@ public class MagicSpells extends JavaPlugin {
 			log("...xp system loaded");
 		}
 
-		// Load in-game spell names, incantations, and initialize spells
-		log("Initializing spells...");
-		for (Spell spell : spells.values()) {
-			spellNames.put(Util.getPlainString(Util.getMiniMessage(spell.getName().toLowerCase())), spell);
-			String[] aliases = spell.getAliases();
-			if (aliases != null) {
-				for (String alias : aliases) {
-					if (!spellNames.containsKey(alias.toLowerCase())) spellNames.put(alias.toLowerCase(), spell);
-				}
-			}
-			List<String> incs = spell.getIncantations();
-			if (incs != null && !incs.isEmpty()) {
-				for (String s : incs) {
-					incantations.put(s.toLowerCase(), spell);
-				}
-			}
-			spell.initialize();
-		}
-		log("...done");
-
 		// Load player data using a storage handler
 		log("Initializing storage handler...");
 		storageHandler = new TXTFileStorage(plugin);
@@ -667,9 +647,40 @@ public class MagicSpells extends JavaPlugin {
 		Bukkit.getScheduler().runTaskLater(this, this::loadExternalData, 1);
 	}
 
+	private void initializeSpells() {
+		log("Initializing spells...");
+		for (Spell spell : new ArrayList<>(spells.values())) {
+			DependsOn dependsOn = spell.getClass().getAnnotation(DependsOn.class);
+			if (dependsOn != null && !Util.checkPluginsEnabled(dependsOn.value())) {
+				spells.remove(spell.getInternalName().toLowerCase());
+				spellsOrdered.remove(spell);
+
+				MagicSpells.error(spell.getClass().getSimpleName() + " '" + spell.internalName + "' could not be loaded.");
+				continue;
+			}
+
+			spellNames.put(Util.getPlainString(Util.getMiniMessage(spell.getName().toLowerCase())), spell);
+			String[] aliases = spell.getAliases();
+			if (aliases != null) {
+				for (String alias : aliases) {
+					if (!spellNames.containsKey(alias.toLowerCase())) spellNames.put(alias.toLowerCase(), spell);
+				}
+			}
+			List<String> incs = spell.getIncantations();
+			if (incs != null && !incs.isEmpty()) {
+				for (String s : incs) {
+					incantations.put(s.toLowerCase(), spell);
+				}
+			}
+			spell.initialize();
+		}
+		log("...done");
+	}
+
 	private void loadExternalData() {
 		log("Loading external data...");
 
+		initializeSpells();
 		loadVariables();
 		loadSpellEffects();
 		loadConditions();
@@ -816,9 +827,6 @@ public class MagicSpells extends JavaPlugin {
 					} catch (ClassNotFoundException e) {
 						continue;
 					}
-
-					DependsOn dependsOn = spellClass.getAnnotation(DependsOn.class);
-					if (dependsOn != null && !Util.checkPluginsEnabled(dependsOn.value())) continue;
 
 					try {
 						constructor = spellClass.getConstructor(MagicConfig.class, String.class);

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -874,7 +874,7 @@ public class MagicSpells extends JavaPlugin {
 
 		finalElapsed = System.currentTimeMillis() - startTimePre;
 		if (lastReloadTime != 0) getLogger().warning("Loaded in " + finalElapsed + "ms (previously " + lastReloadTime + " ms)");
-		getLogger().warning("Need help? Check out our discord: discord.gg/6bYqnNy");
+		getLogger().warning("Need help? Check out our discord: https://discord.magicspells.dev/");
 		lastReloadTime = finalElapsed;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -353,7 +353,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		ignoreGlobalCooldown = config.getBoolean(internalKey + "ignore-global-cooldown", false);
 		charges = config.getInt(internalKey + "charges", 0);
 		rechargeSound = config.getString(internalKey + "recharge-sound", "");
-		nextCast = new WeakHashMap<>();
+		nextCast = new HashMap<>();
 		chargesConsumed = new IntMap<>();
 		nextCastServer = 0;
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -356,7 +356,7 @@ public class MagicCommand extends BaseCommand {
 			if (player == null) s.getCooldowns().clear();
 			else s.setCooldown(player, 0, false);
 		}
-		issuer.sendMessage(MagicSpells.getTextColor() + "Cooldowns reset" + (player == null ? "" : " for " + player.getName()) + (spell == null ? "" : " for spell " + Util.getMiniMessage(spell.getName())) + ".");
+		issuer.sendMessage(MagicSpells.getTextColor() + "Cooldowns reset" + (player == null ? "" : " for " + player.getName()) + (spell == null ? "" : " for spell " + Util.getLegacyFromMiniMessage(spell.getName())));
 	}
 
 	@Subcommand("mana")

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -270,10 +270,10 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				return;
 			}
 
-			Location loc = getLocation();
-			data = data.location(loc);
+			move();
+			data = data.location(currentLocation);
 
-			if (!transparent.test(loc)) {
+			if (!transparent.test(currentLocation)) {
 				if (groundSpell != null) groundSpell.subcast(data.noTarget());
 				if (stopOnHitGround) {
 					stop(true);
@@ -281,7 +281,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				}
 			}
 
-			playSpellEffects(EffectPosition.SPECIAL, loc, data);
+			playSpellEffects(EffectPosition.SPECIAL, currentLocation, data);
 
 			if (effectSet != null) {
 				Effect effect;
@@ -289,7 +289,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				for (EffectlibSpellEffect spellEffect : effectSet) {
 					effect = spellEffect.getEffect();
 
-					effectLoc = spellEffect.getSpellEffect().applyOffsets(loc.clone(), data);
+					effectLoc = spellEffect.getSpellEffect().applyOffsets(currentLocation.clone(), data);
 					effect.setLocation(effectLoc);
 
 					if (effect instanceof ModifiedEffect) {
@@ -301,19 +301,19 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 
 			if (armorStandSet != null) {
 				for (ArmorStand armorStand : armorStandSet) {
-					armorStand.teleport(loc, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
+					armorStand.teleport(currentLocation, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
 				}
 			}
 
 			if (entityMap != null) {
 				for (var entry : entityMap.entrySet()) {
-					entry.getValue().teleport(entry.getKey().applyOffsets(loc.clone()), TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
+					entry.getValue().teleport(entry.getKey().applyOffsets(currentLocation.clone()), TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
 				}
 			}
 
 			if (orbitSpell != null) orbitSpell.subcast(data.noTarget());
 
-			box.setCenter(loc);
+			box.setCenter(currentLocation);
 
 			for (LivingEntity e : data.caster().getWorld().getLivingEntities()) {
 				if (!e.isValid() || immune.contains(e) || !box.contains(e)) continue;
@@ -328,7 +328,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 				if (entitySpell != null) entitySpell.subcast(subData.noLocation());
 
 				playSpellEffects(EffectPosition.TARGET, event.getTarget(), subData);
-				playSpellEffectsTrail(loc, event.getTarget().getLocation(), subData);
+				playSpellEffectsTrail(currentLocation, event.getTarget().getLocation(), subData);
 
 				if (stopOnHitEntity) {
 					stop(true);
@@ -341,7 +341,7 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			return OrbitSpell.this;
 		}
 
-		private Location getLocation() {
+		private void move() {
 			if (data.hasTarget()) {
 				data.target().getLocation(currentLocation);
 
@@ -360,12 +360,11 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			else perp = new Vector(-currentDirection.getZ(), 0, currentDirection.getX());
 
 			currentDirection.add(perp.multiply(distancePerTick)).normalize();
-
-			return currentLocation.clone().add(0, yOffset, 0).add(currentDirection.clone().multiply(orbitRadius)).setDirection(perp);
+			currentLocation.add(0, yOffset, 0).add(currentDirection.clone().multiply(orbitRadius)).setDirection(perp);
 		}
 
 		private void stop(boolean removeTracker) {
-			playSpellEffects(EffectPosition.DELAYED, getLocation(), data);
+			playSpellEffects(EffectPosition.DELAYED, currentLocation, data);
 
 			MagicSpells.cancelTask(taskId);
 			MagicSpells.cancelTask(repeatingHorizTaskId);

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/Interaction.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/Interaction.java
@@ -1,0 +1,82 @@
+package com.nisovin.magicspells.util.trackers;
+
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.Subspell;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellFilter;
+import com.nisovin.magicspells.util.ValidTargetList;
+import com.nisovin.magicspells.util.ConfigReaderUtil;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+public record Interaction(
+		@NotNull SpellFilter interactsWith,
+		@Nullable Subspell collisionSpell,
+		boolean stopCausing,
+		boolean stopWith,
+		@Nullable ValidTargetList canInteractList
+) {
+
+	public Interaction(@NotNull SpellFilter interactWith, @Nullable Subspell collisionSpell) {
+		this(interactWith, collisionSpell, true, true, null);
+	}
+
+	public static List<Interaction> read(Spell causing, List<?> objectList) {
+		String logPrefix = causing.getClass().getSimpleName() + " '" + causing.getInternalName() + "' ";
+		List<Interaction> interactions = new ArrayList<>();
+
+		for (Object object : objectList) {
+			if (object instanceof String string) {
+				String[] splits = string.split(" ");
+
+				SpellFilter interactsWith = SpellFilter.fromString(splits[0]);
+				if (splits.length < 2) {
+					interactions.add(new Interaction(interactsWith, null));
+					continue;
+				}
+
+				String collisionName = splits[1];
+				Subspell collisionSpell = new Subspell(collisionName);
+				if (!collisionSpell.process()) {
+					MagicSpells.error(logPrefix + "has an invalid interaction because the collision spell '" + collisionName + "' is not a valid spell!");
+					continue;
+				}
+
+				interactions.add(new Interaction(interactsWith, collisionSpell));
+				continue;
+			}
+
+			if (!(object instanceof Map<?, ?> map)) continue;
+			ConfigurationSection config = ConfigReaderUtil.mapToSection(map);
+
+			SpellFilter interactsWith;
+			if (config.isConfigurationSection("with"))
+				interactsWith = SpellFilter.fromConfig(config, "with");
+			else interactsWith = SpellFilter.fromString(config.getString("with", ""));
+
+			String collisionName = config.getString("collision-spell", "");
+			Subspell collisionSpell = collisionName.isEmpty() ? null : new Subspell(collisionName);
+			if (collisionSpell != null && !collisionSpell.process()) {
+				MagicSpells.error(logPrefix + "has an invalid interaction because their collision spell '" + collisionName + "' is not a valid spell!");
+				continue;
+			}
+
+			boolean stopCausing = config.getBoolean("stop-causing", true);
+			boolean stopWith = config.getBoolean("stop-with", true);
+			String canInteractString = config.getString("can-interact");
+			ValidTargetList canInteractList = canInteractString == null ? null : new ValidTargetList(causing, canInteractString);
+
+			interactions.add(new Interaction(interactsWith, collisionSpell, stopCausing, stopWith, canInteractList));
+		}
+
+		return interactions;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -440,11 +440,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 				continue;
 			}
 
-			double x = (currentLocation.getX() + collisionTracker.currentLocation.getX()) / 2D;
-			double y = (currentLocation.getY() + collisionTracker.currentLocation.getY()) / 2D;
-			double z = (currentLocation.getZ() + collisionTracker.currentLocation.getZ()) / 2D;
-
-			Location middleLoc = new Location(currentLocation.getWorld(), x, y, z);
+			Location middleLoc = currentLocation.clone().add(collisionTracker.currentLocation).multiply(0.5);
 			collisionSpell.subcast(data.location(middleLoc));
 			toRemove.add(collisionTracker);
 			toRemove.add(this);


### PR DESCRIPTION
- Fixed cooldown not persisting during reloads and restarts.
- `OrbitSpell` now has an `interactions` option for interacting with other orbits just like `ParticleProjectileSpell`. Interactions have been refactored such that they can be either configured as a list of strings like before or a list of configuration sections which allow for more configuration around each interaction:
    * String: `<interactWith> <collisionSpell>` - The `<interactWith>` segment may now be a [string Spell Filter](https://github.com/TheComputerGeek2/MagicSpells/wiki/Spell-Filter#string).
    * Config:
        - `with`  - [Either variant of Spell Filter](https://github.com/TheComputerGeek2/MagicSpells/wiki/Spell-Filter)
        - `collision-spell` - sub-spell to cast on collision.
        - `stop-causing` (bool, `true` by default)
        - `stop-with` (bool, `true` by default)
        - `can-interact` (string, [Valid Target List](https://github.com/TheComputerGeek2/MagicSpells/wiki/Valid-Target-List#string-based)) - Allows everyone if left empty. On `ParticleProjectileSpell` this overrides `allow-caster-interact` if defined.
 ```yml
 interactions:
    # String-based
    - otherProjectile collisionSpell
    # Config-based:
    - with: otherPorjectile
      collision-spell: collisionSpell
      can-interact: self
 ```