### PR TITLE
Managers

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -74,6 +74,7 @@ import com.nisovin.magicspells.castmodifiers.ModifierSet;
 import com.nisovin.magicspells.commands.CommandHelpFilter;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.recipes.CustomRecipes;
+import com.nisovin.magicspells.util.ai.CustomGoalsManager;
 import com.nisovin.magicspells.handlers.DeprecationHandler;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.storage.types.TXTFileStorage;
@@ -87,6 +88,7 @@ import com.nisovin.magicspells.spelleffects.trackers.AsyncEffectTracker;
 import com.nisovin.magicspells.spelleffects.effecttypes.EffectLibEffect;
 import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
 import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
+import com.nisovin.magicspells.spells.targeted.cleanse.util.CleanserManager;
 
 public class MagicSpells extends JavaPlugin {
 
@@ -134,6 +136,8 @@ public class MagicSpells extends JavaPlugin {
 	private SpellEffectManager spellEffectManager;
 	private ConditionManager conditionManager;
 	private NoMagicZoneManager zoneManager;
+	private CleanserManager cleanserManager;
+	private CustomGoalsManager customGoalsManager;
 	private PaperCommandManager commandManager;
 	private ExperienceBarManager expBarManager;
 
@@ -416,6 +420,8 @@ public class MagicSpells extends JavaPlugin {
 
 		// Create handling objects
 		zoneManager = new NoMagicZoneManager();
+		cleanserManager = new CleanserManager();
+		customGoalsManager = new CustomGoalsManager();
 		buffManager = new BuffManager(config.getInt(path + "buff-check-interval", 100));
 		expBarManager = new ExperienceBarManager();
 		bossBarManager = new BossBarManager();
@@ -1358,6 +1364,22 @@ public class MagicSpells extends JavaPlugin {
 		return plugin.zoneManager;
 	}
 
+	/**
+	 * Gets the handler for CleanseSpell cleansers.
+	 * @return the CleanseSpell cleanser handler
+	 */
+	public static CleanserManager getCleanserManager() {
+		return plugin.cleanserManager;
+	}
+
+	/**
+	 * Gets the handler for mob goals.
+	 * @return the mob goals handler
+	 */
+	public static CustomGoalsManager getCustomGoalsManager() {
+		return plugin.customGoalsManager;
+	}
+
 	public static BuffManager getBuffManager() {
 		return plugin.buffManager;
 	}
@@ -2227,9 +2249,11 @@ public class MagicSpells extends JavaPlugin {
 		strWrongWorld = null;
 		strSpellChange = null;
 		strUnknownSpell = null;
+		cleanserManager = null;
 		strXpAutoLearned = null;
 		lifeLengthTracker = null;
 		deprecationHandler = null;
+		customGoalsManager = null;
 		strMissingReagents = null;
 		strSpellChangeEmpty = null;
 		soundFailOnCooldown = null;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
@@ -173,11 +173,11 @@ public class PortalSpell extends InstantSpell {
 	}
 
 	public ConfigData<Integer> getMinDistance() {
-		return duration;
+		return minDistance;
 	}
 
 	public ConfigData<Integer> getMaxDistance() {
-		return duration;
+		return maxDistance;
 	}
 
 	public ConfigData<Double> getTeleportCooldown() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CleanseSpell.java
@@ -6,48 +6,62 @@ import java.util.Arrays;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.spells.targeted.cleanse.util.Cleansers;
+import com.nisovin.magicspells.spells.targeted.cleanse.util.Cleanser;
 
 public class CleanseSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private Cleansers cleansers;
-
-	private final List<String> cleanseList;
+	private List<Cleanser> cleansers;
 
 	public CleanseSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-
-		cleanseList = getConfigStringList("remove", Arrays.asList("fire", "hunger", "poison", "wither"));
 	}
 
 	@Override
 	public void initialize() {
 		super.initialize();
 
-		cleansers = new Cleansers(cleanseList, internalName);
+		List<String> list = getConfigStringList("remove", Arrays.asList("fire", "hunger", "poison", "wither"));
+		if (list == null) {
+			MagicSpells.error("CleanseSpell '" + internalName + "' has no cleansers defined in 'remove'.");
+			return;
+		}
+
+		cleansers = MagicSpells.getCleanserManager().createCleansers();
+		outer:
+		for (String string : list) {
+			for (Cleanser cleanser : cleansers)
+				if (cleanser.add(string))
+					continue outer;
+
+			MagicSpells.error("CleanseSpell '" + internalName + "' has an invalid cleanser '" + string + "' defined in 'remove'.");
+		}
 	}
 
 	@Override
 	public CastResult cast(SpellData data) {
-		TargetInfo<LivingEntity> info = getTargetedEntity(data, cleansers.getChecker());
+		TargetInfo<LivingEntity> info = getTargetedEntity(data, getValidTargetChecker());
 		if (info.noTarget()) return noTarget(info);
-		data = info.spellData();
-
-		return castAtEntity(data);
+		return castAtEntity(info.spellData());
 	}
 
 	@Override
 	public CastResult castAtEntity(SpellData data) {
-		cleansers.cleanse(data.target());
+		cleansers.forEach(cleanser -> cleanser.cleanse(data.target()));
 		playSpellEffects(data);
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
 	@Override
 	public ValidTargetChecker getValidTargetChecker() {
-		return cleansers.getChecker();
+		return entity -> {
+			for (Cleanser cleanser : cleansers)
+				if (cleanser.isAnyActive(entity))
+					return true;
+			return false;
+		};
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/CleanserManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/CleanserManager.java
@@ -1,0 +1,49 @@
+package com.nisovin.magicspells.spells.targeted.cleanse.util;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.spells.targeted.cleanse.*;
+
+public class CleanserManager {
+
+	private final List<Class<? extends Cleanser>> cleanserClasses = new ArrayList<>();
+
+	public CleanserManager() {
+		initialize();
+	}
+
+	public List<Cleanser> createCleansers() {
+		List<Cleanser> cleansers = new ArrayList<>();
+		try {
+			for (Class<? extends Cleanser> clazz : cleanserClasses) {
+				cleansers.add(clazz.getDeclaredConstructor().newInstance());
+			}
+		} catch (Exception e) {
+			DebugHandler.debugGeneral(e);
+		}
+		return cleansers;
+	}
+
+	public void addCleanser(@NotNull Class<? extends Cleanser> clazz) {
+		cleanserClasses.add(clazz);
+	}
+
+	private void initialize() {
+		addCleanser(BuffSpellCleanser.class);
+		addCleanser(DotSpellCleanser.class);
+		addCleanser(FireCleanser.class);
+		addCleanser(FreezeCleanser.class);
+		addCleanser(LevitateSpellCleanser.class);
+		addCleanser(LoopSpellCleanser.class);
+		addCleanser(OrbitSpellCleanser.class);
+		addCleanser(PotionCleanser.class);
+		addCleanser(SilenceSpellCleanser.class);
+		addCleanser(StunSpellCleanser.class);
+		addCleanser(TotemSpellCleanser.class);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/Cleansers.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/cleanse/util/Cleansers.java
@@ -1,78 +1,23 @@
 package com.nisovin.magicspells.spells.targeted.cleanse.util;
 
-import java.util.List;
-import java.util.Arrays;
-import java.util.ArrayList;
-
-import org.bukkit.entity.LivingEntity;
-
 import org.jetbrains.annotations.NotNull;
 
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.handlers.DebugHandler;
-import com.nisovin.magicspells.util.ValidTargetChecker;
-import com.nisovin.magicspells.spells.targeted.cleanse.*;
 
+/**
+ * @deprecated See {@link MagicSpells#getCleanserManager()}
+ */
+@Deprecated(forRemoval = true)
 public class Cleansers {
-
-	private static final List<Class<? extends Cleanser>> cleanserClasses = new ArrayList<>(Arrays.asList(
-			PotionCleanser.class,
-			BuffSpellCleanser.class,
-			DotSpellCleanser.class,
-			LevitateSpellCleanser.class,
-			LoopSpellCleanser.class,
-			OrbitSpellCleanser.class,
-			SilenceSpellCleanser.class,
-			StunSpellCleanser.class,
-			TotemSpellCleanser.class,
-			FireCleanser.class,
-			FreezeCleanser.class
-	));
-
-	private final List<Cleanser> cleansers = new ArrayList<>();
-
-	private ValidTargetChecker checker;
 
 	private Cleansers() {}
 
-	public Cleansers(List<String> toCleanse, String spellName) {
-		try {
-			for (Class<? extends Cleanser> clazz : cleanserClasses) {
-				cleansers.add(clazz.getDeclaredConstructor().newInstance());
-			}
-		} catch (Exception e) {
-			DebugHandler.debugGeneral(e);
-		}
-
-		checker = entity -> {
-			for (Cleanser cleanser : cleansers) {
-				if (cleanser.isAnyActive(entity)) {
-					return true;
-				}
-			}
-			return false;
-		};
-
-		outer:
-		for (String string : toCleanse) {
-			for (Cleanser cleanser : cleansers)
-				if (cleanser.add(string))
-					continue outer;
-
-			MagicSpells.error("CleanseSpell '" + spellName + "' has an invalid cleanser '" + string + "' defined in 'remove'.");
-		}
-	}
-
-	public ValidTargetChecker getChecker() {
-		return checker;
-	}
-
-	public void cleanse(LivingEntity entity) {
-		cleansers.forEach(cleanser -> cleanser.cleanse(entity));
-	}
-
+	/**
+	 * @deprecated See {@link MagicSpells#getCleanserManager()} and {@link CleanserManager#addCleanser(Class)}
+	 */
+	@Deprecated(forRemoval = true)
 	public static void addCleanserClass(@NotNull Class<? extends Cleanser> clazz) {
-		cleanserClasses.add(clazz);
+		MagicSpells.getCleanserManager().addCleanser(clazz);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/LocationUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/LocationUtil.java
@@ -11,7 +11,6 @@ import org.bukkit.entity.Entity;
 import org.bukkit.util.NumberConversions;
 import org.bukkit.command.BlockCommandSender;
 
-import org.apache.commons.math4.core.jdkmath.JdkMath;
 import org.apache.commons.math4.core.jdkmath.AccurateMath;
 
 public class LocationUtil {
@@ -164,7 +163,7 @@ public class LocationUtil {
 
 		double x2 = NumberConversions.square(x);
 		double z2 = NumberConversions.square(z);
-		double xz = JdkMath.sqrt(x2 + z2);
+		double xz = Math.sqrt(x2 + z2);
 		loc.setPitch((float) AccurateMath.toDegrees(AccurateMath.atan(-v.getY() / xz)));
 
 		return loc;

--- a/core/src/main/java/com/nisovin/magicspells/util/ai/CustomGoals.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ai/CustomGoals.java
@@ -1,68 +1,19 @@
 package com.nisovin.magicspells.util.ai;
 
-import java.util.Map;
-import java.util.HashMap;
-import java.lang.reflect.Field;
+import com.nisovin.magicspells.MagicSpells;
 
-import org.bukkit.entity.Mob;
-
-import com.destroystokyo.paper.entity.ai.GoalKey;
-import com.destroystokyo.paper.entity.ai.VanillaGoal;
-
-import com.nisovin.magicspells.util.Name;
-import com.nisovin.magicspells.util.SpellData;
-import com.nisovin.magicspells.util.ai.goals.*;
-import com.nisovin.magicspells.handlers.DebugHandler;
-
+/**
+ * @deprecated See {@link MagicSpells#getCustomGoalsManager()}
+ */
+@Deprecated(forRemoval = true)
 public class CustomGoals {
 
-	private static final Map<String, Class<? extends CustomGoal>> GOALS = new HashMap<>();
-	static {
-		addGoal(LookAtEntityTypeGoal.class);
-		addGoal(PathToGoal.class);
-	}
-	
-	private static final Map<String, GoalKey<?>> VANILLA_GOAL_KEYS = new HashMap<>();
-	static {
-		for (Field field : VanillaGoal.class.getDeclaredFields()) {
-			try {
-				if (!(field.get(null) instanceof GoalKey<?> key)) continue;
-				if (field.isAnnotationPresent(Deprecated.class)) continue;
-				VANILLA_GOAL_KEYS.put(field.getName(), key);
-			}
-			catch (IllegalAccessException ignored) {}
-		}
-	}
-
-	public static Map<String, Class<? extends CustomGoal>> getGoals() {
-		return GOALS;
-	}
-
 	/**
-	 * @return {@link VanillaGoal} mapped by the passed field name.
+	 * @deprecated See {@link MagicSpells#getCustomGoalsManager()} and {@link CustomGoalsManager#addGoal(Class)}
 	 */
-	public static GoalKey<?> getVanillaGoal(String fieldName) {
-		return VANILLA_GOAL_KEYS.get(fieldName.toUpperCase());
-	}
-
-	/**
-	 * @param goal must be annotated with {@link Name}.
-	 */
+	@Deprecated(forRemoval = true)
 	public static void addGoal(Class<? extends CustomGoal> goal) {
-		Name name = goal.getAnnotation(Name.class);
-		if (name == null) throw new IllegalStateException("Missing 'Name' annotation from CustomGoal class: " + goal.getName());
-		GOALS.put(name.value(), goal);
-	}
-
-	public static CustomGoal getGoal(String name, Mob mob, SpellData data) {
-		Class<? extends CustomGoal> clazz = GOALS.get(name);
-		if (clazz == null) return null;
-		try {
-			return clazz.getDeclaredConstructor(Mob.class, SpellData.class).newInstance(mob, data);
-		} catch (Exception e) {
-			DebugHandler.debugGeneral(e);
-			return null;
-		}
+		MagicSpells.getCustomGoalsManager().addGoal(goal);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/ai/CustomGoalsManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ai/CustomGoalsManager.java
@@ -1,0 +1,72 @@
+package com.nisovin.magicspells.util.ai;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.lang.reflect.Field;
+
+import org.bukkit.entity.Mob;
+
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.VanillaGoal;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.ai.goals.*;
+import com.nisovin.magicspells.handlers.DebugHandler;
+
+public class CustomGoalsManager {
+
+	private static final Map<String, GoalKey<?>> VANILLA_GOAL_KEYS = new HashMap<>();
+	static {
+		for (Field field : VanillaGoal.class.getDeclaredFields()) {
+			try {
+				if (!(field.get(null) instanceof GoalKey<?> key)) continue;
+				VANILLA_GOAL_KEYS.put(field.getName(), key);
+			}
+			catch (IllegalAccessException ignored) {}
+		}
+	}
+
+	private final Map<String, Class<? extends CustomGoal>> GOALS = new HashMap<>();
+
+	public CustomGoalsManager() {
+		initialize();
+	}
+
+	/**
+	 * @return {@link VanillaGoal} mapped by the passed field name.
+	 */
+	public GoalKey<?> getVanillaGoal(String fieldName) {
+		return VANILLA_GOAL_KEYS.get(fieldName.toUpperCase());
+	}
+
+	public Map<String, Class<? extends CustomGoal>> getGoals() {
+		return GOALS;
+	}
+
+	/**
+	 * @param goal must be annotated with {@link Name}.
+	 */
+	public void addGoal(Class<? extends CustomGoal> goal) {
+		Name name = goal.getAnnotation(Name.class);
+		if (name == null) throw new IllegalStateException("Missing 'Name' annotation from CustomGoal class: " + goal.getName());
+		GOALS.put(name.value(), goal);
+	}
+
+	public CustomGoal getGoal(String name, Mob mob, SpellData data) {
+		Class<? extends CustomGoal> clazz = GOALS.get(name);
+		if (clazz == null) return null;
+		try {
+			return clazz.getDeclaredConstructor(Mob.class, SpellData.class).newInstance(mob, data);
+		} catch (Exception e) {
+			DebugHandler.debugGeneral(e);
+			return null;
+		}
+	}
+
+	private void initialize() {
+		addGoal(LookAtEntityTypeGoal.class);
+		addGoal(PathToGoal.class);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -12,7 +12,7 @@ import com.nisovin.magicspells.castmodifiers.conditions.*;
 
 public class ConditionManager {
 
-	private static final Map<String, Class<? extends Condition>> conditions = new HashMap<>();
+	private final Map<String, Class<? extends Condition>> conditions = new HashMap<>();
 
 	public ConditionManager() {
 		initialize();

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/PassiveManager.java
@@ -14,9 +14,9 @@ import com.nisovin.magicspells.spells.passive.util.PassiveListener;
 
 public class PassiveManager {
 
-	private static final Map<String, EventPriority> eventPriorities = new HashMap<>();
+	private final Map<String, EventPriority> eventPriorities = new HashMap<>();
 
-	private static final Map<String, Class<? extends PassiveListener>> listeners = new HashMap<>();
+	private final Map<String, Class<? extends PassiveListener>> listeners = new HashMap<>();
 
 	public PassiveManager() {
 		initialize();
@@ -101,10 +101,10 @@ public class PassiveManager {
 		addListener(CraftListener.class);
 		addListener(DamageListener.class);
 		addListener(DeathListener.class);
-		addListener(DropItemListener.class);
-		addListener(EnterBedListener.class);
 		addListener(DismountListener.class);
+		addListener(DropItemListener.class);
 		addListener(EnchantListener.class);
+		addListener(EnterBedListener.class);
 		addListener(EntityTargetListener.class);
 		addListener(EquipListener.class);
 		addListener(FatalDamageListener.class);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/SpellEffectManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/SpellEffectManager.java
@@ -12,7 +12,7 @@ import com.nisovin.magicspells.spelleffects.effecttypes.*;
 
 public class SpellEffectManager {
 
-	private static final Map<String, Class<? extends SpellEffect>> spellEffects = new HashMap<>();
+	private final Map<String, Class<? extends SpellEffect>> spellEffects = new HashMap<>();
 
 	public SpellEffectManager() {
 		initialize();

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -27,15 +27,19 @@ import com.nisovin.magicspells.variables.variabletypes.*;
 
 public class VariableManager {
 
-	private static final Map<String, Class<? extends Variable>> variableTypes = new HashMap<>();
-	private static final Map<String, Variable> metaVariables = new HashMap<>();
-	private static final Map<String, Variable> variables = new HashMap<>();
-	private static final Set<String> dirtyPlayerVars = new HashSet<>();
+	private final Map<String, Variable> metaVariables = new HashMap<>();
+	private final Map<String, Class<? extends Variable>> variableTypes = new HashMap<>();
 
+	private static final Map<String, Variable> variables = new HashMap<>();
+
+	private static final Set<String> dirtyPlayerVars = new HashSet<>();
 	private static boolean dirtyGlobalVars = false;
+
 	private static File folder;
 
 	public VariableManager() {
+		folder = new File(MagicSpells.getInstance().getDataFolder(), "vars");
+
 		initialize();
 	}
 
@@ -181,8 +185,6 @@ public class VariableManager {
 			variables.putAll(getMetaVariables());
 
 			// Load vars
-			folder = new File(MagicSpells.getInstance().getDataFolder(), "vars");
-			if (!folder.exists()) folder.mkdir();
 			loadGlobalVariables();
 			for (Player player : Bukkit.getOnlinePlayers()) {
 				loadPlayerVariables(player.getName(), Util.getUniqueId(player));
@@ -278,9 +280,6 @@ public class VariableManager {
 		variables.putAll(getMetaVariables());
 
 		// Load vars
-		folder = new File(MagicSpells.getInstance().getDataFolder(), "vars");
-		if (!folder.exists()) folder.mkdir();
-
 		loadGlobalVariables();
 		for (Player player : Bukkit.getOnlinePlayers()) {
 			loadPlayerVariables(player.getName(), Util.getUniqueId(player));
@@ -438,6 +437,7 @@ public class VariableManager {
 	}
 
 	public void loadGlobalVariables() {
+		if (!folder.exists()) folder.mkdir();
 		File file = new File(folder, "GLOBAL.txt");
 		if (!file.exists()) {
 			dirtyGlobalVars = false;
@@ -465,6 +465,7 @@ public class VariableManager {
 	}
 
 	public void saveGlobalVariables() {
+		if (!folder.exists()) folder.mkdir();
 		File file = new File(folder, "GLOBAL.txt");
 		if (file.exists()) file.delete();
 
@@ -507,6 +508,7 @@ public class VariableManager {
 	}
 
 	public void loadPlayerVariables(String player, String uniqueId) {
+		if (!folder.exists()) folder.mkdir();
 		File file = new File(folder, "PLAYER_" + uniqueId + ".txt");
 		if (!file.exists()) {
 			File file2 = new File(folder, "PLAYER_" + player + ".txt");
@@ -537,6 +539,7 @@ public class VariableManager {
 	}
 
 	public void savePlayerVariables(String player, String uniqueId) {
+		if (!folder.exists()) folder.mkdir();
 		File file = new File(folder, "PLAYER_" + player + ".txt");
 		if (file.exists()) file.delete();
 		file = new File(folder, "PLAYER_" + uniqueId + ".txt");


### PR DESCRIPTION
Custom cleanser and mob goal API methods have been migrated to be consistent with other Manager classes that depend on the plugin's life cycle of spell config loading and initialising.

Before:
```java
Cleansers.addCleanserClass
CustomGoals.addGoal
```
Now:
```java
MagicSpells.getCleanserManager()#addCleanser
MagicSpells.getCustomGoalsManager()#addGoal
```

Previous methods have been marked for removal.

This PR also fixes an edge case oversight where add-on features from Managers were not being removed on reload.