### PR TITLE
Add options for trail particle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,20 +1,16 @@
 plugins {
-  id("dev.magicspells.msjava")
-}
-
-wrapper {
-  gradleVersion = "8.11.1"
-  setDistributionType(Wrapper.DistributionType.ALL)
+    id("dev.magicspells.msjava")
 }
 
 subprojects {
-  apply plugin: "dev.magicspells.msjava"
+    apply plugin: "dev.magicspells.msjava"
 
-  dependencies {
-    implementation(group: "io.papermc.paper", name: "paper-api", version: "1.21.4-R0.1-SNAPSHOT")
-  }
+    dependencies {
+        implementation(group: "io.papermc.paper", name: "paper-api", version: "1.21.4-R0.1-SNAPSHOT")
+    }
 
-  processResources {
-    expand(["version": version])
-  }
+    processResources {
+        expand(["version": version])
+    }
+
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ subprojects {
   apply plugin: "dev.magicspells.msjava"
 
   dependencies {
-    implementation(group: "io.papermc.paper", name: "paper-api", version: "1.21.3-R0.1-SNAPSHOT")
+    implementation(group: "io.papermc.paper", name: "paper-api", version: "1.21.4-R0.1-SNAPSHOT")
   }
 
   processResources {

--- a/buildSrc/src/main/java/dev/magicspells/gradle/MSPaperweight.java
+++ b/buildSrc/src/main/java/dev/magicspells/gradle/MSPaperweight.java
@@ -7,6 +7,6 @@ public class MSPaperweight implements Plugin<Project> {
     // TODO figure out how to apply the plugin
     @Override
     public void apply(Project project) {
-        project.getDependencies().add("paperweightDevelopmentBundle", "io.papermc.paper:dev-bundle:1.21.3-R0.1-SNAPSHOT").because("We need a server implementation rather than just an api here.");
+        project.getDependencies().add("paperweightDevelopmentBundle", "io.papermc.paper:dev-bundle:1.21.4-R0.1-SNAPSHOT").because("We need a server implementation rather than just an api here.");
     }
 }

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
@@ -199,6 +199,10 @@ public abstract class SpellEffect {
 		return applyOffsets(loc, offset.get(data), relativeOffset.get(data), zOffset.get(data), heightOffset.get(data), forwardOffset.get(data), yaw.get(data), pitch.get(data));
 	}
 
+	public Location applyOffsets(Location loc, Vector offset, Vector relativeOffset) {
+		return applyOffsets(loc, offset, relativeOffset, 0, 0, 0, Angle.DEFAULT, Angle.DEFAULT);
+	}
+
 	public Location applyOffsets(Location loc, Vector offset, Vector relativeOffset, double zOffset, double heightOffset, double forwardOffset, Angle yaw, Angle pitch) {
 		loc.add(offset);
 		loc.add(0, heightOffset, 0);

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
@@ -44,7 +44,7 @@ public class ParticleCloudEffect extends ParticlesEffect {
 		cloud.setDuration(duration.get(data));
 		cloud.setRadiusPerTick(radiusPerTick.get(data));
 
-		cloud.setParticle(particle, getParticleData(particle, location, data));
+		cloud.setParticle(particle, getParticleData(particle, null, location, data));
 
 		return null;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesPersonalEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesPersonalEffect.java
@@ -30,14 +30,17 @@ public class ParticlesPersonalEffect extends ParticlesEffect {
 		if (player == null) return null;
 
 		Location location = applyOffsets(entity.getLocation(), data);
-
 		Particle particle = this.particle.get(data);
+
+		Location spawnLocation = getSpawnLocation(particle, location, data);
+		if (spawnLocation == null) return null;
+
 		particle.builder()
 				.location(location)
 				.count(count.get(data))
 				.offset(xSpread.get(data), ySpread.get(data), zSpread.get(data))
 				.extra(speed.get(data))
-				.data(getParticleData(particle, location, data))
+				.data(getParticleData(particle, entity, location, data))
 				.force(force.get(data))
 				.receivers(player)
 				.spawn();
@@ -51,12 +54,16 @@ public class ParticlesPersonalEffect extends ParticlesEffect {
 		if (player == null) return null;
 
 		Particle particle = this.particle.get(data);
+
+		Location spawnLocation = getSpawnLocation(particle, location, data);
+		if (spawnLocation == null) return null;
+
 		particle.builder()
 				.location(location)
 				.count(count.get(data))
 				.offset(xSpread.get(data), ySpread.get(data), zSpread.get(data))
 				.extra(speed.get(data))
-				.data(getParticleData(particle, location, data))
+				.data(getParticleData(particle, null, location, data))
 				.force(force.get(data))
 				.receivers(player)
 				.spawn();

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -3,7 +3,7 @@ main: com.nisovin.magicspells.MagicSpells
 version: $version
 authors: [nisovin, TheComputerGeek2, Chronoken, tonythemacaroni, JasperLorelai]
 website: "https://github.com/TheComputerGeek2/MagicSpells/"
-api-version: "1.21.3"
+api-version: "1.21.4"
 softdepend:
     - GriefPrevention
     - Vault

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/nms/latest/build.gradle
+++ b/nms/latest/build.gradle
@@ -1,8 +1,8 @@
 plugins {
-    id "io.papermc.paperweight.userdev" version "1.7.4"
+    id "io.papermc.paperweight.userdev" version "2.0.0-beta.13"
 }
 
 dependencies {
-    paperweightDevelopmentBundle("io.papermc.paper:dev-bundle:1.21.3-R0.1-SNAPSHOT")
+    paperweight.paperDevBundle("1.21.4-R0.1-SNAPSHOT")
     implementation project(":nms:shared")
 }


### PR DESCRIPTION
- Added the `trail` section to the `particles` spell effect, for use with `particle-name: trail`.

    ```yml
    test:
        spell-class: ".targeted.AreaEffectSpell"
        horizontal-radius: 16
        vertical-radius: 8
        spells:
            - test/trail
    
    test/trail:
        spell-class: ".targeted.LoopSpell"
        duration: 200
        interval: 2
        effects:
            0:
                position: caster
                effect: particles
                particle-name: trail
                count: 2
                height-offset: 0.5
                trail:
                    origin: caster # Particle position. Specifies where the particles start. Defaults to 'POSITION'.
                    target: target # Particle position. Specifies where the particles travel to. Required.
                    color: # RGB color. Specifies the color of the trail particles. Required.
                        red: "rand(100, 255)"
                        green: "rand(100, 255)"
                        blue: "rand(100, 255)"
                    duration: 20 # Integer. Specifies how long the trail particles take to travel. Required.
                    target-offset: ["rand(-0.5, 0.5)", "1 + rand(-0.5, 0.5)", " rand(-0.5, 0.5)"] # Vector. Absolute offset applied to target location.
                    target-relative-offset: [0, 0, 0] # Vector. Relative offset applied to target location.
    ```

- Fixed an issue with the `vibration-origin` option that prevented it from functioning.