### PR TITLE
More attribute changes, fix `external::vanilla` magic item serializer

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -54,4 +54,12 @@ public class AttributeUtil {
 		return operationNameMap.get(operation.toLowerCase());
 	}
 
+	public static String getOperationName(Operation operation) {
+		return switch (operation) {
+			case ADD_NUMBER -> "add_value";
+			case ADD_SCALAR -> "add_multiplied_base";
+			case MULTIPLY_SCALAR_1 -> "add_multiplied_total";
+		};
+	}
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/AttributeUtil.java
@@ -3,6 +3,8 @@ package com.nisovin.magicspells.util;
 import java.util.Map;
 import java.util.HashMap;
 
+import org.bukkit.Registry;
+import org.bukkit.NamespacedKey;
 import org.bukkit.attribute.Attribute;
 
 import static org.bukkit.attribute.AttributeModifier.Operation;
@@ -42,12 +44,18 @@ public class AttributeUtil {
 			attributeNameMap.put(key.substring(key.indexOf('.') + 1), attribute);
 
 			attributeNameMap.put(rep, attribute);
-			attributeNameMap.put(rep.substring(key.indexOf('.') + 1), attribute);
+			attributeNameMap.put(rep.substring(rep.indexOf('.') + 1), attribute);
 		}
 	}
 
 	public static Attribute getAttribute(String attribute) {
-		return attributeNameMap.get(attribute.toLowerCase());
+		Attribute attr = attributeNameMap.get(attribute.toLowerCase());
+		if (attr != null) return attr;
+
+		NamespacedKey key = NamespacedKey.fromString(attribute);
+		if (key == null) return null;
+
+		return Registry.ATTRIBUTE.get(key);
 	}
 
 	public static Operation getOperation(String operation) {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/AttributeHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/AttributeHandler.java
@@ -113,7 +113,7 @@ public class AttributeHandler {
 						key = NamespacedKey.fromString(args[4], MagicSpells.getInstance());
 
 						if (key == null) {
-							MagicSpells.error("Invalid namespaced key '" + args[3] + "' on attribute modifier '" + string + "'.");
+							MagicSpells.error("Invalid namespaced key '" + args[4] + "' on attribute modifier '" + string + "'.");
 							continue;
 						}
 					} else {

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/BannerHandler.java
@@ -38,10 +38,11 @@ public class BannerHandler {
 			if (patternType == null) {
 				NamespacedKey key = NamespacedKey.fromString(patternTypeString);
 				if (key != null) patternType = Registry.BANNER_PATTERN.get(key);
-			}
-			if (patternType == null) {
-				MagicSpells.error("Invalid banner pattern type '" + args[0] + "' when parsing magic item.");
-				continue;
+
+				if (patternType == null) {
+					MagicSpells.error("Invalid banner pattern type '" + args[0] + "' when parsing magic item.");
+					continue;
+				}
 			}
 
 			DyeColor dyeColor;

--- a/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/VanillaReader.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/itemreader/alternative/VanillaReader.java
@@ -31,7 +31,7 @@ public class VanillaReader implements ItemConfigTransformer {
 		YamlConfiguration configuration = new YamlConfiguration();
 
 		String data = itemStack.getType().getKey().toString();
-		if (itemStack.hasItemMeta()) data += itemStack.getItemMeta().getAsString();
+		if (itemStack.hasItemMeta()) data += itemStack.getItemMeta().getAsComponentString();
 
 		configuration.set("data", data);
 		configuration.set("amount", itemStack.getAmount());


### PR DESCRIPTION
- Breaking change: magic item comparison no longer uses a liberal method of attribute modifier checking. Attribute modifiers must now have the same ID and be listed in the same order in order to match.
- Attribute usages now allow specifying a full namespaced key.
- Fixed an issue that caused the `external::vanilla` magic item serializer to not output the correct format.