### PR TITLE
Add respect-item-cooldowns option

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -170,6 +170,7 @@ public class MagicSpells extends JavaPlugin {
 	private boolean allowCastWithFist;
 	private boolean castWithLeftClick;
 	private boolean castWithRightClick;
+	private boolean respectItemCooldowns;
 	private boolean reverseBowCycleButtons;
 	private boolean bowCycleSpellsSneaking;
 	private boolean castBoundBowSpellsFromOffhand;
@@ -342,6 +343,7 @@ public class MagicSpells extends JavaPlugin {
 		allowCastWithFist = config.getBoolean(path + "allow-cast-with-fist", false);
 		castWithLeftClick = config.getBoolean(path + "cast-with-left-click", true);
 		castWithRightClick = config.getBoolean(path + "cast-with-right-click", false);
+		respectItemCooldowns = config.getBoolean(path + "respect-item-cooldowns", false);
 		cycleSpellsOnOffhandAction = config.getBoolean(path + "cycle-spells-with-offhand-action", false);
 
 		ignoreDefaultBindings = config.getBoolean(path + "ignore-default-bindings", false);
@@ -1243,6 +1245,10 @@ public class MagicSpells extends JavaPlugin {
 
 	public static boolean canCastWithRightClick() {
 		return plugin.castWithRightClick;
+	}
+
+	public static boolean isRespectingItemCooldowns() {
+		return plugin.respectItemCooldowns;
 	}
 
 	public static boolean profilingEnabled() {

--- a/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/CastListener.java
@@ -81,6 +81,7 @@ public class CastListener implements Listener {
 		if (MagicSpells.isCastingOnAnimate() && action.isLeftClick()) return;
 
 		ItemStack item = player.getInventory().getItemInMainHand();
+		if (MagicSpells.isRespectingItemCooldowns() && player.hasCooldown(item)) return;
 
 		Material type = item.getType();
 		if (!MagicSpells.canCastWithFist() && type.isAir()) return;
@@ -104,6 +105,7 @@ public class CastListener implements Listener {
 		if (inventoryType != InventoryType.CRAFTING && inventoryType != InventoryType.CREATIVE) return;
 
 		ItemStack item = player.getInventory().getItemInMainHand();
+		if (MagicSpells.isRespectingItemCooldowns() && player.hasCooldown(item)) return;
 
 		Material type = item.getType();
 		if (!MagicSpells.canCastWithFist() && type.isAir()) return;

--- a/core/src/main/java/com/nisovin/magicspells/listeners/LeftClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/LeftClickListener.java
@@ -49,8 +49,9 @@ public class LeftClickListener implements Listener {
 		if (spell == null) return;
 
 		Player player = event.getPlayer();
-		Spellbook spellbook = MagicSpells.getSpellbook(player);
+		if (MagicSpells.isRespectingItemCooldowns() && player.hasCooldown(item)) return;
 
+		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		if (!spellbook.hasSpell(spell) || !spellbook.canCast(spell)) return;
 
 		if (!spell.isIgnoringGlobalCooldown()) {

--- a/core/src/main/java/com/nisovin/magicspells/listeners/RightClickListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/RightClickListener.java
@@ -49,8 +49,9 @@ public class RightClickListener implements Listener {
 		if (spell == null) return;
 
 		Player player = event.getPlayer();
-		Spellbook spellbook = MagicSpells.getSpellbook(player);
+		if (MagicSpells.isRespectingItemCooldowns() && player.hasCooldown(item)) return;
 
+		Spellbook spellbook = MagicSpells.getSpellbook(player);
 		if (!spellbook.hasSpell(spell) || !spellbook.canCast(spell)) return;
 
 		if (!spell.isIgnoringGlobalCooldown()) {

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -104,6 +104,7 @@ los-fluid-collision-mode: always
 global-radius: 500
 global-cooldown: 500
 cast-on-animate: false
+respect-item-cooldowns: false
 use-exp-bar-as-cast-time-bar: true
 cooldowns-persist-through-reload: true
 sound-on-cooldown: ""


### PR DESCRIPTION
Adds the `respect-item-cooldowns` option to `general.yml`. With `respect-item-cooldowns: true`, an item with a cooldown cannot be used to cast or cycle spells. Defaults to `false`.