### PR TITLE
Additions and bugfixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -103,9 +103,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 	@Override
 	public CastResult cast(SpellData data) {
-		if (capPerPlayer > 0 && hasReachedCap(data)) {
-			return noTarget(strAtCap, data);
-		}
+		if (capPerPlayer > 0 && hasReachedCap(data)) return noTarget(strAtCap, data);
 
 		RayTraceResult result = rayTraceBlocks(data);
 		if (result == null) return noTarget(data);
@@ -144,9 +142,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 	@Override
 	public CastResult castAtLocation(SpellData data) {
-		if (capPerPlayer > 0 && data.hasCaster() && hasReachedCap(data)) {
-			return noTarget(strAtCap, data);
-		}
+		if (capPerPlayer > 0 && data.hasCaster() && hasReachedCap(data)) return noTarget(strAtCap, data);
 
 		Location location = data.location();
 		Block block = location.getBlock();
@@ -181,9 +177,9 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		int count = 0;
 		for (Pulser pulser : pulsers.values()) {
 			if (!Objects.equals(pulser.data.caster(), data.caster())) continue;
-			count++;
-			if (count >= capPerPlayer) return true;
+			if (++count >= capPerPlayer) return true;
 		}
+
 		return false;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -215,6 +215,11 @@ public class EntityData {
 		addOptBoolean(transformers, config, "can-mob-pickup", Item.class, Item::setCanMobPickup);
 		addOptBoolean(transformers, config, "can-player-pickup", Item.class, Item::setCanPlayerPickup);
 
+		// Interaction
+		addOptFloat(transformers, config, "interaction-height", Interaction.class, Interaction::setInteractionHeight);
+		addOptFloat(transformers, config, "interaction-width", Interaction.class, Interaction::setInteractionWidth);
+		addOptBoolean(transformers, config, "responsive", Interaction.class, Interaction::setResponsive);
+
 		// Llama
 		llamaColor = addOptEnum(transformers, config, "color", Llama.class, Llama.Color.class, Llama::setColor);
 		addOptMaterial(transformers, config, "material", Llama.class, (llama, material) -> llama.getInventory().setDecor(new ItemStack(material)));

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -255,8 +255,9 @@ public class VariableManager {
 						}
 					}
 					bossBarNamespaceKey = bossBar.getString("namespace-key");
-					if (!MagicSpells.getBossBarManager().isNamespaceKey(bossBarNamespaceKey)) {
+					if (bossBarNamespaceKey != null && !MagicSpells.getBossBarManager().isNamespaceKey(bossBarNamespaceKey)) {
 						MagicSpells.error("Variable '" + var + "' has an invalid bossBar namespace-key defined: '" + bossBarNamespaceKey + "'");
+						bossBarNamespaceKey = null;
 					}
 				}
 			}

--- a/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneWorldGuard.java
+++ b/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZoneWorldGuard.java
@@ -1,18 +1,18 @@
 package com.nisovin.magicspells.zones;
 
 import org.bukkit.World;
-import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.configuration.ConfigurationSection;
+
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.protection.regions.RegionType;
+import com.sk89q.worldguard.protection.managers.RegionManager;
+import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.DependsOn;
-
-import com.sk89q.worldguard.WorldGuard;
-import com.sk89q.worldedit.bukkit.BukkitAdapter;
-import com.sk89q.worldguard.protection.managers.RegionManager;
-import com.sk89q.worldguard.protection.regions.ProtectedRegion;
 
 @Name("worldguard")
 @DependsOn("WorldGuard")
@@ -21,37 +21,39 @@ public class NoMagicZoneWorldGuard extends NoMagicZone {
 	private String worldName;
 	private String regionName;
 
-	private ProtectedRegion region;
-
-	private boolean global = false;
-
 	@Override
 	public void initialize(ConfigurationSection config) {
-		worldName = config.getString("world", "");
-		regionName = config.getString("region", "");
-
-		World world = Bukkit.getWorld(worldName);
-		if (world == null) return;
-
-		RegionManager regionManager = WorldGuard.getInstance()
-				.getPlatform()
-				.getRegionContainer()
-				.get(BukkitAdapter.adapt(world));
-		if (regionManager != null) region = regionManager.getRegion(regionName);
-
-		if (regionName.toLowerCase().contains("global")) global = true;
+		worldName = config.getString("world");
+		regionName = config.getString("region");
 	}
 
 	@Override
 	public boolean inZone(Location location) {
-		if (!worldName.equals(location.getWorld().getName())) return false;
-		if (region == null && !global) {
-			MagicSpells.error("Failed to access WorldGuard region '" + regionName + "'");
+		if (regionName == null) {
+			MagicSpells.error("Failed to access WorldGuard region - no region specified.");
 			return false;
 		}
 
-		if (global) return true;
-		return region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
+		if (worldName == null) {
+			MagicSpells.error("Failed to access WorldGuard region '" + regionName + "' - no world specified.");
+			return false;
+		}
+
+		World world = location.getWorld();
+		if (world == null || !world.getName().equals(worldName)) return false;
+
+		RegionManager regionManager = WorldGuard.getInstance()
+			.getPlatform()
+			.getRegionContainer()
+			.get(BukkitAdapter.adapt(world));
+
+		ProtectedRegion region = regionManager == null ? null : regionManager.getRegion(regionName);
+		if (region == null) {
+			MagicSpells.error("Failed to access WorldGuard region '" + regionName + "' - no such region exists.");
+			return false;
+		}
+
+		return region.getType() == RegionType.GLOBAL || region.contains(location.getBlockX(), location.getBlockY(), location.getBlockZ());
 	}
 
 }


### PR DESCRIPTION
- Added the `interaction-height`, `interaction-width`, and `responsive` options to entity data for interaction entities.
- Fixed an issue that caused an error if the `namespace-key` option was not specified in the `boss-bar` section of a variable.
- Fixed an issue with the `worldguard` no magic zone type that caused zone checks to be incorrect if the region was re-defined.