### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1737,6 +1737,8 @@ public class MagicSpells extends JavaPlugin {
 		return formatMessage(message, SpellData.NULL, replacements);
 	}
 
+	private static final Pattern TARGET_NAME_PATTERN = Pattern.compile("%[art]");
+
 	/**
 	 * Formats a string by performing the specified replacements.
 	 *
@@ -1784,6 +1786,9 @@ public class MagicSpells extends JavaPlugin {
 		if (matcher.find()) return true;
 
 		matcher = PLACEHOLDER_PATTERN.matcher(message);
+		if (matcher.find()) return true;
+
+		matcher = TARGET_NAME_PATTERN.matcher(message);
 		return matcher.find();
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -217,7 +217,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 	private void open(Player opener, PlayerMenuInventory menu) {
 		List<Player> players = new ArrayList<>(Bukkit.getOnlinePlayers());
 		if (!menu.addOpener) players.remove(opener);
-		if (playerModifiers != null) players.removeIf(p -> !playerModifiers.check(p));
+		if (playerModifiers != null) players.removeIf(p -> !playerModifiers.check(menu.data.caster(), p));
 		if (menu.radius > 0) players.removeIf(p -> opener.getLocation().distance(p.getLocation()) > menu.radius);
 
 		int size = Math.max((int) Math.ceil(Math.min(players.size(), 54) / 9.0) * 9, 9);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
@@ -4,10 +4,10 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import org.bukkit.Fluid;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
 import org.bukkit.Location;
-import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 import org.bukkit.block.BlockFace;
@@ -107,6 +107,11 @@ public class WaterwalkSpell extends BuffSpell {
 			taskId = MagicSpells.scheduleRepeatingTask(this, 5, 5);
 		}
 
+		private boolean isWater(Location location) {
+			Fluid fluid = location.getWorld().getFluidData(location).getFluidType();
+			return fluid == Fluid.WATER || fluid == Fluid.FLOWING_WATER;
+		}
+
 		@Override
 		public void run() {
 			count++;
@@ -126,18 +131,18 @@ public class WaterwalkSpell extends BuffSpell {
 				feet = loc.getBlock();
 				underfeet = feet.getRelative(BlockFace.DOWN);
 
-				if (feet.getType() == Material.WATER) {
-					loc.setY(Math.floor(loc.getY() + 1) + 0.1);
+				if (isWater(feet.getLocation())) {
+					loc.setY(Math.floor(loc.getY() + 1) + 0.01);
 					pl.teleport(loc, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
 				} else if (pl.isFlying() && underfeet.getType().isAir()) {
-					loc.setY(Math.floor(loc.getY() - 1) + 0.1);
+					loc.setY(Math.floor(loc.getY() - 1) + 0.01);
 					pl.teleport(loc, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
 				}
 
 				feet = pl.getLocation().getBlock();
 				underfeet = feet.getRelative(BlockFace.DOWN);
 
-				if (feet.getType().isAir() && underfeet.getType() == Material.WATER) {
+				if (feet.getType().isAir() && isWater(underfeet.getLocation())) {
 					if (!pl.isFlying()) {
 						pl.setAllowFlight(true);
 						pl.setFlying(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/AreaScanSpell.java
@@ -287,9 +287,9 @@ public class AreaScanSpell extends TargetedSpell implements TargetedLocationSpel
 							if (zVariable != null) manager.set(zVariable, playerCaster, target.getZ());
 						}
 
-						SpellData subData = data;
+						SpellData subData = data.location(target);
 						if (scanModifiers != null) {
-							ModifierResult result = scanModifiers.apply(data.caster(), target, data);
+							ModifierResult result = scanModifiers.apply(subData.caster(), target, subData);
 							if (!result.check()) continue;
 
 							subData = result.data();


### PR DESCRIPTION
* Fixed `AreaScanSpell` sub-spell not casting on scanned block locations.
* Fixed `MagSpells#requireReplacement` not considering `%[art]`.
* Fixed `PlayerMenuSpell` checking `player-modifiers` as if the opener was the caster instead of the target.
* Fixed `WaterwalkSpell` not working with non-water fluids, such as waterlogged blocks, kelp, sea grass, etc.