### PR TITLE
Delayed "entity" and "armorstand" entity handling

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1912,36 +1912,50 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	@Deprecated
 	protected Map<SpellEffect, Entity> playSpellEntityEffects(EffectPosition pos, Location location) {
-		return playSpellEntityEffects(pos, location, SpellData.NULL);
+		Map<SpellEffect, DelayableEntity<Entity>> values = playSpellEntityEffects(pos, location, SpellData.NULL);
+		if (values == null) return null;
+
+		Map<SpellEffect, Entity> map = new HashMap<>();
+		values.forEach((key, value) -> value.ifPresent(entity -> map.put(key, entity)));
+
+		return map;
 	}
 
-	protected Map<SpellEffect, Entity> playSpellEntityEffects(EffectPosition pos, Location location, SpellData data) {
+	protected Map<SpellEffect, DelayableEntity<Entity>> playSpellEntityEffects(EffectPosition pos, Location location, SpellData data) {
 		if (effects == null) return null;
 		List<SpellEffect> effectsList = effects.get(pos);
 		if (effectsList == null) return null;
-		Map<SpellEffect, Entity> values = new HashMap<>();
+
+		Map<SpellEffect, DelayableEntity<Entity>> values = new HashMap<>();
 		for (SpellEffect effect : effectsList) {
 			if (!(effect instanceof EntityEffect)) continue;
-			Entity entity = effect.playEntityEffect(location, data);
+			DelayableEntity<Entity> entity = effect.playEntityEffect(location, data);
 			if (entity == null) continue;
 			values.put(effect, entity);
 		}
+
 		return values;
 	}
 
 	@Deprecated
 	protected Set<ArmorStand> playSpellArmorStandEffects(EffectPosition pos, Location location) {
-		return playSpellArmorStandEffects(pos, location, SpellData.NULL);
+		Set<DelayableEntity<ArmorStand>> values = playSpellArmorStandEffects(pos, location, SpellData.NULL);
+		if (values == null) return null;
+
+		Set<ArmorStand> set = new HashSet<>();
+		values.forEach(stand -> stand.ifPresent(set::add));
+
+		return set;
 	}
 
-	protected Set<ArmorStand> playSpellArmorStandEffects(EffectPosition pos, Location location, SpellData data) {
+	protected Set<DelayableEntity<ArmorStand>> playSpellArmorStandEffects(EffectPosition pos, Location location, SpellData data) {
 		if (effects == null) return null;
 		List<SpellEffect> effectsList = effects.get(pos);
 		if (effectsList == null) return null;
-		Set<ArmorStand> armorStands = new HashSet<>();
+		Set<DelayableEntity<ArmorStand>> armorStands = new HashSet<>();
 		for (SpellEffect effect : effectsList) {
 			if (!(effect instanceof ArmorStandEffect)) continue;
-			ArmorStand stand = effect.playArmorStandEffect(location, data);
+			DelayableEntity<ArmorStand> stand = effect.playArmorStandEffect(location, data);
 			if (stand == null) continue;
 			armorStands.add(stand);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
@@ -41,10 +41,8 @@ public class MagicSpellListener implements Listener {
 	}
 
 	/**
-	 * Remove entities in unloaded chunks.
-	 * @implNote If you don't need any other listener handling done aside from this one that
-	 *           {@link Entity#setPersistent(boolean)} exists. This code is only here due to
-	 *           backwards compatibility for removing old entities.
+	 * This is for backwards compatibility for removing entities in unloaded chunks.
+	 * @see Entity#setPersistent(boolean)
 	 */
 	@EventHandler
 	public void onChunkLoad(ChunkLoadEvent event) {

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
@@ -13,6 +13,8 @@ import org.bukkit.configuration.ConfigurationSection;
 
 import de.slikey.effectlib.Effect;
 
+import org.jetbrains.annotations.Nullable;
+
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.MagicSpells;
@@ -320,48 +322,42 @@ public abstract class SpellEffect {
 		return null;
 	}
 
+	@Nullable
 	@Deprecated
 	public final Entity playEntityEffect(final Location location) {
-		return playEntityEffect(location, SpellData.NULL);
+		DelayableEntity<Entity> entity = playEntityEffect(location, SpellData.NULL);
+		return entity == null ? null : entity.now();
 	}
 
-	public final Entity playEntityEffect(final Location location, SpellData data) {
+	@Nullable
+	public final DelayableEntity<Entity> playEntityEffect(final Location location, SpellData data) {
 		double chance = this.chance.get(data);
 		if (chance > 0 && chance < 1 && random.nextDouble() > chance) return null;
 
 		ModifierResult result = checkModifiers(data, location);
 		if (!result.check()) return null;
-		data = result.data();
 
-		int delay = this.delay.get(data);
-		if (delay <= 0) return playEntityEffectLocationReal(location, data);
-
-		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEntityEffectLocationReal(location, finalData), delay);
-
-		return null;
+		SpellData finalData = result.data();
+		return new DelayableEntity<>(loc -> playEntityEffectLocationReal(loc, finalData), location, delay.get(finalData));
 	}
 
+	@Nullable
 	@Deprecated
 	public final ArmorStand playArmorStandEffect(final Location location) {
-		return playArmorStandEffect(location, SpellData.NULL);
+		DelayableEntity<ArmorStand> armorStand = playArmorStandEffect(location, SpellData.NULL);
+		return armorStand == null ? null : armorStand.now();
 	}
 
-	public final ArmorStand playArmorStandEffect(final Location location, SpellData data) {
+	@Nullable
+	public final DelayableEntity<ArmorStand> playArmorStandEffect(final Location location, SpellData data) {
 		double chance = this.chance.get(data);
 		if (chance > 0 && chance < 1 && random.nextDouble() > chance) return null;
 
 		ModifierResult result = checkModifiers(data, location);
 		if (!result.check()) return null;
-		data = result.data();
 
-		int delay = this.delay.get(data);
-		if (delay <= 0) return playArmorStandEffectLocationReal(location, data);
-
-		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playArmorStandEffectLocationReal(location, finalData), delay);
-
-		return null;
+		SpellData finalData = result.data();
+		return new DelayableEntity<>(loc -> playArmorStandEffectLocationReal(loc, finalData), location, delay.get(finalData));
 	}
 
 	private Runnable playEffectLocationReal(Location location, SpellData data) {

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/EffectTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/EffectTracker.java
@@ -5,6 +5,7 @@ import org.bukkit.entity.Entity;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.spells.BuffSpell;
+import com.nisovin.magicspells.util.DelayableEntity;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 import com.nisovin.magicspells.spelleffects.effecttypes.EntityEffect;
 import com.nisovin.magicspells.spelleffects.SpellEffect.SpellEffectActiveChecker;
@@ -22,7 +23,7 @@ public class EffectTracker implements Runnable {
 
 	protected boolean isEntityEffect;
 
-	protected Entity effectEntity;
+	protected DelayableEntity<Entity> effectEntity;
 
 	public EffectTracker(Entity entity, SpellEffectActiveChecker checker, SpellEffect effect, SpellData data) {
 		this.entity = entity;

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ParticleProjectileSpell.java
@@ -387,11 +387,11 @@ public class ParticleProjectileSpell extends InstantSpell implements TargetedLoc
 		return playSpellEffectLibEffects(position, location, data);
 	}
 
-	public Map<SpellEffect, Entity> playEntityEffectsProjectile(EffectPosition position, Location location, SpellData data) {
+	public Map<SpellEffect, DelayableEntity<Entity>> playEntityEffectsProjectile(EffectPosition position, Location location, SpellData data) {
 		return playSpellEntityEffects(position, location, data);
 	}
 
-	public Set<ArmorStand> playArmorStandEffectsProjectile(EffectPosition position, Location location, SpellData data) {
+	public Set<DelayableEntity<ArmorStand>> playArmorStandEffectsProjectile(EffectPosition position, Location location, SpellData data) {
 		return playSpellArmorStandEffects(position, location, data);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -351,7 +351,7 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 		return playSpellEffectLibEffects(position, location, data);
 	}
 
-	public Map<SpellEffect, Entity> playEntityEffectsProjectile(EffectPosition position, Location location, SpellData data) {
+	public Map<SpellEffect, DelayableEntity<Entity>> playEntityEffectsProjectile(EffectPosition position, Location location, SpellData data) {
 		return playSpellEntityEffects(position, location, data);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -4,13 +4,10 @@ import java.util.*;
 
 import org.bukkit.Color;
 import org.bukkit.Location;
+import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 import org.bukkit.block.Block;
-import org.bukkit.entity.Entity;
-import org.bukkit.entity.Projectile;
-import org.bukkit.entity.WitherSkull;
 import org.bukkit.event.EventHandler;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
@@ -353,6 +350,10 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 
 	public Map<SpellEffect, DelayableEntity<Entity>> playEntityEffectsProjectile(EffectPosition position, Location location, SpellData data) {
 		return playSpellEntityEffects(position, location, data);
+	}
+
+	public Set<DelayableEntity<ArmorStand>> playArmorStandEffectsProjectile(EffectPosition position, Location location, SpellData data) {
+		return playSpellArmorStandEffects(position, location, data);
 	}
 
 	public static Set<ProjectileTracker> getProjectileTrackers() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.Map;
 import java.util.Set;
 import java.util.List;
+import java.util.HashSet;
 
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -29,6 +30,8 @@ import com.nisovin.magicspells.spelleffects.util.EffectlibSpellEffect;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
 
 public class HomingMissileSpell extends TargetedSpell implements TargetedEntitySpell, TargetedEntityFromLocationSpell {
+
+	private static final Set<MissileTracker> trackers = new HashSet<>();
 
 	private NoMagicZoneManager zoneManager;
 
@@ -185,6 +188,12 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
+	@Override
+	protected void turnOff() {
+		trackers.forEach(tracker -> tracker.stop(false));
+		trackers.clear();
+	}
+
 	private class MissileTracker implements Runnable {
 
 		private Location currentLocation;
@@ -221,6 +230,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		private int counter = 0;
 
 		private MissileTracker(SpellData data) {
+			trackers.add(this);
 			startTime = System.currentTimeMillis();
 
 			currentLocation = data.location();
@@ -445,7 +455,13 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			playSpellEffects(EffectPosition.SPECIAL, loc, data);
 		}
 
-		private void stop() {
+		public void stop() {
+			stop(true);
+		}
+
+		public void stop(boolean removeTracker) {
+			if (removeTracker) trackers.remove(this);
+
 			playSpellEffects(EffectPosition.DELAYED, currentLocation, data);
 			MagicSpells.cancelTask(taskId);
 			if (effectSet != null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -192,8 +192,8 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 		private SpellData data;
 
 		private final Set<EffectlibSpellEffect> effectSet;
-		private final Map<SpellEffect, Entity> entityMap;
-		private final Set<ArmorStand> armorStandSet;
+		private final Map<SpellEffect, DelayableEntity<Entity>> entityMap;
+		private final Set<DelayableEntity<ArmorStand>> armorStandSet;
 
 		private final BoundingBox hitBox;
 		private final long startTime;
@@ -356,14 +356,14 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 				effectLoc = Util.makeFinite(effectLoc);
 
 				if (armorStandSet != null) {
-					for (ArmorStand armorStand : armorStandSet) {
-						armorStand.teleportAsync(effectLoc);
+					for (DelayableEntity<ArmorStand> armorStand : armorStandSet) {
+						armorStand.teleport(effectLoc);
 					}
 				}
 
 				if (entityMap != null) {
 					for (var entry : entityMap.entrySet()) {
-						entry.getValue().teleportAsync(entry.getKey().applyOffsets(effectLoc.clone(), data));
+						entry.getValue().teleport(entry.getKey().applyOffsets(effectLoc.clone(), data));
 					}
 				}
 			}
@@ -455,15 +455,11 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 				effectSet.clear();
 			}
 			if (armorStandSet != null) {
-				for (ArmorStand armorStand : armorStandSet) {
-					armorStand.remove();
-				}
+				armorStandSet.forEach(DelayableEntity::remove);
 				armorStandSet.clear();
 			}
 			if (entityMap != null) {
-				for (Entity entity : entityMap.values()) {
-					entity.remove();
-				}
+				entityMap.values().forEach(DelayableEntity::remove);
 				entityMap.clear();
 			}
 			currentLocation = null;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/OrbitSpell.java
@@ -16,8 +16,6 @@ import org.bukkit.util.BoundingBox;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.entity.LivingEntity;
 
-import io.papermc.paper.entity.TeleportFlag;
-
 import de.slikey.effectlib.Effect;
 import de.slikey.effectlib.effect.ModifiedEffect;
 
@@ -219,9 +217,9 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 		private final Vector perpendicular;
 
 		private final Object2IntMap<UUID> immune;
-		private final Set<ArmorStand> armorStandSet;
+		private final Set<DelayableEntity<ArmorStand>> armorStandSet;
 		private final Predicate<Location> transparent;
-		private final Map<SpellEffect, Entity> entityMap;
+		private final Map<SpellEffect, DelayableEntity<Entity>> entityMap;
 		private final Set<EffectlibSpellEffect> effectSet;
 
 		private final boolean followYaw;
@@ -370,14 +368,14 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			}
 
 			if (armorStandSet != null) {
-				for (ArmorStand armorStand : armorStandSet) {
-					armorStand.teleport(currentLocation, TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
+				for (DelayableEntity<ArmorStand> armorStand : armorStandSet) {
+					armorStand.teleport(currentLocation);
 				}
 			}
 
 			if (entityMap != null) {
 				for (var entry : entityMap.entrySet()) {
-					entry.getValue().teleport(entry.getKey().applyOffsets(currentLocation.clone(), data), TeleportFlag.EntityState.RETAIN_PASSENGERS, TeleportFlag.EntityState.RETAIN_VEHICLE);
+					entry.getValue().teleport(entry.getKey().applyOffsets(currentLocation.clone(), data));
 				}
 			}
 
@@ -516,15 +514,13 @@ public class OrbitSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			}
 
 			if (armorStandSet != null) {
-				for (ArmorStand armorStand : armorStandSet) {
-					armorStand.remove();
-				}
+				armorStandSet.forEach(DelayableEntity::remove);
+				armorStandSet.clear();
 			}
 
 			if (entityMap != null) {
-				for (Entity entity : entityMap.values()) {
-					entity.remove();
-				}
+				entityMap.values().forEach(DelayableEntity::remove);
+				entityMap.clear();
 			}
 
 			if (removeTracker) trackerSet.remove(this);

--- a/core/src/main/java/com/nisovin/magicspells/util/DelayableEntity.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/DelayableEntity.java
@@ -1,0 +1,125 @@
+package com.nisovin.magicspells.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.ApiStatus;
+
+import io.papermc.paper.entity.TeleportFlag;
+
+import java.util.function.Function;
+import java.util.function.Consumer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.CancellationException;
+
+import com.nisovin.magicspells.MagicSpells;
+
+import org.bukkit.Location;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+/**
+ * A wrapper class which holds an {@link Entity} which may be immediately available, or delayed.
+ */
+public class DelayableEntity<E extends Entity> {
+
+	private final CompletableFuture<E> future = new CompletableFuture<>();
+
+	private Location spawnLocation;
+
+	/**
+	 * Gets the {@link Entity}, if available.
+	 * @return {@link Entity} or {@code null}
+	 */
+	@Nullable
+	@Deprecated
+	@ApiStatus.Internal
+	public E now() {
+		try {
+			return future.getNow(null);
+		} catch (CancellationException | CompletionException e) {
+			return null;
+		}
+	}
+
+	/**
+	 * Operation to run if the {@link Entity} is available.
+	 * @param consumer Consumer to run
+	 * @see DelayableEntity#accept(Consumer)
+	 * @see DelayableEntity#teleport(Location)
+	 */
+	@Deprecated
+	@ApiStatus.Internal
+	public void ifPresent(@NotNull Consumer<E> consumer) {
+		E entity = now();
+		if (entity == null) return;
+		consumer.accept(entity);
+	}
+
+	/**
+	 * Operation to run when the {@link Entity} becomes available.
+	 * @param consumer Consumer to run
+	 * @see DelayableEntity#ifPresent(Consumer)
+	 * @see DelayableEntity#teleport(Location)
+	 */
+	public void accept(@NotNull Consumer<E> consumer) {
+		future.thenAccept(consumer);
+	}
+
+	/**
+	 * Teleport the {@link Entity}, if available, otherwise store its start location.
+	 * @param location {@link Location} to teleport to.
+	 * @see DelayableEntity#ifPresent(Consumer)
+	 * @see DelayableEntity#accept(Consumer)
+	 */
+	public void teleport(@NotNull Location location) {
+		E entity = now();
+		if (entity == null) spawnLocation = location;
+		else entity.teleportAsync(
+				location,
+				PlayerTeleportEvent.TeleportCause.PLUGIN,
+				TeleportFlag.EntityState.RETAIN_PASSENGERS,
+				TeleportFlag.EntityState.RETAIN_VEHICLE
+		);
+	}
+
+	/**
+	 * Remove the {@link Entity} or cancel its delayed spawning.
+	 */
+	public void remove() {
+		ifPresent(Entity::remove);
+		future.cancel(true);
+	}
+
+	/**
+	 * Defer an {@link Entity}'s spawn with the provided delay. If {@link DelayableEntity#teleport(Location)}
+	 * is called before the entity is present, its teleport location is overridden. If the {@code delay} is {@code <= 0},
+	 * the underlying {@link CompletableFuture} is completed instantly.
+	 * @param function Function which spawns the {@link Entity} after the {@code delay}.
+	 * @param location Initial {@link Location} to spawn the entity at.
+	 * @param delay Delay in server ticks.
+	 */
+	public DelayableEntity(@NotNull Function<Location, E> function, @NotNull Location location, long delay) {
+		spawnLocation = location;
+
+		Runnable spawnEntity = () -> {
+			try {
+				future.complete(function.apply(spawnLocation));
+			} catch (Exception e) {
+				future.completeExceptionally(e);
+			}
+		};
+
+		int taskId = -1;
+		if (delay <= 0) spawnEntity.run();
+		else taskId = MagicSpells.scheduleDelayedTask(spawnEntity, delay);
+
+		int id = taskId;
+		future.whenComplete((result, throwable) -> {
+			if (future.isCancelled() && id != -1) MagicSpells.cancelTask(id);
+			if (throwable == null) return;
+			MagicSpells.handleException(new Exception("Delayed entity failed to spawn", throwable));
+		});
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -15,13 +15,10 @@ import net.kyori.adventure.text.Component;
 import de.slikey.effectlib.Effect;
 import de.slikey.effectlib.effect.ModifiedEffect;
 
+import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
-import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.projectile.*;
-import com.nisovin.magicspells.util.ModifierResult;
-import com.nisovin.magicspells.util.ValidTargetList;
 import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.events.TrackerMoveEvent;
@@ -37,7 +34,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 	private final Random rand = ThreadLocalRandom.current();
 
 	private Set<EffectlibSpellEffect> effectSet;
-	private Map<SpellEffect, Entity> entityMap;
+	private Map<SpellEffect, DelayableEntity<Entity>> entityMap;
 
 	private ProjectileSpell spell;
 
@@ -230,7 +227,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 			effectLoc.add(0, effectOffset.getY(), 0);
 
 			for (var entry : entityMap.entrySet()) {
-				entry.getValue().teleportAsync(entry.getKey().applyOffsets(effectLoc.clone(), data));
+				entry.getValue().teleport(entry.getKey().applyOffsets(effectLoc.clone(), data));
 			}
 		}
 
@@ -318,9 +315,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 			effectSet.clear();
 		}
 		if (entityMap != null) {
-			for (Entity entity : entityMap.values()) {
-				entity.remove();
-			}
+			entityMap.values().forEach(DelayableEntity::remove);
 			entityMap.clear();
 		}
 		currentLocation = null;


### PR DESCRIPTION
- Fixed an issue where playing the `entity` and `armorstand` effect with `delay` did not pass the spawned entities to spells which would remove them on reload or drag them along their path, such as orbits, projectiles, etc.
- Fixed an issue where the `HomingMissileSpell` was not cleaned up on plugin reload.
- Added support for the `armorstand` effect on the `ProjectileSpell`.