### PR TITLE
Bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -516,7 +516,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 			LivingEntity entity = getWhoToCancel(event.getCaster());
 			if (entity == null) return;
-			if (filter.check(event.getSpell())) return;
+			if (!filter.isEmpty() && filter.check(event.getSpell())) return;
 			turnOff(entity);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
@@ -104,7 +104,14 @@ public class LeapSpell extends InstantSpell {
 	}
 
 	public boolean isJumping(LivingEntity livingEntity) {
-		return leapMonitor.jumping.containsKey(livingEntity);
+		Collection<LeapData> data = leapMonitor.jumping.get(livingEntity);
+		if (data.isEmpty()) return false;
+
+		for (LeapData leapData : data)
+			if (leapData.leapSpell == this)
+				return true;
+
+		return false;
 	}
 
 	public Subspell getLandSpell() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
@@ -99,7 +99,14 @@ public class VelocitySpell extends InstantSpell implements TargetedEntitySpell, 
 	}
 
 	public boolean isJumping(LivingEntity livingEntity) {
-		return velocityMonitor.jumping.containsKey(livingEntity);
+		Collection<VelocityData> data = velocityMonitor.jumping.get(livingEntity);
+		if (data.isEmpty()) return false;
+
+		for (VelocityData velocityData : data)
+			if (velocityData.velocitySpell == this)
+				return true;
+
+		return false;
 	}
 
 	public static Multimap<LivingEntity, VelocityData> getJumping() {

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellFilter.java
@@ -84,6 +84,10 @@ public class SpellFilter {
 		return defaultReturn;
 	}
 
+	public boolean isEmpty() {
+		return emptyFilter;
+	}
+
 	/**
 	 * Create a {@link SpellFilter} instance out of a configuration section.
 	 * @param config Reads from the following keys: "spells", "denied-spells", "spell-tags", and "denied-spell-tags".


### PR DESCRIPTION
- `cancel-on-spell-cast: true` on `BuffSpell` now causes the buff to cancel on all spell casts if the spell filter options are not specified.
- Fixed an issue with the `leaping` and `velocityactive` conditions that caused them to not function properly.