### PR TITLE
Cast command tab completion

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,6 @@
 
 [//]: # (These links are here for easier hyperlink referencing and less clutter in the actual text below.)
 [Discord server]: https://discord.magicspells.dev
-[showcase channel]: https://canary.discord.com/channels/335237931633606656/468537255925907466
 [Releases]: https://github.com/TheComputerGeek2/MagicSpells/releases
 [Wiki]: https://github.com/TheComputerGeek2/MagicSpells/wiki
 [SpellRepo]: https://github.com/niblexis/ms-examples
@@ -28,7 +27,7 @@
 
 MagicSpells is a [PaperMC] plugin which gives its users the ability to modify their Minecraft servers by configuring existing features without writing Java code. It provides you with the tools for playing with blocks of logic, bringing other plugins together, playing fantastic special effects, making your own new mechanics, and more.
 
-Check out more examples of what this plugin can do in our [Discord server] (in the [showcase channel]).
+Check out more examples of what this plugin can do in our [Discord server].
 
 ---
 ## Resources 📝

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -986,19 +986,30 @@ public class MagicSpells extends JavaPlugin {
 	/**
 	 * Gets a spell by its internal name (the key name in the config file)
 	 * @param spellName the internal name of the spell to find
-	 * @return the Spell found, or null if no spell with that name was found
+	 * @return {@link Spell} found, or null if no spell with that name was found
 	 */
 	public static Spell getSpellByInternalName(String spellName) {
 		return plugin.spells.get(spellName.toLowerCase());
 	}
 
 	/**
-	 * Gets a spell by its in-game name (the name specified with the 'name' config option)
+	 * Gets a spell by its in-game name (<code>aliases</code>, the name specified with the <code>name</code>
+	 * config option, or the internal spell name if <code>name</code> was not specified).
 	 * @param spellName the in-game name of the spell to find
-	 * @return the Spell found, or null if no spell with that name was found
+	 * @return {@link Spell} found, or null if no spell with that name was found
 	 */
 	public static Spell getSpellByInGameName(String spellName) {
 		return plugin.spellNames.get(spellName.toLowerCase());
+	}
+
+	/**
+	 * Gets a spell by its internal name, <code>aliases</code> or <code>name</code>).
+	 * @param spellName the name of the spell to find
+	 * @return {@link Spell} found, or null
+	 */
+	public static Spell getSpellByName(String spellName) {
+		Spell spell = getSpellByInternalName(spellName);
+		return spell == null ? getSpellByInGameName(spellName) : spell;
 	}
 
 	/**

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1180,25 +1180,8 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		return true;
 	}
 
-	public List<String> tabComplete(CommandSender sender, String partial) {
+	public List<String> tabComplete(CommandSender sender, String[] args) {
 		return null;
-	}
-
-	protected List<String> tabCompletePlayerName(CommandSender sender, String partial) {
-		List<String> matches = new ArrayList<>();
-		partial = partial.toLowerCase();
-		// TODO stream this
-		for (Player p : Bukkit.getOnlinePlayers()) {
-			String name = p.getName();
-			if (!name.toLowerCase().startsWith(partial)) continue;
-			if (sender.isOp() || !(sender instanceof Player player) || player.canSee(p)) matches.add(name);
-		}
-		if (!matches.isEmpty()) return matches;
-		return null;
-	}
-
-	protected List<String> tabCompleteSpellName(CommandSender sender, String partial) {
-		return TxtUtil.tabCompleteSpellName(sender, partial);
 	}
 
 	// TODO can this safely be made varargs?

--- a/core/src/main/java/com/nisovin/magicspells/Spellbook.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spellbook.java
@@ -179,12 +179,6 @@ public class Spellbook {
 		return player.hasPermission(Perm.ADVANCED.getNode() + spell);
 	}
 
-	public Spell getSpellByName(String spellName) {
-		Spell spell = MagicSpells.getSpellByInGameName(spellName);
-		if (spell != null && hasSpell(spell)) return spell;
-		return null;
-	}
-
 	public void addSpell(Spell spell) {
 		addSpell(spell, (CastItem[]) null);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/commands/CommandHelpFilter.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/CommandHelpFilter.java
@@ -1,9 +1,8 @@
 package com.nisovin.magicspells.commands;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.HashMap;
-import java.util.HashSet;
+import java.util.Iterator;
 
 import co.aikar.commands.HelpEntry;
 import co.aikar.commands.RootCommand;
@@ -20,9 +19,8 @@ public class CommandHelpFilter {
 
 	public static void mapPerms() {
 		for (RootCommand rootCommand : MagicSpells.getCommandManager().getRegisteredRootCommands()) {
-			//noinspection rawtypes
-			for (RegisteredCommand command : rootCommand.getSubCommands().values()) {
-				HelpPermission annotation = (HelpPermission) command.getAnnotation(HelpPermission.class);
+			for (RegisteredCommand<?> command : rootCommand.getSubCommands().values()) {
+				HelpPermission annotation = command.getAnnotation(HelpPermission.class);
 				if (annotation == null) continue;
 				magicPerms.put(command.getCommand(), annotation.permission().getNode());
 			}
@@ -31,15 +29,12 @@ public class CommandHelpFilter {
 
 	public static void filter(CommandSender sender, CommandHelp help) {
 		// Filter help entries by permissions.
-		Set<HelpEntry> toRemove = new HashSet<>();
-		for (HelpEntry entry : help.getHelpEntries()) {
-			String perm = magicPerms.get(entry.getCommand());
+		Iterator<HelpEntry> iterator = help.getHelpEntries().iterator();
+		while (iterator.hasNext()) {
+			String perm = magicPerms.get(iterator.next().getCommand());
 			if (perm == null) continue;
 			if (sender.hasPermission(perm)) continue;
-			toRemove.add(entry);
-		}
-		for (HelpEntry entry : toRemove) {
-			help.getHelpEntries().remove(entry);
+			iterator.remove();
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -824,6 +824,7 @@ public class MagicCommand extends BaseCommand {
 		public void onCastAt(CommandIssuer issuer, String[] args) {
 			if (!MagicSpells.isLoaded()) return;
 			if (noPermission(issuer.getIssuer(), Perm.COMMAND_CAST_AT)) return;
+
 			args = Util.splitParams(args);
 			if (args.length < 4) throw new InvalidCommandArgument();
 			Spell spell = getSpell(issuer, args[0]);
@@ -833,7 +834,7 @@ public class MagicCommand extends BaseCommand {
 			}
 
 			World world = null;
-			float pitch = 0, yaw = 0;
+			float yaw = 0, pitch = 0;
 			int i = 0;
 			// Has world parameter.
 			if (!ACFUtil.isDouble(args[1])) {
@@ -847,8 +848,8 @@ public class MagicCommand extends BaseCommand {
 				world = location.getWorld();
 				// If only coordinates were specified.
 				if (args.length < 5) {
-					pitch = location.getPitch();
 					yaw = location.getYaw();
+					pitch = location.getPitch();
 				}
 			}
 			// This fails if the world wasn't specified and the issuer is console, or if the world was invalid.
@@ -863,13 +864,13 @@ public class MagicCommand extends BaseCommand {
 			double z = ACFUtil.parseDouble(args[3 + i]);
 			if (args.length > 4 + i) {
 				if (!ACFUtil.isFloat(args[4 + i])) throw new InvalidCommandArgument();
-				pitch = ACFUtil.parseFloat(args[4 + i]);
+				yaw = ACFUtil.parseFloat(args[4 + i]);
 			}
 			if (args.length > 5 + i) {
 				if (!ACFUtil.isFloat(args[5 + i])) throw new InvalidCommandArgument();
-				yaw = ACFUtil.parseFloat(args[5 + i]);
+				pitch = ACFUtil.parseFloat(args[5 + i]);
 			}
-			Location location = new Location(world, x, y, z, pitch, yaw);
+			Location location = new Location(world, x, y, z, yaw, pitch);
 
 			// Handle with or without caster.
 			SpellData data = new SpellData(issuer.getIssuer() instanceof LivingEntity le ? le : null, location, 1f, null);

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -172,16 +172,13 @@ public class MagicCommand extends BaseCommand {
 		return spellNames;
 	}
 
+	private static Spell getSpell(String name) {
+		return MagicSpells.getSpellByName(QUOTATIONS_PATTERN.matcher(name).replaceAll(""));
+	}
+
 	private static Spell getSpell(CommandIssuer issuer, String name) {
-		Spell spell = MagicSpells.getSpellByInternalName(name);
-		if (spell == null) {
-			// Remove quotations for ingame name - previous handling.
-			name = QUOTATIONS_PATTERN.matcher(name).replaceAll("");
-			spell = MagicSpells.getSpellByInGameName(name);
-		}
-		if (spell == null) {
-			issuer.sendMessage(MagicSpells.getTextColor() + "No matching spell found: '" + name + "'");
-		}
+		Spell spell = getSpell(name);
+		if (spell == null) issuer.sendMessage(MagicSpells.getTextColor() + "No matching spell found: '" + name + "'");
 		return spell;
 	}
 
@@ -229,13 +226,11 @@ public class MagicCommand extends BaseCommand {
 	}
 
 	private static float getPowerFromArgs(String[] args) {
-		float power = 1F;
 		for (String string : args) {
 			if (!string.startsWith("-p:")) continue;
-			power = ACFUtil.parseFloat(string.substring(3), 1F);
-			break;
+			return ACFUtil.parseFloat(string.substring(3), 1F);
 		}
-		return power;
+		return 1F;
 	}
 
 	private static boolean noPermission(CommandSender sender, Perm perm) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/CommandSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/CommandSpell.java
@@ -27,6 +27,6 @@ public abstract class CommandSpell extends Spell {
 	public abstract boolean castFromConsole(CommandSender sender, String[] args);
 
 	@Override
-	public abstract List<String> tabComplete(CommandSender sender, String partial);
-	
+	public abstract List<String> tabComplete(CommandSender sender, String[] args);
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/AdminTeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/AdminTeachSpell.java
@@ -10,6 +10,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.command.CommandSender;
 import org.bukkit.scheduler.BukkitRunnable;
+import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.*;
@@ -52,8 +53,9 @@ public class AdminTeachSpell extends CommandSpell {
 	}
 	
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof ConsoleCommandSender) || args.length != 1) return null;
+		return TxtUtil.tabCompleteSpellName(sender);
 	}
 	
 	private static class AdminTeachTask extends BukkitRunnable {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
@@ -71,7 +71,7 @@ public class BindSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(data.args(), ' '));
+		Spell spell = MagicSpells.getSpellByName(Util.arrayJoin(data.args(), ' '));
 		Spellbook spellbook = MagicSpells.getSpellbook(caster);
 
 		if (spell == null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/BindSpell.java
@@ -137,9 +137,8 @@ public class BindSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (sender instanceof Player && !partial.contains(" ")) return tabCompleteSpellName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return sender instanceof Player && args.length == 1 ? TxtUtil.tabCompleteSpellName(sender) : null;
 	}
 
 	public Set<CastItem> getBindableItems() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
@@ -76,7 +76,7 @@ public class ForgetSpell extends CommandSpell {
 		boolean all = false;
 		Spell spell = null;
 		if (spellName.equals("*")) all = true;
-		else spell = MagicSpells.getSpellByInGameName(spellName);
+		else spell = MagicSpells.getSpellByName(spellName);
 
 		if (spell == null && !all) {
 			sendMessage(strNoSpell, caster, data);
@@ -137,7 +137,7 @@ public class ForgetSpell extends CommandSpell {
 		Spell spell = null;
 		boolean all = false;
 		if (args[1].equals("*")) all = true;
-		else spell = MagicSpells.getSpellByInGameName(args[1]);
+		else spell = MagicSpells.getSpellByName(args[1]);
 
 		if (spell == null && !all) {
 			sender.sendMessage(strNoSpell);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ForgetSpell.java
@@ -6,6 +6,7 @@ import java.util.ArrayList;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.*;
@@ -169,19 +170,32 @@ public class ForgetSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		String[] args = Util.splitParams(partial);
-		if (args.length == 1) {
-			// Matching player name or spell name
-			List<String> options = new ArrayList<>();
-			List<String> players = tabCompletePlayerName(sender, args[0]);
-			List<String> spells = tabCompleteSpellName(sender, args[0]);
-			if (players != null) options.addAll(players);
-			if (spells != null) options.addAll(spells);
-			if (!options.isEmpty()) return options;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (sender instanceof ConsoleCommandSender) {
+			if (args.length == 1) return TxtUtil.tabCompletePlayerName(sender);
+			if (args.length == 2) {
+				List<String> ret = new ArrayList<>();
+				ret.add("*");
+				ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+				return ret;
+			}
+		} else if (sender instanceof Player player) {
+			if (args.length == 1) {
+				List<String> ret = new ArrayList<>();
+				if (MagicSpells.getSpellbook(player).hasAdvancedPerm("forget")) {
+					ret.addAll(TxtUtil.tabCompletePlayerName(sender));
+				}
+				ret.add("*");
+				ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+				return ret;
+			}
+			if (args.length == 2 && Bukkit.getPlayer(args[0]) != null) {
+				List<String> ret = new ArrayList<>();
+				ret.add("*");
+				ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+				return ret;
+			}
 		}
-
-		if (args.length == 2) return tabCompleteSpellName(sender, args[1]);
 		return null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
@@ -64,10 +64,8 @@ public class HelpSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		String[] args = Util.splitParams(partial);
-		if (sender instanceof Player && args.length == 1) return tabCompleteSpellName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return sender instanceof Player && args.length == 1 ? TxtUtil.tabCompleteSpellName(sender) : null;
 	}
 
 	public String getStrUsage() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/HelpSpell.java
@@ -41,7 +41,7 @@ public class HelpSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(data.args(), ' '));
+		Spell spell = MagicSpells.getSpellByName(Util.arrayJoin(data.args(), ' '));
 		Spellbook spellbook = MagicSpells.getSpellbook(caster);
 
 		if (spell == null || requireKnownSpell.get(data) && !spellbook.hasSpell(spell)) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -105,7 +105,7 @@ public class ImbueSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(data.args()[0]);
+		Spell spell = MagicSpells.getSpellByName(data.args()[0]);
 		if (spell == null || !MagicSpells.getSpellbook(caster).hasSpell(spell)) {
 			sendMessage(strCantImbueSpell, caster, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -146,6 +146,14 @@ public class ImbueSpell extends CommandSpell {
 		return false;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player)) return null;
+		if (args.length == 1) return TxtUtil.tabCompleteSpellName(sender);
+		if (args.length == 2) return List.of("1");
+		return null;
+	}
+
 	@EventHandler(priority = EventPriority.HIGHEST)
 	public void onInteract(PlayerInteractEvent event) {
 		if (event.useItemInHand() == Result.DENY) return;
@@ -211,15 +219,6 @@ public class ImbueSpell extends CommandSpell {
 			meta.lore(Collections.singletonList(Util.getMiniMessage(lore)));
 		}
 		item.setItemMeta(meta);
-	}
-
-	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		return null;
-	}
-
-	public static Pattern getCastArgUsesPattern() {
-		return CAST_ARG_USES_PATTERN;
 	}
 
 	public Set<Material> getAllowedItemTypes() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ItemSerializeSpell.java
@@ -86,7 +86,7 @@ public class ItemSerializeSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
+	public List<String> tabComplete(CommandSender sender, String[] args) {
 		return null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.List;
 import java.util.HashMap;
 import java.io.IOException;
+import java.util.ArrayList;
 
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -137,6 +138,14 @@ public class KeybindSpell extends CommandSpell {
 		return false;
 	}
 
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player) || args.length != 1) return null;
+		List<String> ret = new ArrayList<>(List.of("clear", "clearall"));
+		ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+		return ret;
+	}
+
 	@EventHandler
 	public void onItemHeldChange(PlayerItemHeldEvent event) {
 		Keybinds keybinds = playerKeybinds.get(event.getPlayer().getName());
@@ -166,11 +175,6 @@ public class KeybindSpell extends CommandSpell {
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerJoin(PlayerJoinEvent event) {
 		loadKeybinds(event.getPlayer());
-	}
-
-	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		return null;
 	}
 
 	public ItemStack getWandItem() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/KeybindSpell.java
@@ -118,8 +118,8 @@ public class KeybindSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Spell spell = MagicSpells.getSpellbook(caster).getSpellByName(data.args()[0]);
-		if (spell == null) {
+		Spell spell = MagicSpells.getSpellByName(data.args()[0]);
+		if (spell == null || !MagicSpells.getSpellbook(caster).hasSpell(spell)) {
 			caster.sendMessage("No spell.");
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ListSpell.java
@@ -117,10 +117,14 @@ public class ListSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (sender instanceof ConsoleCommandSender && !partial.contains(" "))
-			return tabCompletePlayerName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length != 1) return null;
+
+		if (sender instanceof Player player) {
+			if (!MagicSpells.getSpellbook(player).hasAdvancedPerm("list")) return null;
+		} else if (!(sender instanceof ConsoleCommandSender)) return null;
+
+		return TxtUtil.tabCompletePlayerName(sender);
 	}
 
 	private boolean shouldListSpell(Spell spell, Spellbook spellbook, boolean onlyShowCastableSpells) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -135,7 +135,7 @@ public class ScrollSpell extends CommandSpell {
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(data.args()[0]);
+		Spell spell = MagicSpells.getSpellByName(data.args()[0]);
 		Spellbook spellbook = MagicSpells.getSpellbook(caster);
 		if (spell == null || !spellbook.hasSpell(spell)) {
 			sendMessage(strNoSpell, caster, data);
@@ -180,7 +180,7 @@ public class ScrollSpell extends CommandSpell {
 			return false;
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(args[1]);
+		Spell spell = MagicSpells.getSpellByName(args[1]);
 		if (spell == null) {
 			sender.sendMessage(strNoSpell);
 			return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ScrollSpell.java
@@ -16,6 +16,7 @@ import org.bukkit.event.EventPriority;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.inventory.meta.Damageable;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemHeldEvent;
@@ -229,9 +230,16 @@ public class ScrollSpell extends CommandSpell {
 	}
 	
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		String[] args = Util.splitParams(partial);
-		if (args.length == 1) return tabCompleteSpellName(sender, args[0]);
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (sender instanceof ConsoleCommandSender) {
+			if (args.length == 1) return TxtUtil.tabCompletePlayerName(sender);
+			if (args.length == 2) return TxtUtil.tabCompleteSpellName(sender);
+			if (args.length == 3) return List.of("1");
+		}
+		else if (sender instanceof Player) {
+			if (args.length == 1) return TxtUtil.tabCompleteSpellName(sender);
+			if (args.length == 2) return List.of("1");
+		}
 		return null;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
@@ -21,6 +21,7 @@ import org.bukkit.util.RayTraceResult;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.event.player.PlayerInteractEvent;
 
 import com.nisovin.magicspells.Perm;
@@ -236,9 +237,15 @@ public class SpellbookSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (sender instanceof Player && !partial.contains(" ")) return tabCompleteSpellName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length == 1) {
+			List<String> ret = new ArrayList<>();
+			ret.add("reload");
+			if (sender instanceof Player) ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+			return ret;
+		}
+		if (args.length != 2 || args[0].equals("reload") || sender instanceof ConsoleCommandSender) return null;
+		return List.of("1");
 	}
 
 	private void loadSpellbooks() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SpellbookSpell.java
@@ -112,7 +112,7 @@ public class SpellbookSpell extends CommandSpell {
 		}
 
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
-		Spell spell = MagicSpells.getSpellByInGameName(data.args()[0]);
+		Spell spell = MagicSpells.getSpellByName(data.args()[0]);
 		if (spell == null || !spellbook.hasSpell(spell)) {
 			sendMessage(strNoSpell, player, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/SublistSpell.java
@@ -115,9 +115,8 @@ public class SublistSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (sender instanceof ConsoleCommandSender && !partial.contains(" ")) return tabCompletePlayerName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return sender instanceof ConsoleCommandSender && args.length == 1 ? TxtUtil.tabCompletePlayerName(sender) : null;
 	}
 
 	private boolean shouldListSpell(Spell spell, Spellbook spellbook, boolean onlyShowCastableSpells) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
@@ -60,7 +60,7 @@ public class TeachSpell extends CommandSpell {
 		Player target = players.get(0);
 		data = data.target(target);
 
-		Spell spell = MagicSpells.getSpellByInGameName(data.args()[1]);
+		Spell spell = MagicSpells.getSpellByName(data.args()[1]);
 		if (spell == null) {
 			sendMessage(strNoSpell, player, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
@@ -115,7 +115,7 @@ public class TeachSpell extends CommandSpell {
 			sender.sendMessage(strNoTarget);
 			return true;
 		}
-		Spell spell = MagicSpells.getSpellByInGameName(args[1]);
+		Spell spell = MagicSpells.getSpellByName(args[1]);
 		if (spell == null) {
 			sender.sendMessage(strNoSpell);
 			return true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TeachSpell.java
@@ -146,10 +146,9 @@ public class TeachSpell extends CommandSpell {
 	}
 	
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		String[] args = Util.splitParams(partial);
-		if (args.length == 1) return tabCompletePlayerName(sender, args[0]);
-		if (args.length == 2) return tabCompleteSpellName(sender, args[1]);
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length == 1) return TxtUtil.tabCompletePlayerName(sender);
+		if (args.length == 2) return TxtUtil.tabCompleteSpellName(sender);
 		return null;
 	}
 	

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -80,7 +80,7 @@ public class TomeSpell extends CommandSpell {
 		}
 
 		Spellbook spellbook = MagicSpells.getSpellbook(player);
-		Spell spell = MagicSpells.getSpellByInGameName(data.args()[0]);
+		Spell spell = MagicSpells.getSpellByName(data.args()[0]);
 		if (spell == null || !spellbook.hasSpell(spell)) {
 			sendMessage(strNoSpell, player, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/TomeSpell.java
@@ -114,9 +114,11 @@ public class TomeSpell extends CommandSpell {
 	public boolean castFromConsole(CommandSender sender, String[] args) {
 		return false;
 	}
-	
+
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length == 1) return TxtUtil.tabCompleteSpellName(sender);
+		if (args.length == 2) return List.of("1");
 		return null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
@@ -77,7 +77,7 @@ public class UnbindSpell extends CommandSpell {
 			return new CastResult(PostCastAction.NO_MESSAGES, data);
 		}
 
-		Spell spell = MagicSpells.getSpellByInGameName(Util.arrayJoin(data.args(), ' '));
+		Spell spell = MagicSpells.getSpellByName(Util.arrayJoin(data.args(), ' '));
 		if (spell == null) {
 			sendMessage(strNoSpell, caster, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/UnbindSpell.java
@@ -112,9 +112,12 @@ public class UnbindSpell extends CommandSpell {
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (sender instanceof Player && !partial.contains(" ")) return tabCompleteSpellName(sender, partial);
-		return null;
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (!(sender instanceof Player) || args.length != 1) return null;
+		List<String> ret = new ArrayList<>();
+		ret.add("*");
+		ret.addAll(TxtUtil.tabCompleteSpellName(sender));
+		return ret;
 	}
 
 	public Set<Spell> getAllowedSpells() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/EnderchestSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/EnderchestSpell.java
@@ -1,9 +1,14 @@
 package com.nisovin.magicspells.spells.instant;
 
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 
@@ -17,7 +22,7 @@ public class EnderchestSpell extends InstantSpell implements TargetedEntitySpell
 	public CastResult cast(SpellData data) {
 		if (!(data.caster() instanceof Player caster)) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
-		if (data.hasArgs() && data.args().length == 1 && caster.hasPermission("magicspells.advanced." + internalName)) {
+		if (data.hasArgs() && data.args().length == 1 && MagicSpells.getSpellbook(caster).hasAdvancedPerm(internalName)) {
 			Player target = Bukkit.getPlayer(data.args()[0]);
 			if (target == null) {
 				sendMessage(caster, "Invalid player target.");
@@ -41,6 +46,17 @@ public class EnderchestSpell extends InstantSpell implements TargetedEntitySpell
 		playSpellEffects(data);
 
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length != 1) return null;
+
+		if (sender instanceof Player player) {
+			if (!MagicSpells.getSpellbook(player).hasAdvancedPerm(internalName)) return null;
+		} else if (!(sender instanceof ConsoleCommandSender)) return null;
+
+		return TxtUtil.tabCompletePlayerName(sender);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RecallSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RecallSpell.java
@@ -1,10 +1,14 @@
 package com.nisovin.magicspells.spells.instant;
 
+import java.util.List;
+
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.Vehicle;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.command.CommandSender;
+import org.bukkit.command.ConsoleCommandSender;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.*;
@@ -57,7 +61,8 @@ public class RecallSpell extends InstantSpell implements TargetedEntitySpell {
 	public CastResult cast(SpellData data) {
 		Location markLocation;
 
-		if (data.hasArgs() && data.args().length == 1 && data.caster().hasPermission("magicspells.advanced." + internalName)) {
+		boolean hasPerm = data.caster() instanceof Player caster && MagicSpells.getSpellbook(caster).hasAdvancedPerm(internalName);
+		if (data.hasArgs() && data.args().length == 1 && hasPerm) {
 			Player target = Bukkit.getPlayer(data.args()[0]);
 			markLocation = getRecallLocation(target, data);
 		} else markLocation = getRecallLocation(data.caster(), data);
@@ -69,6 +74,17 @@ public class RecallSpell extends InstantSpell implements TargetedEntitySpell {
 	public CastResult castAtEntity(SpellData data) {
 		if (!data.hasCaster()) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		return recall(data, data.target(), getRecallLocation(data.caster(), data));
+	}
+
+	@Override
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		if (args.length != 1) return null;
+
+		if (sender instanceof Player player) {
+			if (!MagicSpells.getSpellbook(player).hasAdvancedPerm(internalName)) return null;
+		} else if (!(sender instanceof ConsoleCommandSender)) return null;
+
+		return TxtUtil.tabCompletePlayerName(sender);
 	}
 
 	private CastResult recall(SpellData data, LivingEntity entity, Location markLocation) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SummonSpell.java
@@ -168,9 +168,8 @@ public class SummonSpell extends TargetedSpell implements TargetedEntitySpell, T
 	}
 
 	@Override
-	public List<String> tabComplete(CommandSender sender, String partial) {
-		if (partial.contains(" ")) return null;
-		return tabCompletePlayerName(sender, partial);
+	public List<String> tabComplete(CommandSender sender, String[] args) {
+		return args.length == 1 ? TxtUtil.tabCompletePlayerName(sender) : null;
 	}
 
 	private record SummonData(Location location, long time, int maxAcceptDelay, SpellData spellData) {

--- a/towny/src/main/java/com/nisovin/magicspells/towny/MagicSpellsTowny.java
+++ b/towny/src/main/java/com/nisovin/magicspells/towny/MagicSpellsTowny.java
@@ -44,8 +44,7 @@ public class MagicSpellsTowny extends JavaPlugin implements Listener {
 		if (config.contains("disallowed-in-towns")) {
 			List<String> list = config.getStringList("disallowed-in-towns");
 			for (String s : list) {
-				Spell spell = MagicSpells.getSpellByInternalName(s);
-				if (spell == null) spell = MagicSpells.getSpellByInGameName(s);
+				Spell spell = MagicSpells.getSpellByName(s);
 				if (spell != null) disallowedInTowns.add(spell);
 				else getLogger().warning("Could not find spell: '" + s + "'.");
 			}


### PR DESCRIPTION
- Fixed some spells which accept spell names in their spell cast arguments not accepting internal spell names if the passed spell's `name` was defined. Full list: `BindSpell`, `ForgetSpell`, `HelpSpell`, `ImbueSpell`, `ScrollSpell`, `SpellbookSpell`, `TeachSpell`, `TomeSpell`, and `UnbindSpell`.
- Added cast command tab completion for spell cast arguments to: `AdminTeachSpell`, `BindSpell`, `ForgetSpell`, `HelpSpell`, `ImbueSpell`, `KeybindSpell`, `ListSpell`, `ScrollSpell`, `SpellbookSpell`, `SublistSpell`, `TeachSpell`, `TomeSpell`, `UnbindSpell`, `EnderchestSpell`, `RecallSpell`, and `SummonSpell`.
- Fixed the default yaw and pitch passed to the `/ms cast at` command from the executor's location being reversed.
- Added support for passing the `-p:` spell power flag and spell cast arguments using the `/ms cast on` command.