### PR TITLE
Deprecate "hasitem" modifier condition

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/HasItemCondition.java
@@ -19,12 +19,20 @@ import net.kyori.adventure.text.Component;
 
 import com.nisovin.magicspells.util.Name;
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.InventoryUtil;
 import com.nisovin.magicspells.handlers.DebugHandler;
+import com.nisovin.magicspells.util.DeprecationNotice;
 import com.nisovin.magicspells.castmodifiers.Condition;
 
 @Name("hasitem")
 public class HasItemCondition extends Condition {
+
+	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
+			"The 'hasitem' modifier condition does not function properly.",
+			"Use the 'hasitemprecise' condition.",
+			"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#modifier-condition-hasitem"
+	);
 
 	private Material material;
 	private short durability;
@@ -33,6 +41,8 @@ public class HasItemCondition extends Condition {
 
 	@Override
 	public boolean initialize(@NotNull String var) {
+		MagicSpells.getDeprecationManager().addDeprecation(DEPRECATION_NOTICE);
+
 		try {
 			if (var.contains("|")) {
 				String[] subVarData = var.split("\\|");

--- a/core/src/main/java/com/nisovin/magicspells/handlers/DeprecationHandler.java
+++ b/core/src/main/java/com/nisovin/magicspells/handlers/DeprecationHandler.java
@@ -1,20 +1,26 @@
 package com.nisovin.magicspells.handlers;
 
-import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
-import com.nisovin.magicspells.MagicSpells;
+import org.jetbrains.annotations.NotNull;
+
 import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.DeprecationNotice;
 
-import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
-import org.jetbrains.annotations.NotNull;
+import com.google.common.collect.HashMultimap;
 
 public class DeprecationHandler {
 
 	private final Multimap<DeprecationNotice, Spell> deprecations = HashMultimap.create();
+
+	public void addDeprecation(@NotNull DeprecationNotice deprecationNotice) {
+		deprecations.put(deprecationNotice, null);
+	}
 
 	public void addDeprecation(@NotNull Spell spell, @NotNull DeprecationNotice deprecationNotice) {
 		deprecations.put(deprecationNotice, spell);
@@ -34,11 +40,12 @@ public class DeprecationHandler {
 			Collection<Spell> spells = entry.getValue();
 
 			MagicSpells.error("    " + notice.reason());
-			MagicSpells.error("        Relevant spells: " + spells.stream()
+			String relevantSpells = spells.stream()
+				.filter(Objects::nonNull)
 				.map(Spell::getInternalName)
 				.sorted()
-				.collect(Collectors.joining(", ", "[", "]"))
-			);
+				.collect(Collectors.joining(", "));
+			if (!relevantSpells.isEmpty()) MagicSpells.error("        Relevant spells: [" + relevantSpells + "]");
 			MagicSpells.error("        Steps to take: " + notice.replacement());
 			if (notice.context() != null) MagicSpells.error("        Context: " + notice.context());
 		}


### PR DESCRIPTION
It has been discussed internally that we would deprecate `hasitem` in favour of `hasitemprecise` for a while due to its old format being inconsistent across the plugin. Upon reviewing #369 I realised a multitude of bugs with `hasitem` that would not be worth fixing only to deprecate it later.

The modifier condition is supposed to check all slots, have item name and durability optional, and work with any entity or storage block. Instead, it requires the item name to be specified before it can check duration but incorrectly checks both. If only the material is specified, for players, it doesn't check extra slots like armor or offhand. For entities that don't have inventories, it only checks their hand item material.

Closes #369