### PR TITLE
Metrics and Placeholder fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -250,7 +250,7 @@ public class MagicSpells extends JavaPlugin {
 			if (spells == null) return map;
 
 			for (Spell spell : spells.values()) {
-				if (!spell.getName().startsWith("com.nisovin.magicspells.spells")) continue;
+				if (!spell.getClass().getName().startsWith("com.nisovin.magicspells.spells")) continue;
 				if (!(spell instanceof PassiveSpell passiveSpell)) continue;
 
 				for (PassiveListener listener : passiveSpell.getPassiveListeners()) {

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -260,7 +260,7 @@ public class MagicSpells extends JavaPlugin {
 			}
 			return map;
 		}));
-		metrics.addCustomChart(new SimplePie("reload_time", () -> (lastReloadTime - lastReloadTime % 20) + " ms"));
+		metrics.addCustomChart(new SimplePie("reload_time", () -> "<" + (lastReloadTime - lastReloadTime % 500 + 500) + " ms"));
 	}
 
 	public void load() {

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1637,7 +1637,7 @@ public class MagicSpells extends JavaPlugin {
 		return message;
 	}
 
-	private static final Pattern ARGUMENT_PATTERN = Pattern.compile("%arg:(\\d+):(\\w+)%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+	private static final Pattern ARGUMENT_PATTERN = Pattern.compile("%arg:(\\d+):([^%]+)%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	public static String doArgumentSubstitution(String string, String[] args) {
 		if (string == null || string.isEmpty()) return string;
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ModifyCooldownSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ModifyCooldownSpell.java
@@ -48,7 +48,7 @@ public class ModifyCooldownSpell extends TargetedSpell implements TargetedEntity
 		if (powerAffectsMultiplier.get(data)) mult /= data.power();
 
 		for (Spell spell : MagicSpells.spells()) {
-			if (!spell.onCooldown(data.target()) || !filter.check(spell)) continue;
+			if (!filter.check(spell)) continue;
 
 			float cd = spell.getCooldown(data.target()) - sec;
 			if (mult > 0) cd *= mult;

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -25,13 +25,13 @@ public class StringData implements ConfigData<String> {
 
 	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("""
 		%(?:\
-		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
-		(playervar:([^:]+):(\\w+)(?::(\\d+))?)|\
-		(arg:(\\d+):([^%]+))|\
-		((papi|casterpapi|targetpapi):([^%]+))|\
-		(playerpapi:([^:]+):([^%]+))\
+		(?<var>(?<varOwner>var|castervar|targetvar):(?<varName>\\w+)(?::(?<varPrecision>\\d+))?)|\
+		(?<pVar>playervar:(?<pVarUser>[^:]+):(?<pVarName>\\w+)(?::(?<pVarPrecision>\\d+))?)|\
+		(?<arg>arg:(?<argValue>\\d+):(?<argDefault>[^%]+))|\
+		(?<papi>(?<papiOwner>papi|casterpapi|targetpapi):(?<papiValue>[^%]+))|\
+		(?<playerPapi>playerpapi:(?<playerPapiUser>[^:]+):(?<playerPapiValue>[^%]+))\
 		)%|\
-		(%[art])""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+		(?<entityName>%[art])""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	private final List<ConfigData<String>> values;
 	private final List<String> fragments;
@@ -59,10 +59,10 @@ public class StringData implements ConfigData<String> {
 	}
 
 	private static ConfigData<String> createData(Matcher matcher) {
-		if (matcher.group(1) != null) {
-			String owner = matcher.group(2);
-			String variable = matcher.group(3);
-			String placesString = matcher.group(4);
+		if (matcher.group("var") != null) {
+			String owner = matcher.group("varOwner");
+			String variable = matcher.group("varName");
+			String placesString = matcher.group("varPrecision");
 
 			int places = -1;
 			if (placesString != null) {
@@ -80,10 +80,10 @@ public class StringData implements ConfigData<String> {
 			};
 		}
 
-		if (matcher.group(5) != null) {
-			String player = matcher.group(6);
-			String variable = matcher.group(7);
-			String placesString = matcher.group(8);
+		if (matcher.group("pVar") != null) {
+			String player = matcher.group("pVarUser");
+			String variable = matcher.group("pVarName");
+			String placesString = matcher.group("pVarPrecision");
 
 			int places = -1;
 			if (placesString != null) {
@@ -97,12 +97,12 @@ public class StringData implements ConfigData<String> {
 			return new PlayerVariableData(matcher.group(), variable, player, places);
 		}
 
-		if (matcher.group(9) != null) {
-			String def = matcher.group(11);
+		if (matcher.group("arg") != null) {
+			String def = matcher.group("argDefault");
 
 			int index;
 			try {
-				index = Integer.parseInt(matcher.group(10));
+				index = Integer.parseInt(matcher.group("argValue"));
 			} catch (NumberFormatException e) {
 				return null;
 			}
@@ -111,9 +111,9 @@ public class StringData implements ConfigData<String> {
 			return new ArgumentData(index - 1, def);
 		}
 
-		if (matcher.group(12) != null) {
-			String owner = matcher.group(13);
-			String papiPlaceholder = '%' + matcher.group(14) + '%';
+		if (matcher.group("papi") != null) {
+			String owner = matcher.group("papiOwner");
+			String papiPlaceholder = '%' + matcher.group("papiValue") + '%';
 
 			return switch (owner.toLowerCase()) {
 				case "casterpapi" -> new CasterPAPIData(matcher.group(), papiPlaceholder);
@@ -122,14 +122,14 @@ public class StringData implements ConfigData<String> {
 			};
 		}
 
-		if (matcher.group(15) != null) {
-			String player = matcher.group(16);
-			String papiPlaceholder = '%' + matcher.group(17) + '%';
+		if (matcher.group("playerPapi") != null) {
+			String player = matcher.group("playerPapiUser");
+			String papiPlaceholder = '%' + matcher.group("playerPapiValue") + '%';
 
 			return new PlayerPAPIData(matcher.group(), papiPlaceholder, player);
 		}
 
-		return switch (matcher.group(18)) {
+		return switch (matcher.group("entityName")) {
 			case "%r" -> new DefaultNameData();
 			case "%a" -> new CasterNameData();
 			case "%t" -> new TargetNameData();

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -27,7 +27,7 @@ public class StringData implements ConfigData<String> {
 		%(?:\
 		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
 		(playervar:(\\w{3,16}):(\\w+)(?::(\\d+))?)|\
-		(arg:(\\d+):(\\w+))|\
+		(arg:(\\d+):([^%]+))|\
 		((papi|casterpapi|targetpapi):([^%]+))|\
 		(playerpapi:(\\w{3,16}):([^%]+))\
 		)%|\

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -26,10 +26,10 @@ public class StringData implements ConfigData<String> {
 	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("""
 		%(?:\
 		((var|castervar|targetvar):(\\w+)(?::(\\d+))?)|\
-		(playervar:(\\w{3,16}):(\\w+)(?::(\\d+))?)|\
+		(playervar:([^:]+):(\\w+)(?::(\\d+))?)|\
 		(arg:(\\d+):([^%]+))|\
 		((papi|casterpapi|targetpapi):([^%]+))|\
-		(playerpapi:(\\w{3,16}):([^%]+))\
+		(playerpapi:([^:]+):([^%]+))\
 		)%|\
 		(%[art])""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: com.nisovin.magicspells.MagicSpells
 version: $version
 authors: [nisovin, TheComputerGeek2, Chronoken, tonythemacaroni, JasperLorelai]
 website: "https://github.com/TheComputerGeek2/MagicSpells/"
-api-version: "1.20"
+api-version: "1.21.3"
 softdepend:
     - GriefPrevention
     - Vault


### PR DESCRIPTION
- Fixed Metrics Passive Listener chart.
- Grouped Metrics Reload Time chart with more readable slices.
- Removed alphanumeric (and `_`) limitation on default values of the `%arg` placeholder in spell messages and string expressions.
- Removed `[3, 16]` length limitation on player names in string expressions for the `%playervar` and `%playerpapi` placeholders.
- Fixed an issue where the `ModifyCooldownSpell` only worked if the spell was on cooldown.