### PR TITLE
Properly support damage types

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -74,6 +74,7 @@ import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.commands.CommandHelpFilter;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.recipes.CustomRecipes;
+import com.nisovin.magicspells.handlers.DeprecationHandler;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.storage.types.TXTFileStorage;
 import com.nisovin.magicspells.volatilecode.ManagerVolatile;
@@ -122,6 +123,7 @@ public class MagicSpells extends JavaPlugin {
 	private MoneyHandler moneyHandler;
 	private MagicXpHandler magicXpHandler;
 	private StorageHandler storageHandler;
+	private DeprecationHandler deprecationHandler;
 	private VolatileCodeHandle volatileCodeHandle;
 
 	private BuffManager buffManager;
@@ -270,6 +272,8 @@ public class MagicSpells extends JavaPlugin {
 
 	public void load() {
 		plugin = this;
+
+		deprecationHandler = new DeprecationHandler();
 
 		effectManager = new EffectManager(this);
 		effectManager.enableDebug(debug);
@@ -704,6 +708,8 @@ public class MagicSpells extends JavaPlugin {
 		// Call loaded event
 		Bukkit.getPluginManager().callEvent(new MagicSpellsLoadedEvent(this));
 		loaded = true;
+
+		deprecationHandler.printDeprecationNotices();
 
 		log("MagicSpells loading complete!");
 	}
@@ -1406,6 +1412,10 @@ public class MagicSpells extends JavaPlugin {
 
 	public static LifeLengthTracker getLifeLengthTracker() {
 		return plugin.lifeLengthTracker;
+	}
+
+	public static DeprecationHandler getDeprecationManager() {
+		return plugin.deprecationHandler;
 	}
 
 	public static Map<String, Spellbook> getSpellbooks() {
@@ -2219,6 +2229,7 @@ public class MagicSpells extends JavaPlugin {
 		strUnknownSpell = null;
 		strXpAutoLearned = null;
 		lifeLengthTracker = null;
+		deprecationHandler = null;
 		strMissingReagents = null;
 		strSpellChangeEmpty = null;
 		soundFailOnCooldown = null;

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import de.slikey.effectlib.Effect;
 
@@ -902,11 +903,11 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		return ConfigDataUtil.getBlockData(config.getMainConfig(), internalKey + key, def);
 	}
 
-	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(String key, RegistryKey<T> registryKey, T def) {
+	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(@NotNull String key, @NotNull RegistryKey<T> registryKey, @Nullable T def) {
 		return ConfigDataUtil.getRegistryEntry(config.getMainConfig(), internalKey + key, RegistryAccess.registryAccess().getRegistry(registryKey), def);
 	}
 
-	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(String key, Registry<T> registry, T def) {
+	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(@NotNull String key, @NotNull Registry<T> registry, @Nullable T def) {
 		return ConfigDataUtil.getRegistryEntry(config.getMainConfig(), internalKey + key, registry, def);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/events/MagicSpellsEntityDamageByEntityEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/MagicSpellsEntityDamageByEntityEvent.java
@@ -1,9 +1,12 @@
 package com.nisovin.magicspells.events;
 
+import org.jetbrains.annotations.NotNull;
+
 import java.util.Map;
 import java.util.HashMap;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.event.HandlerList;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 import com.nisovin.magicspells.Spell;
@@ -13,27 +16,40 @@ import com.google.common.collect.ImmutableMap;
 
 public class MagicSpellsEntityDamageByEntityEvent extends EntityDamageByEntityEvent implements IMagicSpellsCompatEvent {
 
+	private static final HandlerList HANDLER_LIST = new HandlerList();
+
 	private final Spell spell;
 
 	public MagicSpellsEntityDamageByEntityEvent(Entity damager, Entity damagee, DamageCause cause, double damage, Spell spell) {
 		super(damager, damagee, cause, getModTemplate(damage), getModifierFunctionTemplate(0D));
 		this.spell = spell;
 	}
-	
+
 	private static Map<DamageModifier, Double> getModTemplate(double baseDamage) {
 		return new HashMap<>(ImmutableMap.of(DamageModifier.BASE, baseDamage));
 	}
-	
+
 	private static Map<DamageModifier, Function<Double, Double>> getModifierFunctionTemplate(final double baseDamage) {
 		return new HashMap<>(ImmutableMap.of(DamageModifier.BASE, getConstantFunction(baseDamage)));
 	}
-	
+
 	private static Function<Double, Double> getConstantFunction(final double value) {
 		return arg0 -> value;
+	}
+
+	@NotNull
+	public static HandlerList getHandlerList() {
+		return HANDLER_LIST;
+	}
+
+	@NotNull
+	@Override
+	public HandlerList getHandlers() {
+		return super.getHandlers();
 	}
 
 	public Spell getSpell() {
 		return spell;
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellApplyDamageEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellApplyDamageEvent.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.events;
 
+import org.bukkit.damage.DamageType;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
@@ -10,17 +11,28 @@ public class SpellApplyDamageEvent extends SpellEvent {
 	private final LivingEntity target;
 	private final double damage;
 	private final String spellDamageType;
+	private final DamageType damageType;
 	private final DamageCause cause;
 	private final long timestamp;
 	private float modifier;
 	private double flatModifier;
 
+	@Deprecated
 	public SpellApplyDamageEvent(Spell spell, LivingEntity caster, LivingEntity target, double damage, DamageCause cause, String spellDamageType) {
+		this(spell, caster, target, damage, DamageType.GENERIC, cause, spellDamageType);
+	}
+
+	public SpellApplyDamageEvent(Spell spell, LivingEntity caster, LivingEntity target, double damage, DamageType damageType, String spellDamageType) {
+		this(spell, caster, target, damage, damageType, DamageCause.ENTITY_ATTACK, spellDamageType);
+	}
+
+	private SpellApplyDamageEvent(Spell spell, LivingEntity caster, LivingEntity target, double damage, DamageType damageType, DamageCause cause, String spellDamageType) {
 		super(spell, caster);
 
 		this.target = target;
 		this.spellDamageType = spellDamageType;
 		this.damage = damage;
+		this.damageType = damageType;
 		this.cause = cause;
 
 		timestamp = System.currentTimeMillis();
@@ -49,8 +61,13 @@ public class SpellApplyDamageEvent extends SpellEvent {
 		return damage;
 	}
 
+	@Deprecated
 	public DamageCause getCause() {
 		return cause;
+	}
+
+	public DamageType getDamageType() {
+		return damageType;
 	}
 
 	public long getTimestamp() {

--- a/core/src/main/java/com/nisovin/magicspells/handlers/DeprecationHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/DeprecationHandler.java
@@ -1,0 +1,47 @@
+package com.nisovin.magicspells.handlers;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.DeprecationNotice;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import org.jetbrains.annotations.NotNull;
+
+public class DeprecationHandler {
+
+	private final Multimap<DeprecationNotice, Spell> deprecations = HashMultimap.create();
+
+	public void addDeprecation(@NotNull Spell spell, @NotNull DeprecationNotice deprecationNotice) {
+		deprecations.put(deprecationNotice, spell);
+	}
+
+	public <T extends Spell> void addDeprecation(@NotNull T spell, @NotNull DeprecationNotice deprecationNotice, boolean check) {
+		if (check) addDeprecation(spell, deprecationNotice);
+	}
+
+	public void printDeprecationNotices() {
+		if (deprecations.isEmpty()) return;
+
+		MagicSpells.error("Usage of deprecated features found. All such usages should be examined and replaced with supported alternatives.");
+
+		for (Map.Entry<DeprecationNotice, Collection<Spell>> entry : deprecations.asMap().entrySet()) {
+			DeprecationNotice notice = entry.getKey();
+			Collection<Spell> spells = entry.getValue();
+
+			MagicSpells.error("    " + notice.reason());
+			MagicSpells.error("        Relevant spells: " + spells.stream()
+				.map(Spell::getInternalName)
+				.sorted()
+				.collect(Collectors.joining(", ", "[", "]"))
+			);
+			MagicSpells.error("        Steps to take: " + notice.replacement());
+			if (notice.context() != null) MagicSpells.error("        Context: " + notice.context());
+		}
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -233,29 +233,31 @@ public class PassiveSpell extends Spell {
 	}
 
 	public boolean activate(LivingEntity caster) {
-		return activate(caster, null, null);
+		return activate(new SpellData(caster));
 	}
 	
 	public boolean activate(LivingEntity caster, float power) {
-		return activate(caster, null, null, power);
+		return activate(new SpellData(caster, power));
 	}
 	
 	public boolean activate(LivingEntity caster, LivingEntity target) {
-		return activate(caster, target, null, 1F);
+		return activate(new SpellData(caster, target));
 	}
 	
 	public boolean activate(LivingEntity caster, Location location) {
-		return activate(caster, null, location, 1F);
+		return activate(new SpellData(caster, location));
 	}
 	
 	public boolean activate(final LivingEntity caster, final LivingEntity target, final Location location) {
-		return activate(caster, target, location, 1F);
+		return activate(new SpellData(caster, target, location, 1f, null));
 	}
-	
-	public boolean activate(final LivingEntity caster, final LivingEntity target, final Location location, final float power) {
-		if (disabled) return false;
 
-		SpellData data = new SpellData(caster, target, location, power, null);
+	public boolean activate(final LivingEntity caster, final LivingEntity target, final Location location, final float power) {
+		return activate(new SpellData(caster, target, location, power, null));
+	}
+
+	public boolean activate(SpellData data) {
+		if (disabled) return false;
 
 		int delay = this.delay.get(data);
 		if (delay < 0) return activateSpells(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PassiveSpell.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spells;
 
+import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 
@@ -8,6 +9,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.HandlerList;
 import org.bukkit.event.EventPriority;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.*;
@@ -23,7 +25,6 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 public class PassiveSpell extends Spell {
 
 	private final List<PassiveListener> passiveListeners;
-	private final List<String> triggers;
 	private final List<String> spellNames;
 	private List<Subspell> spells;
 
@@ -46,7 +47,6 @@ public class PassiveSpell extends Spell {
 
 		passiveListeners = new ArrayList<>();
 
-		triggers = getConfigStringList("triggers", null);
 		spellNames = getConfigStringList("spells", null);
 
 		if (config.isList(internalKey + "can-trigger")) {
@@ -98,45 +98,90 @@ public class PassiveSpell extends Spell {
 	}
 
 	public void initializeListeners() {
-		// Get trigger
-		int trigCount = 0;
+		List<?> triggers = getConfigList("triggers", null);
 		if (triggers == null) {
 			MagicSpells.error("PassiveSpell '" + internalName + "' has no triggers defined!");
 			return;
 		}
 
-		for (String trigger : triggers) {
-			String type = trigger;
-			String args = "";
-			if (trigger.contains(" ")) {
-				String[] data = Util.splitParams(trigger, 2);
-				type = data[0];
-				// Util#splitParams does not return empty-string elements.
-				if (data.length > 1) args = data[1];
+		int count = 0;
+		for (int i = 0; i < triggers.size(); i++) {
+			Object trigger = triggers.get(i);
+
+			switch (trigger) {
+				case String string -> {
+					String type, args;
+					if (string.contains(" ")) {
+						String[] data = Util.splitParams(string, 2);
+						type = data[0].toLowerCase();
+						args = data.length > 1 ? data[1] : "";
+					} else {
+						type = string.toLowerCase();
+						args = "";
+					}
+
+					EventPriority priority = MagicSpells.getPassiveManager().getEventPriorityFromName(type);
+					if (priority == null) priority = EventPriority.NORMAL;
+
+					String priorityName = MagicSpells.getPassiveManager().getEventPriorityName(priority);
+					if (priorityName != null) type = type.replace(priorityName, "");
+
+					PassiveListener listener = MagicSpells.getPassiveManager().getListenerByName(type);
+					if (listener == null) {
+						MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid trigger type defined: " + type);
+						continue;
+					}
+
+					listener.setPassiveSpell(this);
+					listener.setEventPriority(priority);
+					listener.initialize(args);
+					MagicSpells.registerEvents(listener, priority);
+					passiveListeners.add(listener);
+					count++;
+				}
+				case Map<?, ?> map -> {
+					ConfigurationSection config = ConfigReaderUtil.mapToSection(map);
+
+					String type = config.getString("trigger");
+					if (type == null) {
+						MagicSpells.error("PassiveSpell '" + internalName + "' has no 'trigger' defined for trigger at position " + i + ".");
+						continue;
+					}
+
+					PassiveListener listener = MagicSpells.getPassiveManager().getListenerByName(type);
+					if (listener == null) {
+						MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid trigger type defined: " + type);
+						continue;
+					}
+
+					listener.setPassiveSpell(this);
+					if (!listener.initialize(config)) {
+						MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid trigger defined at position " + i + ".");
+						continue;
+					}
+
+					EventPriority priority = EventPriority.NORMAL;
+
+					String priorityString = config.getString("priority");
+					if (priorityString != null) {
+						try {
+							priority = EventPriority.valueOf(priorityString.toUpperCase());
+						} catch (IllegalArgumentException e) {
+							MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid 'priority' defined: " + priorityString);
+						}
+					}
+
+					listener.setEventPriority(priority);
+					MagicSpells.registerEvents(listener, priority);
+					passiveListeners.add(listener);
+					count++;
+				}
+				default ->
+					MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid trigger defined: " + trigger);
 			}
-			type = type.toLowerCase();
-
-			EventPriority priority = MagicSpells.getPassiveManager().getEventPriorityFromName(type);
-			if (priority == null) priority = EventPriority.NORMAL;
-
-			String priorityName = MagicSpells.getPassiveManager().getEventPriorityName(priority);
-			if (priorityName != null) type = type.replace(priorityName, "");
-
-			PassiveListener listener = MagicSpells.getPassiveManager().getListenerByName(type);
-			if (listener == null) {
-				MagicSpells.error("PassiveSpell '" + internalName + "' has an invalid trigger defined: " + type);
-				continue;
-			}
-
-			listener.setPassiveSpell(this);
-			listener.setEventPriority(priority);
-			listener.initialize(args);
-			MagicSpells.registerEvents(listener, priority);
-			passiveListeners.add(listener);
-			trigCount++;
 		}
 
-		if (trigCount == 0) MagicSpells.error("PassiveSpell '" + internalName + "' has no triggers defined!");
+		if (count == 0) MagicSpells.error("PassiveSpell '" + internalName + "' has no triggers defined!");
 	}
 
 	public List<PassiveListener> getPassiveListeners() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
@@ -16,7 +15,6 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class FlamewalkSpell extends BuffSpell {
 
@@ -140,10 +138,8 @@ public class FlamewalkSpell extends BuffSpell {
 				for (Entity entity : caster.getNearbyEntities(radius, radius, radius)) {
 					if (!(entity instanceof LivingEntity target) || !validTargetList.canTarget(caster, target)) continue;
 
-					if (data.checkPlugins) {
-						MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(caster, target, DamageCause.ENTITY_ATTACK, 1, FlamewalkSpell.this);
-						if (!event.callEvent()) continue;
-					}
+					if (data.checkPlugins && checkFakeDamageEvent(caster, target))
+						continue;
 
 					SpellTargetEvent targetEvent = new SpellTargetEvent(FlamewalkSpell.this, data.spellData, target);
 					if (!targetEvent.callEvent()) continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class InvulnerabilitySpell extends BuffSpell {
 
@@ -112,6 +113,11 @@ public class InvulnerabilitySpell extends BuffSpell {
 		if (livingEntity.getNoDamageTicks() < livingEntity.getMaximumNoDamageTicks() / 2.0F) {
 			addUseAndChargeCost(livingEntity);
 		}
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onLegacyDamage(MagicSpellsEntityDamageByEntityEvent event) {
+		onEntityDamage(event);
 	}
 
 	public Set<UUID> getEntities() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -5,13 +5,17 @@ import java.util.List;
 import java.util.UUID;
 import java.util.HashSet;
 
+import net.kyori.adventure.key.Key;
+
 import org.bukkit.entity.Entity;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
-import com.nisovin.magicspells.MagicSpells;
 import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
+import io.papermc.paper.registry.RegistryKey;
+
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.MagicConfig;
@@ -21,11 +25,14 @@ import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 public class InvulnerabilitySpell extends BuffSpell {
 
 	private final Set<UUID> entities;
+	private final Set<Key> damageTypes;
 	private final Set<DamageCause> damageCauses;
 	private final Set<String> spellDamageTypes;
 
 	public InvulnerabilitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
+
+		damageTypes = getConfigRegistryKeys("damage-types", RegistryKey.DAMAGE_TYPE);
 
 		damageCauses = new HashSet<>();
 		List<String> causes = getConfigStringList("damage-causes", null);
@@ -102,6 +109,7 @@ public class InvulnerabilitySpell extends BuffSpell {
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
 		if (!(entity instanceof LivingEntity livingEntity)) return;
+		if (damageTypes != null && !damageTypes.contains(event.getDamageSource().getDamageType().key())) return;
 		if (!damageCauses.isEmpty() && !damageCauses.contains(event.getCause())) return;
 		if (!isActive(livingEntity)) return;
 		if (isExpired(livingEntity)) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -19,10 +19,17 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
 import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class InvulnerabilitySpell extends BuffSpell {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'damage-causes' option does not function properly.",
+		"Use the 'damage-types' option.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#buffinvulernabilityspell-damage-causes"
+	);
 
 	private final Set<UUID> entities;
 	private final Set<Key> damageTypes;
@@ -45,6 +52,8 @@ public class InvulnerabilitySpell extends BuffSpell {
 					MagicSpells.error("InvulnerabilitySpell '" + internalName + "' has an invalid damage cause defined: " + cause);
 				}
 			}
+
+			MagicSpells.getDeprecationManager().addDeprecation(this, DEPRECATION_NOTICE);
 		}
 
 		spellDamageTypes = new HashSet<>();

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
@@ -23,10 +23,17 @@ import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
 import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class ResistSpell extends BuffSpell {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'normal-damage-types' option does not function properly.",
+		"Use the 'damage-types' option.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#buffresistspell-normal-damage-types"
+	);
 
 	private final Map<UUID, ResistData> entities;
 
@@ -75,6 +82,8 @@ public class ResistSpell extends BuffSpell {
 					MagicSpells.error("ResistSpell '" + internalName + "' has an invalid damage cause defined '" + cause + "'!");
 				}
 			}
+
+			MagicSpells.getDeprecationManager().addDeprecation(this, DEPRECATION_NOTICE);
 		} else normalDamageTypes = null;
 
 		spellDamageTypes = new HashSet<>();

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
@@ -21,6 +21,7 @@ import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class ResistSpell extends BuffSpell {
 
@@ -159,6 +160,11 @@ public class ResistSpell extends BuffSpell {
 		double finalDamage = (event.getDamage() * calculation.multiplier) - calculation.flatModifier;
 		if (finalDamage < 0D) finalDamage = 0D;
 		event.setDamage(finalDamage);
+	}
+
+	@EventHandler(ignoreCancelled = true)
+	public void onLegacyDamage(MagicSpellsEntityDamageByEntityEvent event) {
+		onEntityDamage(event);
 	}
 
 	private ResistCalculation calculateResist(ResistData data, LivingEntity caster, LivingEntity target, float multiplier, double flatModifier) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -30,7 +30,6 @@ import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.util.config.FunctionData;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpell {
 
@@ -353,12 +352,9 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			double damage = event.getDamage();
 			if (info.powerAffectsDamage) damage *= info.data.power();
 
-			if (info.checkPlugins && info.data.hasCaster()) {
-				MagicSpellsEntityDamageByEntityEvent evt = new MagicSpellsEntityDamageByEntityEvent(info.data.caster(), target, DamageCause.ENTITY_ATTACK, damage, spell);
-				if (!evt.callEvent()) {
-					event.setCancelled(true);
-					return;
-				}
+			if (info.checkPlugins && info.data.hasCaster() && spell.checkFakeDamageEvent(info.data.caster(), info.data.target(), DamageCause.ENTITY_ATTACK, damage)) {
+				event.setCancelled(true);
+				return;
 			}
 
 			event.setDamage(damage);

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/DamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/DamageListener.java
@@ -1,0 +1,226 @@
+package com.nisovin.magicspells.spells.passive;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.*;
+
+import net.kyori.adventure.key.Key;
+
+import org.bukkit.Registry;
+import org.bukkit.entity.*;
+import org.bukkit.NamespacedKey;
+import org.bukkit.damage.DamageType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.EquipmentSlot;
+import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.configuration.ConfigurationSection;
+import org.bukkit.event.entity.EntityDamageByEntityEvent;
+
+import io.papermc.paper.registry.tag.Tag;
+import io.papermc.paper.registry.tag.TagKey;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.RegistryAccess;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
+import com.nisovin.magicspells.util.magicitems.MagicItemData;
+import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+
+@SuppressWarnings("UnstableApiUsage")
+@Name("damage")
+public class DamageListener extends PassiveListener {
+
+	private Mode mode;
+
+	private Set<Key> damageTypes;
+
+	private List<MagicItemData> projectileItems;
+	private List<MagicItemData> weaponItems;
+
+	private ConfigData<Double> minimumDamage;
+
+	private boolean indirectDamager;
+
+	@Override
+	public void initialize(@NotNull String var) {
+		MagicSpells.error("PassiveSpell '" + passiveSpell.getInternalName() + "' attempted to create a 'damage' trigger using the string format, which it does not support.");
+	}
+
+	@Override
+	public boolean initialize(@NotNull ConfigurationSection config) {
+		mode = getMode(config);
+		if (mode == null) return false;
+
+		damageTypes = initializeDamageTypes(config);
+
+		weaponItems = initializeItems(config, "weapon-items");
+		projectileItems = initializeItems(config, "projectile-items");
+
+		minimumDamage = ConfigDataUtil.getDouble(config, "minimum-damage", -1);
+
+		indirectDamager = config.getBoolean("indirect-damager", true);
+
+		return true;
+	}
+
+	private Mode getMode(@NotNull ConfigurationSection config) {
+		String modeString = config.getString("mode");
+		if (modeString == null) {
+			MagicSpells.error("No 'mode' defined in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+			return null;
+		}
+
+		return switch (modeString.toLowerCase()) {
+			case "give" -> Mode.GIVE;
+			case "take" -> Mode.TAKE;
+			default -> {
+				MagicSpells.error("Invalid 'mode' value '" + modeString + "' defined in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+				yield null;
+			}
+		};
+	}
+
+	private Set<Key> initializeDamageTypes(@NotNull ConfigurationSection config) {
+		List<String> damageTypeStrings = config.getStringList("damage-types");
+		if (damageTypeStrings.isEmpty()) return null;
+
+		Set<Key> types = new HashSet<>();
+
+		Registry<DamageType> registry = RegistryAccess.registryAccess().getRegistry(RegistryKey.DAMAGE_TYPE);
+		for (String damageTypeString : damageTypeStrings) {
+			if (!damageTypeString.startsWith("#")) {
+				NamespacedKey key = NamespacedKey.fromString(damageTypeString);
+				if (key == null || registry.get(key) == null) {
+					MagicSpells.error("Invalid damage type '" + damageTypeString + "' found in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+					continue;
+				}
+
+				types.add(key);
+				continue;
+			}
+
+			NamespacedKey key = NamespacedKey.fromString(damageTypeString.substring(1));
+			if (key == null) {
+				MagicSpells.error("Invalid damage type tag '" + damageTypeString + "' found in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+				continue;
+			}
+
+			TagKey<DamageType> tagKey = TagKey.create(RegistryKey.DAMAGE_TYPE, key);
+			if (!registry.hasTag(tagKey)) {
+				MagicSpells.error("Invalid damage type tag '" + damageTypeString + "' found in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+				continue;
+			}
+
+			Tag<DamageType> tag = registry.getTag(tagKey);
+			tag.values().forEach(typedKey -> types.add(typedKey.key()));
+		}
+
+		return types;
+	}
+
+	private List<MagicItemData> initializeItems(@NotNull ConfigurationSection config, @NotNull String path) {
+		List<String> itemStrings = config.getStringList(path);
+		if (itemStrings.isEmpty()) return null;
+
+		List<MagicItemData> items = new ArrayList<>();
+
+		for (String itemString : itemStrings) {
+			MagicItemData itemData = MagicItems.getMagicItemDataFromString(itemString);
+			if (itemData == null) {
+				MagicSpells.error("Invalid magic item '" + itemString + "' in damage trigger on passive spell '" + passiveSpell.getInternalName() + "'.");
+				continue;
+			}
+
+			items.add(itemData);
+		}
+
+		return items;
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onDamage(EntityDamageEvent event) {
+		DamageSource source = event.getDamageSource();
+		if (damageTypes != null && !damageTypes.contains(source.getDamageType().key())) return;
+
+		Entity damaged = event.getEntity();
+
+		LivingEntity livingDamaged = damaged instanceof LivingEntity le ? le : null;
+		if (mode == Mode.TAKE && (livingDamaged == null || !canTrigger(livingDamaged))) return;
+
+		Entity damager = null;
+		if (event instanceof EntityDamageByEntityEvent byEvent) {
+			if (!indirectDamager) damager = byEvent.getDamager();
+			else damager = Objects.requireNonNullElseGet(source.getCausingEntity(), byEvent::getDamager);
+		}
+
+		LivingEntity livingDamager = damager instanceof LivingEntity le ? le : null;
+		if (mode == Mode.GIVE && (livingDamager == null || livingDamaged == null || !canTrigger(livingDamager))) return;
+
+		SpellData data = switch (mode) {
+			case GIVE -> new SpellData(livingDamager, livingDamaged);
+			case TAKE -> new SpellData(livingDamaged, livingDamager);
+		};
+
+		double minimumDamage = this.minimumDamage.get(data);
+		if (minimumDamage >= 0 && event.getFinalDamage() < minimumDamage) return;
+
+		Entity directDamager;
+		if (event instanceof EntityDamageByEntityEvent byEvent) directDamager = byEvent.getDamager();
+		else directDamager = source.getDirectEntity();
+
+		if (weaponItems != null) {
+			ItemStack item = switch (directDamager) {
+				case AbstractArrow arrow -> arrow.getWeapon();
+				case Entity entity when source.getCausingEntity() == null || !source.isIndirect() -> {
+					if (!(entity instanceof LivingEntity livingEntity)) yield null;
+					if (!livingEntity.canUseEquipmentSlot(EquipmentSlot.HAND)) yield null;
+
+					EntityEquipment equipment = livingEntity.getEquipment();
+					if (equipment == null) yield null;
+
+					yield equipment.getItem(EquipmentSlot.HAND);
+				}
+				case null, default -> null;
+			};
+
+			if (item == null || !matches(weaponItems, item)) return;
+		}
+
+		if (projectileItems != null) {
+			ItemStack item = switch (directDamager) {
+				case AbstractArrow arrow -> arrow.getItemStack();
+				case ThrowableProjectile projectile -> projectile.getItem();
+				case null, default -> null;
+			};
+
+			if (item == null || !matches(projectileItems, item)) return;
+		}
+
+		boolean casted = passiveSpell.activate(data);
+		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	private boolean matches(List<MagicItemData> items, ItemStack item) {
+		MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
+		for (MagicItemData data : items)
+			if (data.matches(itemData))
+				return true;
+
+		return false;
+	}
+
+	private enum Mode {
+		GIVE,
+		TAKE
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
@@ -12,11 +12,18 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 @Name("fataldamage")
 public class FatalDamageListener extends PassiveListener {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'fataldamage' trigger does not function properly.",
+		"Use the 'damage' trigger.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#passivespell-passive-triggers-fatal-damage"
+	);
 
 	private final EnumSet<DamageCause> damageCauses = EnumSet.noneOf(DamageCause.class);
 
@@ -34,6 +41,8 @@ public class FatalDamageListener extends PassiveListener {
 			}
 			damageCauses.add(cause);
 		}
+
+		MagicSpells.getDeprecationManager().addDeprecation(passiveSpell, DEPRECATION_NOTICE);
 	}
 
 	@OverridePriority

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/FatalDamageListener.java
@@ -13,6 +13,7 @@ import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 @Name("fataldamage")
 public class FatalDamageListener extends PassiveListener {
@@ -37,7 +38,7 @@ public class FatalDamageListener extends PassiveListener {
 
 	@OverridePriority
 	@EventHandler
-	void onDamage(EntityDamageEvent event) {
+	public void onDamage(EntityDamageEvent event) {
 		if (!(event.getEntity() instanceof LivingEntity caster)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 		if (event.getFinalDamage() < caster.getHealth()) return;
@@ -46,6 +47,12 @@ public class FatalDamageListener extends PassiveListener {
 
 		boolean casted = passiveSpell.activate(caster);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onLegacyDamage(MagicSpellsEntityDamageByEntityEvent event) {
+		onDamage(event);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
@@ -28,6 +29,12 @@ import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 // damage causes or damaging magic items to accept
 @Name("givedamage")
 public class GiveDamageListener extends PassiveListener {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'givedamage' trigger does not function properly.",
+		"Use the 'damage' trigger.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#passivespell-passive-triggers-give-damage"
+	);
 
 	private final EnumSet<DamageCause> damageCauses = EnumSet.noneOf(DamageCause.class);
 	private final Set<MagicItemData> items = new HashSet<>();
@@ -56,6 +63,8 @@ public class GiveDamageListener extends PassiveListener {
 
 			items.add(itemData);
 		}
+
+		MagicSpells.getDeprecationManager().addDeprecation(passiveSpell, DEPRECATION_NOTICE);
 	}
 
 	@OverridePriority

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/GiveDamageListener.java
@@ -22,6 +22,7 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 // Optional trigger variable of a pipe separated list that can contain
 // damage causes or damaging magic items to accept
@@ -79,6 +80,12 @@ public class GiveDamageListener extends PassiveListener {
 
 		boolean casted = passiveSpell.activate(caster, attacked);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onLegacyDamage(MagicSpellsEntityDamageByEntityEvent event) {
+		onDamage(event);
 	}
 
 	private LivingEntity getAttacker(EntityDamageByEntityEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -22,6 +22,7 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 import com.nisovin.magicspells.util.magicitems.MagicItemDataParser;
+import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 // Optional trigger variable of a pipe separated list that can contain
 // damage causes or damaging magic items to accept
@@ -80,6 +81,12 @@ public class TakeDamageListener extends PassiveListener {
 
 		boolean casted = passiveSpell.activate(caster, attacker);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
+	}
+
+	@OverridePriority
+	@EventHandler
+	public void onLegacyDamage(MagicSpellsEntityDamageByEntityEvent event) {
+		onDamage(event);
 	}
 
 	private LivingEntity getAttacker(EntityDamageEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TakeDamageListener.java
@@ -18,6 +18,7 @@ import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.OverridePriority;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.magicitems.MagicItemData;
 import com.nisovin.magicspells.spells.passive.util.PassiveListener;
@@ -28,6 +29,12 @@ import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 // damage causes or damaging magic items to accept
 @Name("takedamage")
 public class TakeDamageListener extends PassiveListener {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'takedamage' trigger does not function properly.",
+		"Use the 'damage' trigger.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#passivespell-passive-triggers-take-damage"
+	);
 
 	private final EnumSet<DamageCause> damageCauses = EnumSet.noneOf(DamageCause.class);
 	private final Set<MagicItemData> items = new HashSet<>();
@@ -56,6 +63,8 @@ public class TakeDamageListener extends PassiveListener {
 
 			items.add(itemData);
 		}
+
+		MagicSpells.getDeprecationManager().addDeprecation(passiveSpell, DEPRECATION_NOTICE);
 	}
 
 	@OverridePriority

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
@@ -59,86 +59,105 @@ public class TicksListener extends PassiveListener {
 
 	@Override
 	public void turnOff() {
-		ticker.turnOff();
+		if (ticker != null) ticker.turnOff();
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onChunkLoad(ChunkLoadEvent event) {
+		if (ticker == null) return;
+
 		for (Entity entity : event.getChunk().getEntities()) {
-			if (!(entity instanceof LivingEntity)) continue;
-			if (!canTrigger((LivingEntity) entity)) continue;
-			ticker.add((LivingEntity) entity);
+			if (!(entity instanceof LivingEntity le) || !canTrigger(le)) continue;
+			ticker.add(le);
 		}
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onChunkUnload(ChunkUnloadEvent event) {
+		if (ticker == null) return;
+
 		for (Entity entity : event.getChunk().getEntities()) {
-			if (!(entity instanceof LivingEntity)) continue;
-			if (!canTrigger((LivingEntity) entity)) continue;
-			ticker.remove((LivingEntity) entity);
+			if (!(entity instanceof LivingEntity le) || !canTrigger(le)) continue;
+			ticker.remove(le);
 		}
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onEntitySpawn(EntitySpawnEvent event) {
+		if (ticker == null) return;
+
 		Entity entity = event.getEntity();
-		if (entity instanceof Player) return;
-		if (!(entity instanceof LivingEntity)) return;
-		if (!canTrigger((LivingEntity) entity)) return;
-		ticker.add((LivingEntity) entity);
+		if (entity instanceof Player || !(entity instanceof LivingEntity le) || !canTrigger(le)) return;
+
+		ticker.add(le);
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onJoin(PlayerJoinEvent event) {
+		if (ticker == null) return;
+
 		Player player = event.getPlayer();
 		if (!canTrigger(player)) return;
+
 		ticker.add(player);
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onQuit(PlayerQuitEvent event) {
+		if (ticker == null) return;
+
 		Player player = event.getPlayer();
 		if (!canTrigger(player)) return;
+
 		ticker.remove(player);
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onDeath(PlayerDeathEvent event) {
+		if (ticker == null) return;
+
 		Player player = event.getEntity();
 		if (!canTrigger(player)) return;
+
 		ticker.remove(player);
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onRespawn(PlayerRespawnEvent event) {
+		if (ticker == null) return;
+
 		Player player = event.getPlayer();
 		if (!canTrigger(player)) return;
+
 		ticker.add(player);
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onLearn(SpellLearnEvent event) {
+		if (ticker == null) return;
+
 		Spell spell = event.getSpell();
-		if (!(spell instanceof PassiveSpell)) return;
-		if (!spell.getInternalName().equals(passiveSpell.getInternalName())) return;
+		if (!(spell instanceof PassiveSpell passive) || !passive.equals(passiveSpell)) return;
+
 		ticker.add(event.getLearner());
 	}
 
 	@OverridePriority
 	@EventHandler
 	public void onForget(SpellForgetEvent event) {
+		if (ticker == null) return;
+
 		Spell spell = event.getSpell();
-		if (!(spell instanceof PassiveSpell)) return;
-		if (!spell.getInternalName().equals(passiveSpell.getInternalName())) return;
+		if (!(spell instanceof PassiveSpell passive) || !passive.equals(passiveSpell)) return;
+
 		ticker.remove(event.getForgetter());
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/util/PassiveListener.java
@@ -4,6 +4,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventPriority;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.configuration.ConfigurationSection;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -74,6 +75,10 @@ public abstract class PassiveListener implements Listener {
 	}
 	
 	public abstract void initialize(@NotNull String var);
+
+	public boolean initialize(@NotNull ConfigurationSection config) {
+		return false;
+	}
 
 	public void turnOff() {
 		// No op

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -17,7 +17,6 @@ import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.events.SpellApplyDamageEvent;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 
@@ -57,10 +56,8 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 
 	@Override
 	public CastResult castAtEntity(SpellData data) {
-		if (data.hasCaster() && checkPlugins.get(data)) {
-			MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(data.caster(), data.target(), DamageCause.ENTITY_ATTACK, 1, this);
-			if (!event.callEvent()) return noTarget(data);
-		}
+		if (data.hasCaster() && checkPlugins.get(data) && checkFakeDamageEvent(data.caster(), data.target()))
+			return noTarget(data);
 
 		int duration = fireTicks.get(data);
 		if (powerAffectsFireTicks.get(data)) duration = Math.round(duration * data.power());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DamageSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DamageSpell.java
@@ -1,0 +1,87 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import org.bukkit.entity.Player;
+import org.bukkit.damage.DamageType;
+import org.bukkit.damage.DamageSource;
+import org.bukkit.entity.LivingEntity;
+
+import io.papermc.paper.registry.RegistryKey;
+
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.CastResult;
+import com.nisovin.magicspells.util.TargetInfo;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.events.SpellApplyDamageEvent;
+import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
+
+@SuppressWarnings("UnstableApiUsage")
+public class DamageSpell extends TargetedSpell implements TargetedEntitySpell, TargetedEntityFromLocationSpell {
+
+	private final ConfigData<String> spellDamageType;
+	private final ConfigData<DamageType> damageType;
+	private final ConfigData<Boolean> creditCaster;
+	private final ConfigData<Double> damage;
+
+	public DamageSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		spellDamageType = getConfigDataString("spell-damage-type", "");
+		creditCaster = getConfigDataBoolean("credit-caster", true);
+		damage = getConfigDataDouble("damage", 4);
+
+		damageType = getConfigDataRegistryEntry("damage-type", RegistryKey.DAMAGE_TYPE, null)
+			.orDefault(data -> switch (data.caster()) {
+				case Player ignored -> DamageType.PLAYER_ATTACK;
+				case LivingEntity ignored -> DamageType.MOB_ATTACK;
+				case null -> DamageType.GENERIC;
+			});
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		TargetInfo<LivingEntity> info = getTargetedEntity(data);
+		if (info.noTarget()) return noTarget(info);
+
+		return castAtEntity(info.spellData());
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		DamageType damageType = this.damageType.get(data);
+		double damage = this.damage.get(data);
+
+		SpellApplyDamageEvent event = new SpellApplyDamageEvent(this, data.caster(), data.target(), damage, damageType, spellDamageType.get(data));
+		event.callEvent();
+		damage = event.getFinalDamage();
+
+		DamageSource.Builder builder = DamageSource.builder(damageType);
+		if (data.hasCaster() && creditCaster.get(data)) builder.withDirectEntity(data.caster());
+
+		data.target().damage(damage, builder.build());
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	@Override
+	public CastResult castAtEntityFromLocation(SpellData data) {
+		DamageType damageType = this.damageType.get(data);
+		double damage = this.damage.get(data);
+
+		SpellApplyDamageEvent event = new SpellApplyDamageEvent(this, data.caster(), data.target(), damage, damageType, spellDamageType.get(data));
+		event.callEvent();
+		damage = event.getFinalDamage();
+
+		DamageSource.Builder builder = DamageSource.builder(damageType).withDamageLocation(data.location());
+		if (data.hasCaster() && creditCaster.get(data)) builder.withDirectEntity(data.caster());
+
+		data.target().damage(damage, builder.build());
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
@@ -23,6 +23,12 @@ import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 
+	private static final DeprecationNotice DAMAGE_TYPE_DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'damage-type' option of '.targeted.DotSpell' does not function properly",
+		"Use '.targeted.DamageSpell', in combination with '.targeted.LoopSpell'.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#targeteddotspell-damage-type"
+	);
+
 	private final Map<UUID, Dot> activeDots;
 
 	private final ConfigData<Integer> delay;
@@ -59,6 +65,10 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 		damageType = getConfigDataEnum("damage-type", DamageCause.class, DamageCause.ENTITY_ATTACK);
 
 		activeDots = new HashMap<>();
+
+		MagicSpells.getDeprecationManager().addDeprecation(this, DAMAGE_TYPE_DEPRECATION_NOTICE,
+			!damage.isConstant() || damage.get() > 0
+		);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
@@ -161,7 +162,7 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 			double localDamage = damage.get(data);
 			if (powerAffectsDamage) localDamage *= data.power();
 
-			if (checkPlugins && data.hasCaster()) {
+			if (checkPlugins && data.hasCaster() && damageType != DamageCause.ENTITY_ATTACK) {
 				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(data.caster(), data.target(), damageType, localDamage, DotSpell.this);
 				if (!event.callEvent()) return;
 
@@ -174,6 +175,13 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 			localDamage = event.getFinalDamage();
 
 			if (ignoreArmor) {
+				if (checkPlugins && data.hasCaster()) {
+					EntityDamageEvent damageEvent = createFakeDamageEvent(data.caster(), data.target(), DamageCause.ENTITY_ATTACK, localDamage);
+					if (!damageEvent.callEvent()) return;
+
+					if (!avoidDamageModification) localDamage = event.getDamage();
+				}
+
 				double maxHealth = Util.getMaxHealth(data.target());
 				double health = data.target().getHealth();
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -27,6 +27,12 @@ import io.papermc.paper.registry.RegistryKey;
 @SuppressWarnings("UnstableApiUsage")
 public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell {
 
+	private static final DeprecationNotice HEALTH_DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'health' drain type of '.targeted.DrainlifeSpell' does not function properly.",
+		"Use the 'health_points' drain type",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#targeteddrainlifespell-health-drain-type"
+	);
+
 	private final ConfigData<DrainType> takeType;
 	private final ConfigData<DrainType> giveType;
 	private final ConfigData<String> spellDamageType;
@@ -73,6 +79,11 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 		damageType = getConfigDataEnum("damage-type", DamageCause.class, null);
 		drainDamageType = getConfigDataRegistryEntry("drain-damage-type", RegistryKey.DAMAGE_TYPE, null)
 			.orDefault(data -> data.caster() instanceof Player ? DamageType.PLAYER_ATTACK : DamageType.MOB_ATTACK);
+
+		MagicSpells.getDeprecationManager().addDeprecation(this, HEALTH_DEPRECATION_NOTICE,
+			takeType.isConstant() && takeType.get() == DrainType.HEALTH ||
+				giveType.isConstant() && giveType.get() == DrainType.HEALTH
+		);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DrainlifeSpell.java
@@ -4,6 +4,8 @@ import org.bukkit.World;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Player;
+import org.bukkit.damage.DamageType;
+import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityRegainHealthEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
@@ -12,7 +14,6 @@ import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.mana.ManaChangeReason;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
@@ -21,20 +22,15 @@ import com.nisovin.magicspells.events.SpellApplyDamageEvent;
 import com.nisovin.magicspells.events.MagicSpellsEntityRegainHealthEvent;
 import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
+import io.papermc.paper.registry.RegistryKey;
+
+@SuppressWarnings("UnstableApiUsage")
 public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private static final String STR_MANA = "mana";
-	private static final String STR_HEALTH = "health";
-	private static final String STR_HUNGER = "hunger";
-	private static final String STR_EXPERIENCE = "experience";
-
-	private static final int MAX_FOOD_LEVEL = 20;
-	private static final int MIN_FOOD_LEVEL = 0;
-	private static final double MIN_HEALTH = 0D;
-
-	private final ConfigData<String> takeType;
-	private final ConfigData<String> giveType;
+	private final ConfigData<DrainType> takeType;
+	private final ConfigData<DrainType> giveType;
 	private final ConfigData<String> spellDamageType;
+	private final ConfigData<DamageType> drainDamageType;
 
 	private final ConfigData<Double> takeAmt;
 	private final ConfigData<Double> giveAmt;
@@ -56,8 +52,8 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 	public DrainlifeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		takeType = getConfigDataString("take-type", "health");
-		giveType = getConfigDataString("give-type", "health");
+		takeType = getConfigDataEnum("take-type", DrainType.class, DrainType.HEALTH_POINTS);
+		giveType = getConfigDataEnum("give-type", DrainType.class, DrainType.HEALTH_POINTS);
 		spellDamageType = getConfigDataString("spell-damage-type", "");
 
 		takeAmt = getConfigDataDouble("take-amt", 2);
@@ -74,7 +70,9 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 
 		spellOnAnimationName = getConfigString("spell-on-animation", "");
 
-		damageType = getConfigDataEnum("damage-type", DamageCause.class, DamageCause.ENTITY_ATTACK);
+		damageType = getConfigDataEnum("damage-type", DamageCause.class, null);
+		drainDamageType = getConfigDataRegistryEntry("drain-damage-type", RegistryKey.DAMAGE_TYPE, null)
+			.orDefault(data -> data.caster() instanceof Player ? DamageType.PLAYER_ATTACK : DamageType.MOB_ATTACK);
 	}
 
 	@Override
@@ -114,10 +112,8 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 			give *= data.power();
 		}
 
-		Player playerTarget = target instanceof Player p ? p : null;
-
 		switch (takeType.get(data)) {
-			case STR_HEALTH -> {
+			case HEALTH -> {
 				DamageCause damageType = this.damageType.get(data);
 
 				if (checkPlugins) {
@@ -128,42 +124,53 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 				}
 
 				SpellApplyDamageEvent event = new SpellApplyDamageEvent(this, caster, target, take, damageType, spellDamageType.get(data));
-				EventUtil.call(event);
+				event.callEvent();
 				take = event.getFinalDamage();
 				if (ignoreArmor.get(data)) {
-					double health = target.getHealth();
-					if (health > Util.getMaxHealth(target)) health = Util.getMaxHealth(target);
-					health -= take;
-					if (health < MIN_HEALTH) health = MIN_HEALTH;
-					if (health > Util.getMaxHealth(target)) health = Util.getMaxHealth(target);
-					if (health == MIN_HEALTH && caster instanceof Player) target.setKiller((Player) caster);
+					double maxHealth = Util.getMaxHealth(target);
+					double health = Math.min(target.getHealth(), maxHealth);
+
+					health = Math.clamp(health - take, 0, maxHealth);
+					if (health == 0 && caster instanceof Player playerCaster) target.setKiller(playerCaster);
+
 					target.setHealth(health);
 					target.setLastDamage(take);
-					Util.playHurtEffect(data.target(), data.caster());
+					Util.playHurtEffect(target, caster);
 				} else target.damage(take, caster);
 			}
-			case STR_MANA -> {
-				if (playerTarget == null) break;
+			case HEALTH_POINTS -> {
+				DamageType type = drainDamageType.get(data);
+
+				SpellApplyDamageEvent event = new SpellApplyDamageEvent(this, caster, target, take, type, spellDamageType.get(data));
+				event.callEvent();
+				take = event.getFinalDamage();
+
+				DamageSource source = DamageSource.builder(type)
+					.withDirectEntity(caster)
+					.build();
+
+				target.damage(take, source);
+			}
+			case MANA -> {
+				if (!(target instanceof Player playerTarget)) break;
+
 				boolean removed = MagicSpells.getManaHandler().removeMana(playerTarget, (int) Math.round(take), ManaChangeReason.OTHER);
 				if (!removed) give = 0;
 			}
-			case STR_HUNGER -> {
-				if (playerTarget == null) break;
-				int food = playerTarget.getFoodLevel();
-				if (give > food) give = food;
-				food -= take;
-				if (food < MIN_FOOD_LEVEL) food = MIN_FOOD_LEVEL;
-				playerTarget.setFoodLevel(food);
+			case HUNGER -> {
+				if (!(target instanceof Player playerTarget)) break;
+
+				int food = playerTarget.getFoodLevel() - (int) take;
+				playerTarget.setFoodLevel(Math.clamp(food, 0, 20));
 			}
-			case STR_EXPERIENCE -> {
-				if (playerTarget == null) break;
-				int exp = playerTarget.calculateTotalExperiencePoints();
-				if (give > exp) give = exp;
+			case EXPERIENCE -> {
+				if (!(target instanceof Player playerTarget)) break;
+
 				Util.addExperience(playerTarget, (int) Math.round(-take));
 			}
 		}
 
-		String giveType = this.giveType.get(data);
+		DrainType giveType = this.giveType.get(data);
 		boolean instant = this.instant.get(data);
 
 		if (instant) {
@@ -177,9 +184,9 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 		return true;
 	}
 
-	private void giveToCaster(LivingEntity caster, String giveType, double give, boolean checkPlugins) {
+	private void giveToCaster(LivingEntity caster, DrainType giveType, double give, boolean checkPlugins) {
 		switch (giveType) {
-			case STR_HEALTH -> {
+			case HEALTH -> {
 				if (checkPlugins) {
 					MagicSpellsEntityRegainHealthEvent event = new MagicSpellsEntityRegainHealthEvent(caster, give, EntityRegainHealthEvent.RegainReason.CUSTOM);
 					if (!event.callEvent()) return;
@@ -191,20 +198,20 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 				if (h > Util.getMaxHealth(caster)) h = Util.getMaxHealth(caster);
 				caster.setHealth(h);
 			}
-			case STR_MANA -> {
-				if (caster instanceof Player)
-					MagicSpells.getManaHandler().addMana((Player) caster, (int) give, ManaChangeReason.OTHER);
+			case HEALTH_POINTS -> caster.heal(give);
+			case MANA -> {
+				if (caster instanceof Player player)
+					MagicSpells.getManaHandler().addMana(player, (int) give, ManaChangeReason.OTHER);
 			}
-			case STR_HUNGER -> {
-				if (caster instanceof Player) {
-					int food = ((Player) caster).getFoodLevel();
-					food += give;
-					if (food > MAX_FOOD_LEVEL) food = MAX_FOOD_LEVEL;
-					((Player) caster).setFoodLevel(food);
+			case HUNGER -> {
+				if (caster instanceof Player player) {
+					int food = player.getFoodLevel() + (int) give;
+					player.setFoodLevel(Math.clamp(food, 0, 20));
 				}
 			}
-			case STR_EXPERIENCE -> {
-				if (caster instanceof Player) Util.addExperience((Player) caster, (int) give);
+			case EXPERIENCE -> {
+				if (caster instanceof Player player)
+					Util.addExperience(player, (int) give);
 			}
 		}
 	}
@@ -214,14 +221,14 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 		private final LivingEntity caster;
 		private final boolean checkPlugins;
 		private final boolean instant;
-		private final String giveType;
+		private final DrainType giveType;
 		private final SpellData data;
 		private final Vector current;
 		private final double giveAmt;
 		private final World world;
 		private final int range;
 
-		private DrainAnimation(LivingEntity caster, Location start, String giveType, double giveAmt, boolean instant, boolean checkPlugins, SpellData data) {
+		private DrainAnimation(LivingEntity caster, Location start, DrainType giveType, double giveAmt, boolean instant, boolean checkPlugins, SpellData data) {
 			super(animationSpeed.get(data), true);
 
 			this.data = data;
@@ -250,6 +257,16 @@ public class DrainlifeSpell extends TargetedSpell implements TargetedEntitySpell
 				if (!instant) giveToCaster(caster, giveType, giveAmt, checkPlugins);
 			}
 		}
+
+	}
+
+	private enum DrainType{
+
+		EXPERIENCE,
+		HEALTH,
+		HEALTH_POINTS,
+		HUNGER,
+		MANA
 
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
@@ -28,7 +28,6 @@ import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class FireballSpell extends TargetedSpell implements TargetedEntityFromLocationSpell {
 
@@ -101,10 +100,8 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 			if (info.noTarget()) return noTarget(info);
 			data = info.spellData();
 
-			if (checkPlugins.get(data)) {
-				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(data.caster(), data.target(), DamageCause.PROJECTILE, 1D, this);
-				if (!event.callEvent()) return noTarget(data);
-			}
+			if (checkPlugins.get(data) && checkFakeDamageEvent(data.caster(), data.target(), DamageCause.PROJECTILE, 1d))
+				return noTarget(data);
 
 			Location origin = data.caster().getEyeLocation();
 			if (data.caster().equals(data.target())) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ForcetossSpell.java
@@ -2,13 +2,11 @@ package com.nisovin.magicspells.spells.targeted;
 
 import org.bukkit.util.Vector;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell {
 
@@ -18,11 +16,9 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 	private ConfigData<Double> hForce;
 	private ConfigData<Double> rotation;
 
-	private ConfigData<Boolean> checkPlugins;
 	private ConfigData<Boolean> powerAffectsForce;
 	private ConfigData<Boolean> powerAffectsDamage;
 	private ConfigData<Boolean> addVelocityInstead;
-	private ConfigData<Boolean> avoidDamageModification;
 
 	public ForcetossSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -33,11 +29,9 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 		hForce = getConfigDataDouble("horizontal-force", 20);
 		rotation = getConfigDataDouble("rotation", 0);
 
-		checkPlugins = getConfigDataBoolean("check-plugins", true);
 		powerAffectsForce = getConfigDataBoolean("power-affects-force", true);
 		powerAffectsDamage = getConfigDataBoolean("power-affects-damage", true);
 		addVelocityInstead = getConfigDataBoolean("add-velocity-instead", false);
-		avoidDamageModification = getConfigDataBoolean("avoid-damage-modification", true);
 	}
 
 	@Override
@@ -59,16 +53,7 @@ public class ForcetossSpell extends TargetedSpell implements TargetedEntitySpell
 		double damage = this.damage.get(data);
 		if (powerAffectsDamage.get(data)) damage *= data.power();
 
-		if (damage > 0) {
-			if (checkPlugins.get(data)) {
-				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(caster, target, DamageCause.ENTITY_ATTACK, damage, this);
-				if (!event.callEvent()) return noTarget(data);
-
-				if (!avoidDamageModification.get(data)) damage = event.getDamage();
-			}
-
-			target.damage(damage, caster);
-		}
+		if (damage > 0) target.damage(damage, caster);
 
 		Vector v;
 		if (caster.equals(target)) v = caster.getLocation().getDirection();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -60,10 +60,8 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 			double additionalDamage = this.additionalDamage.get(data);
 			if (powerAffectsAdditionalDamage.get(data)) additionalDamage *= data.power();
 
-			if (checkPlugins.get(data)) {
-				MagicSpellsEntityDamageByEntityEvent event = new MagicSpellsEntityDamageByEntityEvent(data.caster(), data.target(), DamageCause.LIGHTNING, additionalDamage, this);
-				if (!event.callEvent()) return noTarget(data);
-			}
+			if (checkPlugins.get(data) && checkFakeDamageEvent(data.caster(), data.target()))
+				return noTarget(data);
 
 			ChargeOption option = new ChargeOption(additionalDamage, chargeCreepers.get(data), zapPigs.get(data));
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -1,26 +1,33 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.HashMap;
 
 import org.bukkit.Location;
+import org.bukkit.event.Listener;
+import org.bukkit.damage.DamageType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.metadata.MetadataValue;
+import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.LightningStrike;
 import org.bukkit.event.entity.PigZapEvent;
-import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.event.entity.CreeperPowerEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
-import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
+
+import com.destroystokyo.paper.event.entity.EntityZapEvent;
+import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
-import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class LightningSpell extends TargetedSpell implements TargetedLocationSpell {
+
+	//	private Map<UUID, ChargeOption> striking;
+	private static LightningListener lightningListener;
 
 	private final ConfigData<Double> additionalDamage;
 
@@ -28,6 +35,7 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 	private final ConfigData<Boolean> noDamage;
 	private final ConfigData<Boolean> checkPlugins;
 	private final ConfigData<Boolean> chargeCreepers;
+	private final ConfigData<Boolean> transformEntities;
 	private final ConfigData<Boolean> requireEntityTarget;
 	private final ConfigData<Boolean> powerAffectsAdditionalDamage;
 
@@ -40,8 +48,19 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 		noDamage = getConfigDataBoolean("no-damage", false);
 		checkPlugins = getConfigDataBoolean("check-plugins", true);
 		chargeCreepers = getConfigDataBoolean("charge-creepers", true);
+		transformEntities = getConfigDataBoolean("transform-entities", true);
 		requireEntityTarget = getConfigDataBoolean("require-entity-target", false);
 		powerAffectsAdditionalDamage = getConfigDataBoolean("power-affects-additional-damage", true);
+
+		if (lightningListener == null) {
+			lightningListener = new LightningListener();
+			MagicSpells.registerEvents(lightningListener);
+		}
+	}
+
+	@Override
+	protected void turnOff() {
+		if (lightningListener != null) lightningListener = null;
 	}
 
 	@Override
@@ -63,10 +82,9 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 			if (checkPlugins.get(data) && checkFakeDamageEvent(data.caster(), data.target()))
 				return noTarget(data);
 
-			ChargeOption option = new ChargeOption(additionalDamage, chargeCreepers.get(data), zapPigs.get(data));
-
+			ChargeOption option = new ChargeOption(additionalDamage, chargeCreepers.get(data), zapPigs.get(data), transformEntities.get(data));
 			LightningStrike strike = data.target().getWorld().strikeLightning(data.target().getLocation());
-			strike.setMetadata("MS" + internalName, new FixedMetadataValue(MagicSpells.plugin, option));
+			lightningListener.striking.put(strike.getUniqueId(), option);
 
 			return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 		}
@@ -85,57 +103,70 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 		else {
 			double additionalDamage = this.additionalDamage.get(data);
 			if (powerAffectsAdditionalDamage.get(data)) additionalDamage *= data.power();
-			ChargeOption option = new ChargeOption(additionalDamage, chargeCreepers.get(data), zapPigs.get(data));
 
+			ChargeOption option = new ChargeOption(additionalDamage, chargeCreepers.get(data), zapPigs.get(data), transformEntities.get(data));
 			LightningStrike strike = target.getWorld().strikeLightning(target);
-			strike.setMetadata("MS" + internalName, new FixedMetadataValue(MagicSpells.plugin, option));
+			lightningListener.striking.put(strike.getUniqueId(), option);
 		}
 
 		playSpellEffects(data);
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
-	@EventHandler
-	public void onLightningDamage(EntityDamageByEntityEvent event) {
-		if (event.getCause() != DamageCause.LIGHTNING || !(event.getDamager() instanceof LightningStrike strike)) return;
+	private record ChargeOption(double additionalDamage, boolean chargeCreeper, boolean changePig, boolean transformEntities) {
 
-		List<MetadataValue> data = strike.getMetadata("MS" + internalName);
-		if (data.isEmpty()) return;
-
-		for (MetadataValue val : data) {
-			ChargeOption option = (ChargeOption) val.value();
-			if (option != null && option.additionalDamage > 0)
-				event.setDamage(event.getDamage() + option.additionalDamage);
-			return;
-		}
 	}
 
-	@EventHandler
-	public void onCreeperCharge(CreeperPowerEvent event) {
-		LightningStrike strike = event.getLightning();
-		if (strike == null) return;
-		List<MetadataValue> data = strike.getMetadata("MS" + internalName);
-		if (data.isEmpty()) return;
-		for (MetadataValue val : data) {
-			ChargeOption option = (ChargeOption) val.value();
-			if (option == null) continue;
-			if (!option.chargeCreeper) event.setCancelled(true);
-			break;
-		}
-	}
+	private static class LightningListener implements Listener {
 
-	@EventHandler
-	public void onPigZap(PigZapEvent event) {
-		LightningStrike strike = event.getLightning();
-		List<MetadataValue> data = strike.getMetadata("MS" + internalName);
-		if (data.isEmpty()) return;
-		for (MetadataValue val : data) {
-			ChargeOption option = (ChargeOption) val.value();
-			if (option == null) continue;
-			if (!option.changePig) event.setCancelled(true);
-		}
-	}
+		private final Map<UUID, ChargeOption> striking = new HashMap<>();
 
-	private record ChargeOption(double additionalDamage, boolean chargeCreeper, boolean changePig) { }
+		@SuppressWarnings("UnstableApiUsage")
+		@EventHandler
+		public void onLightningDamage(EntityDamageByEntityEvent event) {
+			if (!(event.getDamager() instanceof LightningStrike strike)) return;
+
+			DamageSource source = event.getDamageSource();
+			if (source.getDamageType() != DamageType.LIGHTNING_BOLT) return;
+
+			ChargeOption option = striking.get(strike.getUniqueId());
+			if (option == null || option.additionalDamage <= 0) return;
+
+			event.setDamage(event.getDamage() + option.additionalDamage);
+		}
+
+		@EventHandler
+		public void onCreeperCharge(CreeperPowerEvent event) {
+			LightningStrike strike = event.getLightning();
+			if (strike == null) return;
+
+			ChargeOption option = striking.get(strike.getUniqueId());
+			if (option == null || option.transformEntities && option.chargeCreeper) return;
+
+			event.setCancelled(true);
+		}
+
+		@EventHandler
+		public void onPigZap(PigZapEvent event) {
+			ChargeOption option = striking.get(event.getLightning().getUniqueId());
+			if (option == null || option.transformEntities && option.changePig) return;
+
+			event.setCancelled(true);
+		}
+
+		@EventHandler
+		public void onZap(EntityZapEvent event) {
+			ChargeOption option = striking.get(event.getBolt().getUniqueId());
+			if (option == null || option.transformEntities) return;
+
+			event.setCancelled(true);
+		}
+
+		@EventHandler
+		public void onRemove(EntityRemoveFromWorldEvent event) {
+			striking.remove(event.getEntity().getUniqueId());
+		}
+
+	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PainSpell.java
@@ -6,6 +6,7 @@ import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.util.compat.CompatBasics;
@@ -14,6 +15,12 @@ import com.nisovin.magicspells.events.SpellApplyDamageEvent;
 import com.nisovin.magicspells.events.MagicSpellsEntityDamageByEntityEvent;
 
 public class PainSpell extends TargetedSpell implements TargetedEntitySpell {
+
+	private static final DeprecationNotice DAMAGE_TYPE_DEPRECATION_NOTICE = new DeprecationNotice(
+		"The 'damage-type' option of '.targeted.PainSpell' does not function properly.",
+		"Use '.targeted.DamageSpell', which has proper damage type support.",
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#targetedpainspell-damage-type"
+	);
 
 	private final ConfigData<String> spellDamageType;
 	private final ConfigData<DamageCause> damageType;
@@ -40,6 +47,10 @@ public class PainSpell extends TargetedSpell implements TargetedEntitySpell {
 		powerAffectsDamage = getConfigDataBoolean("power-affects-damage", true);
 		avoidDamageModification = getConfigDataBoolean("avoid-damage-modification", true);
 		tryAvoidingAntiCheatPlugins = getConfigDataBoolean("try-avoiding-anticheat-plugins", false);
+
+		MagicSpells.getDeprecationManager().addDeprecation(this, DAMAGE_TYPE_DEPRECATION_NOTICE,
+			!damageType.isConstant() || damageType.get() != DamageCause.ENTITY_ATTACK
+		);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/util/DeprecationNotice.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/DeprecationNotice.java
@@ -1,0 +1,12 @@
+package com.nisovin.magicspells.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public record DeprecationNotice(@NotNull String reason, @NotNull String replacement, @Nullable String context) {
+
+	public DeprecationNotice(@NotNull String reason, @NotNull String replacement) {
+		this(reason, replacement, null);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigData.java
@@ -18,6 +18,13 @@ public interface ConfigData<T> {
 		return value == null ? fallback : value;
 	}
 
+	default ConfigData<T> orDefault(@NotNull ConfigData<T> def) {
+		return data -> {
+			T value = get(data);
+			return value != null ? value : def.get(data);
+		};
+	}
+
 	default boolean isConstant() {
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -99,6 +99,7 @@ public class PassiveManager {
 		addListener(BlockPlaceListener.class);
 		addListener(BuffListener.class);
 		addListener(CraftListener.class);
+		addListener(DamageListener.class);
 		addListener(DeathListener.class);
 		addListener(DropItemListener.class);
 		addListener(EnterBedListener.class);


### PR DESCRIPTION
Closes #557.
- Added a section-based format for passive triggers. Old triggers do not currently have support for the format.
  
```yml
test:
    spell-class: ".PassiveSpell"
    triggers:
      - trigger: <trigger name> # Specifies the type of the passive trigger.
        priority: normal # Specifies the event priority of the passive trigger. Defaults to 'normal'.
```      

- Added the `damage` passive trigger.

```yml
test:
    spell-class: ".PassiveSpell"
    triggers:
      - trigger: damage
        mode: give # Specifies if this trigger fires for taking damage or receiving damage. Takes the values of 'give' or 'take'. Required.
        damage-types: ["player_attack", "#bypasses_armor"] # List of damage types and damage type tags to listen for.
        indirect-damager: true # If true, if the damage is indirect, the causing entity (i.e. an entity that shoots a projectile) is used instead of the direct damaging entity (i.e. a projectile, such as an arrow). Defaults to true.
        minimum-damage: -1 # Specifies the minimum damage (inclusive) needed to fire the trigger. Defaults to '-1'.
        weapon-items: [diamond_sword] # List of magic item filters for the weapon item.
        projectile-items: [arrow] # List of magic item filters for a projectile's item.
```

- Added the `.targeted.DamageSpell` spell class.

```yml
test:
    spell-class: ".targeted.DamageSpell"
    damage: 4 # Specifies the amount of damage to deal. Defaults to '4'.
    damage-type: player_attack # Specifies which damage type to deal damage with. Defaults to 'player_attack' for players, 'mob_attack' for non-players, and 'generic' for no caster.
    credit-caster: true # Specifies if the damage should be credited to the caster.
    spell-damage-type: "" # Optional tag used in other spells.
```

- `MagicSpellsEntityDamageByEntityEvent` now has its own `HandlerList`; this requires plugins to explicitly listen for it. This event should generally not be used. `InvulnerabilitySpell`, `ResistSpell`, `fataldamage`, `givedamage`, `takedamage` still listen to the event for legacy support.
- Removed most usages of `MagicSpellsEntityDamageByEntityEvent`.
- Fixed an issue with the `ticks` passive trigger causing errors when configured incorrectly.
- Added the `health_points` drain type to `DrainlifeSpell`, which replaces the `health` drain type. `give-type` and `take-type` now default to `health_points`.
- Added the `drain-damage-type` option to `DrainlifeSpell`. When `give-type: health_points`, `drain-damage-type` specifies the damage type to use when draining the target.
- Added the `damage-types` option to `InvulnerabilitySpell`, which replaces the `damage-causes` option. Specifies a list of damage types and damage type tags to restrict invulnerability to.
- Added the `damage-types` option to `ResistSpell`, which replaces the `normal-damage-types` option. Specifies the list of damage types and damage type tags to resist damage for. When `damage-types: true`, all damage is resisted instead.
- Added the `transform-entities` option to `LightningSpell`. Defaults to `true`. When `transform-entities: false`, the lightning spawned by the spell will not transform entities (turn villagers to witches, pigs to zombified piglins, etc.).
- Added deprecation messages for spell options/passive triggers that relied on Bukkit damage causes.