### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingInSlotCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/WearingInSlotCondition.java
@@ -22,6 +22,7 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.castmodifiers.Condition;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("wearinginslot")
 public class WearingInSlotCondition extends Condition {
@@ -80,8 +81,8 @@ public class WearingInSlotCondition extends Condition {
 			slots.add(slot);
 		}
 
-		for (String magicItemString : data[1].split("\\|")) {
-			if (magicItemString.equals("0") || magicItemString.equals("air") || magicItemString.equals("empty")) {
+		for (String magicItemString : data[1].split(MagicItemDataParser.DATA_REGEX)) {
+			if (List.of("0", "air", "empty").contains(magicItemString)) {
 				emptyCheck = true;
 				continue;
 			}

--- a/core/src/main/java/com/nisovin/magicspells/handlers/EnchantmentHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/EnchantmentHandler.java
@@ -2,15 +2,17 @@ package com.nisovin.magicspells.handlers;
 
 import org.jetbrains.annotations.NotNull;
 
-import org.bukkit.Registry;
 import org.bukkit.NamespacedKey;
 import org.bukkit.enchantments.Enchantment;
+
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.RegistryAccess;
 
 public class EnchantmentHandler {
 
 	public static Enchantment getEnchantment(@NotNull String name) {
 		NamespacedKey key = NamespacedKey.fromString(name.toLowerCase());
-		return key == null ? null : Registry.ENCHANTMENT.get(key);
+		return key == null ? null : RegistryAccess.registryAccess().getRegistry(RegistryKey.ENCHANTMENT).get(key);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
@@ -2,7 +2,6 @@ package com.nisovin.magicspells.listeners;
 
 import org.bukkit.entity.Entity;
 import org.bukkit.event.Listener;
-import org.bukkit.entity.ArmorStand;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.world.ChunkLoadEvent;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/AnvilListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/AnvilListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("anvil")
 public class AnvilListener extends PassiveListener {
@@ -32,7 +33,7 @@ public class AnvilListener extends PassiveListener {
 
 		if (split.length > 0) {
 			if (!split[0].equals("any")) {
-				String[] items = split[0].split("\\|");
+				String[] items = split[0].split(MagicItemDataParser.DATA_REGEX);
 				firstItem = new HashSet<>();
 
 				for (String item : items) {
@@ -49,7 +50,7 @@ public class AnvilListener extends PassiveListener {
 
 		if (split.length > 1) {
 			if (!split[1].equals("any")) {
-				String[] items = split[1].split("\\|");
+				String[] items = split[1].split(MagicItemDataParser.DATA_REGEX);
 				secondItem = new HashSet<>();
 
 				for (String item : items) {
@@ -66,7 +67,7 @@ public class AnvilListener extends PassiveListener {
 
 		if (split.length > 2) {
 			if (!split[2].equals("any")) {
-				String[] items = split[2].split("\\|");
+				String[] items = split[2].split(MagicItemDataParser.DATA_REGEX);
 				resultItem = new HashSet<>();
 
 				for (String item : items) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/CraftListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("craft")
 public class CraftListener extends PassiveListener {
@@ -25,7 +26,7 @@ public class CraftListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);
 			if (itemData == null) {
 				MagicSpells.error("Invalid magic item '" + s + "' in craft trigger on passive spell '" + passiveSpell.getInternalName() + "'");

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/DropItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/DropItemListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Optional trigger variable that may contain a pipe separated list of items to accept
 @Name("dropitem")
@@ -26,7 +27,7 @@ public class DropItemListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/EnchantListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/EnchantListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("enchant")
 public class EnchantListener extends PassiveListener {
@@ -28,7 +29,7 @@ public class EnchantListener extends PassiveListener {
 		if (var.isEmpty()) return;
 
 		items = new HashSet<>();
-		for (String item : var.split("\\|")) {
+		for (String item : var.split(MagicItemDataParser.DATA_REGEX)) {
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(item);
 			if (itemData == null) {
 				MagicSpells.error("Invalid magic item '" + item + "' in enchant trigger on passive spell '" + passiveSpell.getInternalName() + "'.");

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/EquipListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/EquipListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("equip")
 public class EquipListener extends PassiveListener {
@@ -27,7 +28,7 @@ public class EquipListener extends PassiveListener {
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
 
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FoodLevelChangeListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FoodLevelChangeListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("foodlevelchange")
 public class FoodLevelChangeListener extends PassiveListener {
@@ -25,7 +26,7 @@ public class FoodLevelChangeListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
@@ -21,6 +21,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Optional trigger variable of a pipe separated list that can contain
 // damage causes or damaging magic items to accept
@@ -33,7 +34,7 @@ public class GiveDamageListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			boolean isDamCause = false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GrindstoneListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GrindstoneListener.java
@@ -20,6 +20,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("grindstone")
 public class GrindstoneListener extends PassiveListener {
@@ -35,7 +36,7 @@ public class GrindstoneListener extends PassiveListener {
 
 		if (split.length > 0) {
 			if (!split[0].equals("any")) {
-				String[] items = split[0].split("\\|");
+				String[] items = split[0].split(MagicItemDataParser.DATA_REGEX);
 				upperItem = new HashSet<>();
 
 				for (String item : items) {
@@ -52,7 +53,7 @@ public class GrindstoneListener extends PassiveListener {
 
 		if (split.length > 1) {
 			if (!split[1].equals("any")) {
-				String[] items = split[1].split("\\|");
+				String[] items = split[1].split(MagicItemDataParser.DATA_REGEX);
 				lowerItem = new HashSet<>();
 
 				for (String item : items) {
@@ -69,7 +70,7 @@ public class GrindstoneListener extends PassiveListener {
 
 		if (split.length > 2) {
 			if (!split[2].equals("any")) {
-				String[] items = split[2].split("\\|");
+				String[] items = split[2].split(MagicItemDataParser.DATA_REGEX);
 				resultItem = new HashSet<>();
 
 				for (String item : items) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("hitarrow")
 public class HitArrowListener extends PassiveListener {
@@ -26,7 +27,7 @@ public class HitArrowListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarDeselectListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("hotbardeselect")
 public class HotbarDeselectListener extends PassiveListener {
@@ -25,7 +26,7 @@ public class HotbarDeselectListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HotbarSelectListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Trigger variable is the item to trigger on
 @Name("hotbarselect")
@@ -26,7 +27,7 @@ public class HotbarSelectListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/LeftClickItemListener.java
@@ -18,6 +18,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Trigger variable of a pipe separated list of items to accept
 @Name("leftclickitem")
@@ -28,7 +29,7 @@ public class LeftClickItemListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
@@ -23,6 +23,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("missarrow")
 public class MissArrowListener extends PassiveListener {
@@ -32,7 +33,7 @@ public class MissArrowListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PickupItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PickupItemListener.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Optional trigger variable that is a pipe separated list of items to accept
 @Name("pickupitem")
@@ -26,7 +27,7 @@ public class PickupItemListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PlayerAnimationListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Trigger variable of a pipe separated list of items to accept
 @Name("playeranimate")
@@ -27,7 +28,7 @@ public class PlayerAnimationListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/PrepareEnchantListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/PrepareEnchantListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("prepareenchant")
 public class PrepareEnchantListener extends PassiveListener {
@@ -28,7 +29,7 @@ public class PrepareEnchantListener extends PassiveListener {
 		if (var.isEmpty()) return;
 		items = new HashSet<>();
 
-		for (String item : var.split("\\|")) {
+		for (String item : var.split(MagicItemDataParser.DATA_REGEX)) {
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(item);
 			if (itemData == null) {
 				MagicSpells.error("Invalid magic item '" + item + "' in enchant trigger on passive spell '" + passiveSpell.getInternalName() + "'.");

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/RightClickItemListener.java
@@ -18,6 +18,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Trigger variable of a pipe separated list of items to accept
 @Name("rightclickitem")
@@ -28,7 +29,7 @@ public class RightClickItemListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/SmithListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/SmithListener.java
@@ -18,6 +18,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("smith")
 public class SmithListener extends PassiveListener {
@@ -33,7 +34,7 @@ public class SmithListener extends PassiveListener {
 
 		if (split.length > 0) {
 			if (!split[0].equals("any")) {
-				String[] items = split[0].split("\\|");
+				String[] items = split[0].split(MagicItemDataParser.DATA_REGEX);
 				firstItem = new HashSet<>();
 
 				for (String item : items) {
@@ -50,7 +51,7 @@ public class SmithListener extends PassiveListener {
 
 		if (split.length > 1) {
 			if (!split[1].equals("any")) {
-				String[] items = split[1].split("\\|");
+				String[] items = split[1].split(MagicItemDataParser.DATA_REGEX);
 				secondItem = new HashSet<>();
 
 				for (String item : items) {
@@ -67,7 +68,7 @@ public class SmithListener extends PassiveListener {
 
 		if (split.length > 2) {
 			if (!split[2].equals("any")) {
-				String[] items = split[2].split("\\|");
+				String[] items = split[2].split(MagicItemDataParser.DATA_REGEX);
 				resultItem = new HashSet<>();
 
 				for (String item : items) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -21,6 +21,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 // Optional trigger variable of a pipe separated list that can contain
 // damage causes or damaging magic items to accept
@@ -33,7 +34,7 @@ public class TakeDamageListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			boolean isDamCause = false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/UnequipListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/UnequipListener.java
@@ -17,6 +17,7 @@ import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
 
 @Name("unequip")
 public class UnequipListener extends PassiveListener {
@@ -26,7 +27,7 @@ public class UnequipListener extends PassiveListener {
 	@Override
 	public void initialize(@NotNull String var) {
 		if (var.isEmpty()) return;
-		for (String s : var.split("\\|")) {
+		for (String s : var.split(MagicItemDataParser.DATA_REGEX)) {
 			s = s.trim();
 
 			MagicItemData itemData = MagicItems.getMagicItemDataFromString(s);

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 
 import java.net.URL;
+import java.net.URI;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
@@ -526,7 +527,7 @@ public class Util {
 
 	public static boolean downloadFile(String url, File file) {
 		try {
-			URL website = new URL(url);
+			URL website = URI.create(url).toURL();
 			ReadableByteChannel rbc = Channels.newChannel(website.openStream());
 			FileOutputStream fos = new FileOutputStream(file);
 

--- a/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/magicitems/MagicItemDataParser.java
@@ -45,7 +45,7 @@ public class MagicItemDataParser {
 	/* splits the saved magicItemData string by the "|" char
 		itemType{data}|itemType{data}...
 	*/
-	public static final String DATA_REGEX = "(?=(?:(?:[^\"]*\"){2})*[^\"]*$)(?![^{]*})(?![^\\[]*\\])\\|+";
+	public static final String DATA_REGEX = "(?=(?:(?:[^\"]*\"){2})*[^\"]*$)(?![^{]*})(?![^\\[]*])\\|+";
 
 	public static MagicItemData parseMagicItemData(String str) {
 		String[] args = str.split("\\{", 2);


### PR DESCRIPTION
- Adds support for data-driven enchantment namespaced keys.
- Fixes Magic Items being incorrectly split by `|` in the `wearinginslot` modifier condition and the following passive listeners: `anvil`, `craft`, `dropitem`, `enchant`, `equip`, `foodlevelchange`, `givedamage`, `grindstone`, `hitarrow`, `hotbardeselect`, `hotbarselect`, `leftclickitem`, `missarrow`, `pickupitem`, `playeranimate`, `prepareenchant`, `rightclickitem`, `smith`, `takedamage`, and `unequip`.