### PR TITLE
Folia support (wip)

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -105,6 +105,8 @@ public class MagicSpells extends JavaPlugin {
 	// Pass this to methods that want spell arguments passed but doesn't have any to be passed
 	public static final String[] NULL_ARGS = null;
 
+	public static final boolean IS_FOLIA = isFolia();
+
 	private Set<Material> losTransparentBlocks;
 	private List<Material> ignoreCastItemDurability;
 	private Map<EntityType, String> entityNames;
@@ -2331,4 +2333,12 @@ public class MagicSpells extends JavaPlugin {
 		return config;
 	}
 
+	private static boolean isFolia() {
+		try {
+			Class.forName("io.papermc.paper.threadedregions.RegionizedServer");
+			return true;
+		} catch (ClassNotFoundException e) {
+			return false;
+		}
+	}
 }

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -24,6 +24,7 @@ import com.google.common.collect.LinkedHashMultimap;
 
 import de.slikey.effectlib.EffectManager;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.bstats.charts.AdvancedPie;
@@ -652,7 +653,7 @@ public class MagicSpells extends JavaPlugin {
 		CompatBasics.setupExemptionAssistant();
 
 		// Load external data
-		Bukkit.getScheduler().runTaskLater(this, this::loadExternalData, 1);
+		Bukkit.getGlobalRegionScheduler().runDelayed(this, t -> loadExternalData(), 1);
 	}
 
 	private void initializeSpells() {
@@ -1925,8 +1926,8 @@ public class MagicSpells extends JavaPlugin {
 		return m.getAnnotation(clazz) != null;
 	}
 
-	public static int scheduleDelayedTask(final Runnable task, long delay) {
-		return Bukkit.getScheduler().scheduleSyncDelayedTask(plugin, !plugin.enableErrorLogging ? task : () -> {
+	public static ScheduledTask scheduleDelayedTask(final Runnable task, long delay, Location ctx) {
+		return Bukkit.getRegionScheduler().runDelayed(plugin, ctx, !plugin.enableErrorLogging ? t -> task.run() : t -> {
 			try {
 				task.run();
 			} catch (Exception e) {
@@ -1935,8 +1936,22 @@ public class MagicSpells extends JavaPlugin {
 		}, delay);
 	}
 
-	public static int scheduleRepeatingTask(final Runnable task, long delay, long interval) {
-		return Bukkit.getScheduler().scheduleSyncRepeatingTask(plugin, !plugin.enableErrorLogging ? task : () -> {
+	public static ScheduledTask scheduleDelayedTask(final Runnable task, long delay) {
+		return Bukkit.getGlobalRegionScheduler().runDelayed(plugin, !plugin.enableErrorLogging ? t -> task.run() : t -> {
+			try {
+				task.run();
+			} catch (Exception e) {
+				handleException(e);
+			}
+		}, delay);
+	}
+
+	public static ScheduledTask scheduleDelayedTask(final Runnable task, long delay, Entity ent) {
+		return scheduleDelayedTask(task, delay, ent.getLocation());
+	}
+
+	public static ScheduledTask scheduleRepeatingTask(final Runnable task, long delay, long interval, Location ctx) {
+		return Bukkit.getRegionScheduler().runAtFixedRate(plugin, ctx, !plugin.enableErrorLogging ? t -> task.run() : t -> {
 			try {
 				task.run();
 			} catch (Exception e) {
@@ -1945,8 +1960,28 @@ public class MagicSpells extends JavaPlugin {
 		}, delay, interval);
 	}
 
-	public static void cancelTask(int taskId) {
-		Bukkit.getScheduler().cancelTask(taskId);
+	public static ScheduledTask scheduleRepeatingTask(final Runnable task, long delay, long interval) {
+		return Bukkit.getGlobalRegionScheduler().runAtFixedRate(plugin, !plugin.enableErrorLogging ? t -> task.run() : t -> {
+			try {
+				task.run();
+			} catch (Exception e) {
+				handleException(e);
+			}
+		}, delay, interval);
+	}
+
+	public static ScheduledTask scheduleRepeatingTask(final Runnable task, long delay, long interval, Entity ent) {
+		return ent.getScheduler().runAtFixedRate(plugin, !plugin.enableErrorLogging ? t -> task.run() : t -> {
+			try {
+				task.run();
+			} catch (Exception e) {
+				handleException(e);
+			}
+		}, null, delay, interval);
+	}
+
+	public static void cancelTask(ScheduledTask task) {
+		task.cancel();
 	}
 
 	public static void handleException(@NotNull Exception ex) {

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -344,7 +344,7 @@ public class Subspell {
 		if (delay < 0) return castReal(data.noTargeting());
 
 		SpellData finalData = data.noTargeting();
-		MagicSpells.scheduleDelayedTask(() -> castReal(finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> castReal(finalData), delay, data.location());
 
 		return new SpellCastResult(SpellCastState.NORMAL, PostCastAction.DELAYED, data);
 	}
@@ -395,7 +395,7 @@ public class Subspell {
 		if (delay < 0) return castAtEntityReal(data.noLocation());
 
 		SpellData finalData = data.noLocation();
-		MagicSpells.scheduleDelayedTask(() -> castAtEntityReal(finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> castAtEntityReal(finalData), delay, data.target());
 
 		return new SpellCastResult(SpellCastState.NORMAL, PostCastAction.DELAYED, data);
 	}
@@ -467,7 +467,7 @@ public class Subspell {
 		if (delay < 0) return castAtLocationReal(data.noTarget());
 
 		SpellData finalData = data.noTarget();
-		MagicSpells.scheduleDelayedTask(() -> castAtLocationReal(finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> castAtLocationReal(finalData), delay, data.location());
 
 		return new SpellCastResult(SpellCastState.NORMAL, PostCastAction.DELAYED, data);
 	}
@@ -549,7 +549,7 @@ public class Subspell {
 		if (delay < 0) return castAtEntityFromLocationReal(data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> castAtEntityFromLocationReal(finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> castAtEntityFromLocationReal(finalData), delay, data.target());
 
 		return new SpellCastResult(SpellCastState.NORMAL, PostCastAction.DELAYED, data);
 	}

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommand.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.regex.Pattern;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.jetbrains.annotations.NotNull;
 
 import org.bukkit.*;
@@ -15,7 +16,6 @@ import org.bukkit.entity.Player;
 import org.bukkit.util.RayTraceResult;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.scheduler.BukkitTask;
 import org.bukkit.command.CommandSender;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.command.ConsoleCommandSender;
@@ -271,12 +271,12 @@ public class MagicCommand extends BaseCommand {
 		if (!MagicSpells.isLoaded()) return;
 		if (noPermission(issuer.getIssuer(), Perm.COMMAND_TASKINFO)) return;
 
-		List<BukkitTask> msTasks = new ArrayList<>();
-		for (BukkitTask task : Bukkit.getScheduler().getPendingTasks()) {
-			if (task == null) continue;
-			if (!task.getOwner().equals(MagicSpells.getInstance())) continue;
-			msTasks.add(task);
-		}
+		List<ScheduledTask> msTasks = new ArrayList<>();
+//		for (ScheduledTask task : /* api ? */ ) {
+//			if (task == null) continue;
+//			if (!task.getOwningPlugin().equals(MagicSpells.getInstance())) continue;
+//			msTasks.add(task);
+//		}
 
 		issuer.sendMessage(MagicSpells.getTextColor() + "EffectLib effect instances - " + MagicSpells.getEffectManager().getEffects().size());
 		issuer.sendMessage(MagicSpells.getTextColor() + "MagicSpells tasks - " + msTasks.size());

--- a/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/DanceCastListener.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.regex.Pattern;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
@@ -35,7 +36,7 @@ public class DanceCastListener implements Listener {
 	private Map<String, Spell> spells = new HashMap<>();
 
 	private Map<String, String> playerCasts = new HashMap<>();
-	private Map<String, Integer> playerTasks = new HashMap<>();
+	private Map<String, ScheduledTask> playerTasks = new HashMap<>();
 	private Map<String, Location> playerLocations = new HashMap<>();
 
 	private boolean dynamicCasting = false;
@@ -104,8 +105,8 @@ public class DanceCastListener implements Listener {
 				player.setAllowFlight(false);
 			}
 			playerLocations.remove(playerName);
-			Integer taskId = playerTasks.remove(playerName);
-			if (taskId != null) MagicSpells.cancelTask(taskId);
+			ScheduledTask task = playerTasks.remove(playerName);
+			if (task != null) MagicSpells.cancelTask(task);
 			playerCasts.remove(playerName);
 		}
 		return casted;

--- a/core/src/main/java/com/nisovin/magicspells/mana/ManaSystem.java
+++ b/core/src/main/java/com/nisovin/magicspells/mana/ManaSystem.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.mana;
 
 import java.util.*;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 
@@ -288,7 +289,7 @@ public class ManaSystem extends ManaHandler {
 		manaBars.clear();
 
 		for (Regenerator regenerator : regenerators) {
-			MagicSpells.cancelTask(regenerator.taskId);
+			MagicSpells.cancelTask(regenerator.task);
 		}
 		regenerators.clear();
 	}
@@ -297,11 +298,11 @@ public class ManaSystem extends ManaHandler {
 
 		private final ManaRank rank;
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private Regenerator(ManaRank rank, int regenInterval) {
 			this.rank = rank;
-			taskId = MagicSpells.scheduleRepeatingTask(this, regenInterval, regenInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, regenInterval, regenInterval);
 		}
 
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/SpellEffect.java
@@ -257,7 +257,7 @@ public abstract class SpellEffect {
 		if (delay <= 0) return playEffectEntity(entity, data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEffectEntity(entity, finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> playEffectEntity(entity, finalData), delay, entity);
 
 		return null;
 	}
@@ -299,7 +299,7 @@ public abstract class SpellEffect {
 		if (delay <= 0) return playEffectLocationReal(location, data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEffectLocationReal(location, finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> playEffectLocationReal(location, finalData), delay, location);
 
 		return null;
 	}
@@ -321,7 +321,7 @@ public abstract class SpellEffect {
 		if (delay <= 0) return playEffectLibLocationReal(location, data);
 
 		SpellData finalData = data;
-		MagicSpells.scheduleDelayedTask(() -> playEffectLibLocationReal(location, finalData), delay);
+		MagicSpells.scheduleDelayedTask(() -> playEffectLibLocationReal(location, finalData), delay, location);
 
 		return null;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeSwirlEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeSwirlEffect.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spelleffects.effecttypes;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Effect;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
@@ -48,7 +49,7 @@ public class SmokeSwirlEffect extends SpellEffect {
 		private int iteration;
 		private final int interval;
 		private final int animatorDuration;
-		private final int animatorTaskId;
+		private final ScheduledTask animatorTask;
 
 		Animator(Location location, int interval, int duration) {
 			this(interval, duration);
@@ -64,13 +65,13 @@ public class SmokeSwirlEffect extends SpellEffect {
 			this.interval = interval;
 			this.animatorDuration = duration;
 			this.iteration = 0;
-			this.animatorTaskId = MagicSpells.scheduleRepeatingTask(this, 0, interval);
+			this.animatorTask = MagicSpells.scheduleRepeatingTask(this, 0, interval);
 		}
 
 		@Override
 		public void run() {
 			if (iteration * interval > animatorDuration) {
-				MagicSpells.cancelTask(animatorTaskId);
+				MagicSpells.cancelTask(animatorTask);
 				return;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeTrailEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/SmokeTrailEffect.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spelleffects.effecttypes;
 import java.util.List;
 import java.util.ArrayList;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.World;
 import org.bukkit.Effect;
 import org.bukkit.Location;
@@ -45,7 +46,7 @@ public class SmokeTrailEffect extends SpellEffect {
 		private final World world;
 
 		private int i;
-		private int id;
+		private ScheduledTask task;
 
 		SmokeStreamEffect(Location loc1, Location loc2) {
 			this.startLoc = loc1;
@@ -56,7 +57,7 @@ public class SmokeTrailEffect extends SpellEffect {
 		}
 
 		public void start(int interval) {
-			this.id = MagicSpells.scheduleRepeatingTask(this, interval, interval);
+			this.task = MagicSpells.scheduleRepeatingTask(this, interval, interval);
 		}
 
 		void showNoAnimation() {
@@ -68,7 +69,7 @@ public class SmokeTrailEffect extends SpellEffect {
 		@Override
 		public void run() {
 			if (i > locationsForProjection.size() - 1) {
-				MagicSpells.cancelTask(id);
+				MagicSpells.cancelTask(task);
 				return;
 			}
 			Location loc = locationsForProjection.get(i);

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/AsyncEffectTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/AsyncEffectTracker.java
@@ -1,14 +1,16 @@
 package com.nisovin.magicspells.spelleffects.trackers;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
-import org.bukkit.scheduler.BukkitTask;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.spells.BuffSpell;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 import com.nisovin.magicspells.spelleffects.SpellEffect.SpellEffectActiveChecker;
+
+import java.util.concurrent.TimeUnit;
 
 public class AsyncEffectTracker implements Runnable {
 
@@ -19,7 +21,7 @@ public class AsyncEffectTracker implements Runnable {
 
 	protected SpellData data;
 
-	protected BukkitTask effectTask;
+	protected ScheduledTask effectTask;
 
 	public AsyncEffectTracker(Entity entity, SpellEffectActiveChecker checker, SpellEffect effect, SpellData data) {
 		this.entity = entity;
@@ -28,7 +30,7 @@ public class AsyncEffectTracker implements Runnable {
 		this.data = data;
 
 		int interval = effect.getEffectInterval().get(data);
-		effectTask = Bukkit.getScheduler().runTaskTimerAsynchronously(MagicSpells.getInstance(), this, 0, interval);
+		effectTask = Bukkit.getAsyncScheduler().runAtFixedRate(MagicSpells.getInstance(), t -> run(), 0, interval * 50L, TimeUnit.MILLISECONDS);
 	}
 
 	public Entity getEntity() {
@@ -47,7 +49,7 @@ public class AsyncEffectTracker implements Runnable {
 		return checker;
 	}
 
-	public BukkitTask getEffectTrackerTask() {
+	public ScheduledTask getEffectTrackerTask() {
 		return effectTask;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/EffectTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/EffectTracker.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spelleffects.trackers;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.entity.Entity;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -19,7 +20,7 @@ public class EffectTracker implements Runnable {
 
 	protected SpellData data;
 
-	protected int effectTrackerTaskId;
+	protected ScheduledTask effectTrackerTask;
 
 	protected boolean isEntityEffect;
 
@@ -34,7 +35,7 @@ public class EffectTracker implements Runnable {
 		isEntityEffect = effect instanceof EntityEffect;
 
 		int interval = effect.getEffectInterval().get(data);
-		effectTrackerTaskId = MagicSpells.scheduleRepeatingTask(this, 0, interval);
+		effectTrackerTask = MagicSpells.scheduleRepeatingTask(this, 0, interval, entity);
 	}
 
 	public Entity getEntity() {
@@ -53,8 +54,8 @@ public class EffectTracker implements Runnable {
 		return checker;
 	}
 
-	public int getEffectTrackerTaskId() {
-		return effectTrackerTaskId;
+	public ScheduledTask getEffectTrackerTask() {
+		return effectTrackerTask;
 	}
 
 	public SpellData getData() {
@@ -71,7 +72,7 @@ public class EffectTracker implements Runnable {
 	}
 
 	public void stop() {
-		MagicSpells.cancelTask(effectTrackerTaskId);
+		MagicSpells.cancelTask(effectTrackerTask);
 		entity = null;
 		if (effectEntity != null) effectEntity.remove();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitEffectlibTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitEffectlibTracker.java
@@ -1,10 +1,10 @@
 package com.nisovin.magicspells.spelleffects.trackers;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
-import org.bukkit.scheduler.BukkitTask;
 
 import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
@@ -16,12 +16,14 @@ import de.slikey.effectlib.Effect;
 import de.slikey.effectlib.util.VectorUtils;
 import de.slikey.effectlib.effect.ModifiedEffect;
 
+import java.util.concurrent.TimeUnit;
+
 public class OrbitEffectlibTracker extends AsyncEffectTracker implements Runnable {
 
 	private Vector currentPosition;
 
-	private BukkitTask repeatingHorizTask;
-	private BukkitTask repeatingVertTask;
+	private ScheduledTask repeatingHorizTask;
+	private ScheduledTask repeatingVertTask;
 
 	private float orbRadius;
 	private float orbHeight;
@@ -62,14 +64,14 @@ public class OrbitEffectlibTracker extends AsyncEffectTracker implements Runnabl
 		float horizRadius = effect.getHorizExpandRadius().get(data);
 		int horizDelay = effect.getHorizExpandDelay().get(data);
 		if (horizDelay > 0 && horizRadius != 0)
-			repeatingHorizTask = Bukkit.getScheduler().runTaskTimerAsynchronously(MagicSpells.getInstance(),
-				() -> orbRadius += horizRadius, horizDelay, horizDelay);
+			repeatingHorizTask = Bukkit.getAsyncScheduler().runAtFixedRate(MagicSpells.getInstance(),
+				t -> orbRadius += horizRadius, horizDelay * 50L, horizDelay * 50L, TimeUnit.MILLISECONDS);
 
 		float vertRadius = effect.getVertExpandRadius().get(data);
 		int vertDelay = effect.getVertExpandDelay().get(data);
 		if (vertDelay > 0 && vertRadius != 0)
-			repeatingVertTask = Bukkit.getScheduler().runTaskTimerAsynchronously(MagicSpells.getInstance(),
-				() -> orbHeight += vertRadius, vertDelay, vertDelay);
+			repeatingVertTask = Bukkit.getAsyncScheduler().runAtFixedRate(MagicSpells.getInstance(),
+				t -> orbHeight += vertRadius, vertDelay * 50L, vertDelay * 50L, TimeUnit.MILLISECONDS);
 
 		effectlibEffect = effect.playEffectLib(entity.getLocation(), data);
 		if (effectlibEffect != null) effectlibEffect.infinite();

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitTracker.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.spelleffects.trackers;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
@@ -18,8 +19,8 @@ public class OrbitTracker extends EffectTracker implements Runnable {
 
 	private Vector currentPosition;
 
-	private int horizontalTaskId;
-	private int verticalTaskId;
+	private ScheduledTask horizontalTask;
+	private ScheduledTask verticalTask;
 
 	private float orbRadius;
 	private float orbHeight;
@@ -56,12 +57,12 @@ public class OrbitTracker extends EffectTracker implements Runnable {
 		float horizRadius = effect.getHorizExpandRadius().get(data);
 		int horizDelay = effect.getHorizExpandDelay().get(data);
 		if (horizDelay > 0 && horizRadius != 0)
-			horizontalTaskId = MagicSpells.scheduleRepeatingTask(() -> orbRadius += horizRadius, horizDelay, horizDelay);
+			horizontalTask = MagicSpells.scheduleRepeatingTask(() -> orbRadius += horizRadius, horizDelay, horizDelay, entity);
 
 		float vertRadius = effect.getVertExpandRadius().get(data);
 		int vertDelay = effect.getVertExpandDelay().get(data);
 		if (vertDelay > 0 && vertRadius != 0)
-			verticalTaskId = MagicSpells.scheduleRepeatingTask(() -> orbHeight += vertRadius, vertDelay, vertDelay);
+			verticalTask = MagicSpells.scheduleRepeatingTask(() -> orbHeight += vertRadius, vertDelay, vertDelay, entity);
 	}
 
 	@Override
@@ -118,8 +119,8 @@ public class OrbitTracker extends EffectTracker implements Runnable {
 	@Override
 	public void stop() {
 		super.stop();
-		MagicSpells.cancelTask(horizontalTaskId);
-		MagicSpells.cancelTask(verticalTaskId);
+		MagicSpells.cancelTask(horizontalTask);
+		MagicSpells.cancelTask(verticalTask);
 		currentPosition = null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -219,7 +219,7 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 			MagicSpells.scheduleDelayedTask(() -> {
 				if (isExpired(data.target())) turnOff(data.target());
-			}, Math.round(dur * TimeUtil.TICKS_PER_SECOND) + 1); // overestimate ticks, since the duration is real-time ms based
+			}, Math.round(dur * TimeUtil.TICKS_PER_SECOND) + 1, data.target()); // overestimate ticks, since the duration is real-time ms based
 		}
 
 		playSpellEffectsBuff(data.target(), entity -> isActiveAndNotExpired((LivingEntity) entity), data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/PlayerMenuSpell.java
@@ -203,7 +203,7 @@ public class PlayerMenuSpell extends TargetedSpell implements TargetedEntitySpel
 
 	private void openDelay(Player opener, SpellData data) {
 		int delay = this.delay.get(data);
-		if (delay > 0) MagicSpells.scheduleDelayedTask(() -> open(opener, new PlayerMenuInventory(data)), delay);
+		if (delay > 0) MagicSpells.scheduleDelayedTask(() -> open(opener, new PlayerMenuInventory(data)), delay, opener);
 		else open(opener, new PlayerMenuInventory(data));
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ArmorSpell.java
@@ -242,7 +242,7 @@ public class ArmorSpell extends BuffSpell {
 			if (!isActive(player) || isExpired(player)) return;
 
 			EntityEquipment eq = player.getEquipment();
-			Bukkit.getScheduler().scheduleSyncDelayedTask(MagicSpells.plugin, () -> setArmor(eq));
+			player.getScheduler().run(MagicSpells.plugin, t -> setArmor(eq), null);
 		}
 
 		@EventHandler

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -108,14 +109,14 @@ public class FlamewalkSpell extends BuffSpell {
 
 	private class Burner implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private Burner() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval);
 		}
 
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/HasteSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -123,7 +124,7 @@ public class HasteSpell extends BuffSpell {
 					}
 					data.count++;
 					player.addPotionEffect(new PotionEffect(PotionEffectType.SPEED, data.boostDuration, data.strength + (data.count * data.accelerationIncrease), data.ambient, !data.hidden, data.icon));
-				}, data.accelerationDelay, data.accelerationInterval);
+				}, data.accelerationDelay, data.accelerationInterval, player);
 			}
 		} else {
 			player.removePotionEffect(PotionEffectType.SPEED);
@@ -163,7 +164,7 @@ public class HasteSpell extends BuffSpell {
 		private final SpellData data;
 
 		private int count;
-		private int task;
+		private ScheduledTask task;
 
 		private HasteData(SpellData data) {
 			this.data = data;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
@@ -7,6 +7,7 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -111,14 +112,14 @@ public class LifewalkSpell extends BuffSpell {
 
 	private class Grower implements Runnable {
 		
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private Grower() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval);
 		}
 		
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 		
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/LifewalkSpell.java
@@ -134,25 +134,27 @@ public class LifewalkSpell extends BuffSpell {
 					continue;
 				}
 
-				Block feet = livingEntity.getLocation().getBlock();
-				Block ground = feet.getRelative(BlockFace.DOWN);
+				entity.getScheduler().run(MagicSpells.plugin, t -> {
+					Block feet = livingEntity.getLocation().getBlock();
+					Block ground = feet.getRelative(BlockFace.DOWN);
 
-				if (!feet.getType().isAir()) continue;
-				if (ground.getType() != Material.DIRT && ground.getType() != Material.GRASS_BLOCK) continue;
-				if (ground.getType() == Material.DIRT) ground.setType(Material.GRASS_BLOCK);
+					if (!feet.getType().isAir()) return;
+					if (ground.getType() != Material.DIRT && ground.getType() != Material.GRASS_BLOCK) return;
+					if (ground.getType() == Material.DIRT) ground.setType(Material.GRASS_BLOCK);
 
-				int rand = random.nextInt(100);
+					int rand = random.nextInt(100);
 
-				for (Material m : blocks.keySet()) {
-					int chance = blocks.get(m);
+					for (Material m : blocks.keySet()) {
+						int chance = blocks.get(m);
 
-					if (rand > chance) continue;
+						if (rand > chance) continue;
 
-					feet.setType(m);
-					addUseAndChargeCost(livingEntity);
+						feet.setType(m);
+						addUseAndChargeCost(livingEntity);
 
-					rand = random.nextInt(100);
-				}
+						rand = random.nextInt(100);
+					}
+				}, () -> entities.remove(id));
 			}
 		}
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/SeeHealthSpell.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.spells.buff;
 
 import java.util.*;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
@@ -131,10 +132,10 @@ public class SeeHealthSpell extends BuffSpell {
 
 	private class Updater implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private Updater() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, interval);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, interval);
 		}
 
 		@Override
@@ -150,7 +151,7 @@ public class SeeHealthSpell extends BuffSpell {
 		}
 
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WaterwalkSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Fluid;
 import org.bukkit.Bukkit;
 import org.bukkit.GameMode;
@@ -99,12 +100,12 @@ public class WaterwalkSpell extends BuffSpell {
 
 	private class Ticker implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private int count = 0;
 
 		private Ticker() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, 5, 5);
+			task = MagicSpells.scheduleRepeatingTask(this, 5, 5);
 		}
 
 		private boolean isWater(Location location) {
@@ -161,7 +162,7 @@ public class WaterwalkSpell extends BuffSpell {
 		}
 
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindglideSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -186,10 +187,10 @@ public class WindglideSpell extends BuffSpell {
 
 	private class GlideMonitor implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private GlideMonitor() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, interval, interval);
+			task = MagicSpells.scheduleRepeatingTask(this, interval, interval);
 		}
 
 		@Override
@@ -223,7 +224,7 @@ public class WindglideSpell extends BuffSpell {
 		}
 
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/WindwalkSpell.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 
 import io.papermc.paper.entity.TeleportFlag;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
@@ -203,10 +204,10 @@ public class WindwalkSpell extends BuffSpell {
 
 	private class HeightMonitor implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private HeightMonitor() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, TimeUtil.TICKS_PER_SECOND, TimeUtil.TICKS_PER_SECOND);
+			task = MagicSpells.scheduleRepeatingTask(this, TimeUtil.TICKS_PER_SECOND, TimeUtil.TICKS_PER_SECOND);
 		}
 
 		@Override
@@ -258,7 +259,7 @@ public class WindwalkSpell extends BuffSpell {
 		}
 
 		public void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/FlightPathSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/FlightPathSpell.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Player;
@@ -83,7 +84,7 @@ public class FlightPathSpell extends InstantSpell {
 
 		private boolean initialized = false;
 
-		private int task = -1;
+		private ScheduledTask task = null;
 
 		private FlightHandler() {
 			init();
@@ -92,7 +93,7 @@ public class FlightPathSpell extends InstantSpell {
 		private void addFlight(ActiveFlight flight) {
 			flights.put(flight.caster.getUniqueId(), flight);
 			flight.start();
-			if (task < 0) task = MagicSpells.scheduleRepeatingTask(this, 0, interval);
+			if (task == null) task = MagicSpells.scheduleRepeatingTask(this, 0, interval, flight.caster);
 		}
 
 		private void init() {
@@ -139,7 +140,7 @@ public class FlightPathSpell extends InstantSpell {
 			}
 			if (flights.isEmpty()) {
 				MagicSpells.cancelTask(task);
-				task = -1;
+				task = null;
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/LeapSpell.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.ArrayListMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -128,7 +129,7 @@ public class LeapSpell extends InstantSpell {
 		private final List<LeapData> queue = new ArrayList<>();
 
 		private boolean running = false;
-		private int taskId = -1;
+		private ScheduledTask task = null;
 
 		public void add(LeapData data) {
 			queue.add(data);
@@ -136,18 +137,18 @@ public class LeapSpell extends InstantSpell {
 		}
 
 		public void start() {
-			if (taskId != -1) return;
+			if (task != null) return;
 
 			MagicSpells.registerEvents(this);
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, 1);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, 1);
 		}
 
 		public void stop() {
-			if (taskId == -1) return;
+			if (task == null) return;
 
 			EntityDamageEvent.getHandlerList().unregister(this);
-			MagicSpells.cancelTask(taskId);
-			taskId = -1;
+			MagicSpells.cancelTask(task);
+			task = null;
 
 			jumping.clear();
 			queue.clear();

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/PortalSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -266,8 +267,8 @@ public class PortalSpell extends InstantSpell {
 		private final Portal startPortal;
 		private final Portal endPortal;
 
-		private int taskPortal = -1;
-		private int taskStop = -1;
+		private ScheduledTask taskPortal = null;
+		private ScheduledTask taskStop = null;
 
 		private PortalLink(SpellData data, Portal startPortal, Portal endPortal) {
 			this.startPortal = startPortal;
@@ -300,10 +301,10 @@ public class PortalSpell extends InstantSpell {
 						playSpellEffects(EffectPosition.END_POSITION, endPortal.portalLocation(), data);
 					}
 
-				}, interval, interval);
+				}, interval, interval, startPortal.portalLocation);
 			}
 
-			taskStop = MagicSpells.scheduleDelayedTask(this::stop, duration.get(data));
+			taskStop = MagicSpells.scheduleDelayedTask(this::stop, duration.get(data), startPortal.portalLocation);
 		}
 
 		@EventHandler(priority = EventPriority.NORMAL, ignoreCancelled = true)
@@ -404,8 +405,8 @@ public class PortalSpell extends InstantSpell {
 			playSpellEffects(EffectPosition.DELAYED, startPortal.portalLocation(), data);
 			playSpellEffects(EffectPosition.DELAYED, endPortal.portalLocation(), data);
 
-			if (taskPortal > 0) MagicSpells.cancelTask(taskPortal);
-			if (taskStop > 0) MagicSpells.cancelTask(taskStop);
+			if (taskPortal != null) MagicSpells.cancelTask(taskPortal);
+			if (taskStop != null) MagicSpells.cancelTask(taskStop);
 
 			tpCooldowns.clear();
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.HashMap;
 import java.util.Iterator;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Tag;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -35,7 +36,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 
 	private static final Map<Entity, FallingBlockInfo> fallingBlocks = new HashMap<>();
 	private static ThrowBlockListener throwBlockListener;
-	private static int cleanTask = -1;
+	private static ScheduledTask cleanTask = null;
 
 	private final ConfigData<BlockData> material;
 
@@ -243,7 +244,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 	}
 
 	private static void startCleanTask() {
-		if (cleanTask > -1) return;
+		if (cleanTask != null) return;
 
 		cleanTask = MagicSpells.scheduleDelayedTask(() -> {
 			Iterator<Map.Entry<Entity, FallingBlockInfo>> iter = fallingBlocks.entrySet().iterator();
@@ -266,7 +267,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 				}
 			}
 
-			if (fallingBlocks.isEmpty()) cleanTask = -1;
+			if (fallingBlocks.isEmpty()) cleanTask = null;
 			else startCleanTask();
 		}, 500);
 	}
@@ -276,7 +277,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 		private final FallingBlock block;
 		private final FallingBlockInfo info;
 
-		private final int task;
+		private final ScheduledTask task;
 
 		private final boolean stickyBlocks;
 		private final boolean ensureSpellCast;
@@ -290,7 +291,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			this.stickyBlocks = stickyBlocks;
 			this.ensureSpellCast = ensureSpellCast;
 
-			task = MagicSpells.scheduleRepeatingTask(this, TimeUtil.TICKS_PER_SECOND, 1);
+			task = MagicSpells.scheduleRepeatingTask(this, TimeUtil.TICKS_PER_SECOND, 1, block.getLocation());
 		}
 
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/VelocitySpell.java
@@ -9,6 +9,7 @@ import java.util.Collection;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.ArrayListMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.util.Vector;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
@@ -119,7 +120,7 @@ public class VelocitySpell extends InstantSpell implements TargetedEntitySpell, 
 		private final List<VelocityData> queue = new ArrayList<>();
 
 		private boolean running = false;
-		private int taskId = -1;
+		private ScheduledTask task = null;
 
 		public void add(VelocityData data) {
 			queue.add(data);
@@ -127,18 +128,18 @@ public class VelocitySpell extends InstantSpell implements TargetedEntitySpell, 
 		}
 
 		public void start() {
-			if (taskId != -1) return;
+			if (task != null) return;
 
 			MagicSpells.registerEvents(this);
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, 1);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, 1);
 		}
 
 		public void stop() {
-			if (taskId == -1) return;
+			if (task == null) return;
 
 			EntityDamageEvent.getHandlerList().unregister(this);
-			MagicSpells.cancelTask(taskId);
-			taskId = -1;
+			MagicSpells.cancelTask(task);
+			task = null;
 
 			jumping.clear();
 			queue.clear();

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/TicksListener.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.passive;
 import java.util.Set;
 import java.util.HashSet;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.jetbrains.annotations.NotNull;
 
 import org.bukkit.World;
@@ -158,12 +159,12 @@ public class TicksListener extends PassiveListener {
 
 		private final PassiveSpell passiveSpell;
 
-		private final int taskId;
+		private final ScheduledTask task;
 		private final String profilingKey;
 
 		public Ticker(PassiveSpell passiveSpell, int interval) {
 			this.passiveSpell = passiveSpell;
-			taskId = MagicSpells.scheduleRepeatingTask(this, interval, interval);
+			task = MagicSpells.scheduleRepeatingTask(this, interval, interval);
 			profilingKey = MagicSpells.profilingEnabled() ? "PassiveTick:" + interval : null;
 			entities = new HashSet<>();
 		}
@@ -192,7 +193,7 @@ public class TicksListener extends PassiveListener {
 		}
 
 		public void turnOff() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CarpetSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.*;
 import java.util.Map.Entry;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -166,7 +167,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 					CarpetData carpetData = blocks.remove(b1);
 					b1.setType(carpetData.air);
 				}
-			}, duration);
+			}, duration, loc);
 		}
 
 		if (data.hasCaster()) playSpellEffects(EffectPosition.CASTER, data.caster(), data);
@@ -179,10 +180,10 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 
 	private class TouchChecker implements Runnable {
 
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private TouchChecker() {
-			taskId = MagicSpells.scheduleRepeatingTask(this, touchCheckInterval, touchCheckInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, touchCheckInterval, touchCheckInterval);
 		}
 
 		@Override
@@ -210,7 +211,7 @@ public class CarpetSpell extends TargetedSpell implements TargetedLocationSpell 
 		}
 
 		private void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ChainSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.List;
 import java.util.ArrayList;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.LivingEntity;
@@ -130,7 +131,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 
 		private final SpellData data;
 		private final Location start;
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private final List<LivingEntity> targets;
 		private final List<Float> targetPowers;
@@ -144,7 +145,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			this.targetPowers = targetPowers;
 			this.targets = targets;
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, interval);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, interval, start);
 		}
 
 		@Override
@@ -160,7 +161,7 @@ public class ChainSpell extends TargetedSpell implements TargetedEntitySpell, Ta
 			playSpellEffects(EffectPosition.TARGET, target, subData);
 
 			current++;
-			if (current >= targets.size()) MagicSpells.cancelTask(taskId);
+			if (current >= targets.size()) MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseInventorySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseInventorySpell.java
@@ -41,7 +41,7 @@ public class CloseInventorySpell extends TargetedSpell implements TargetedEntity
 			MagicSpells.scheduleDelayedTask(() -> {
 				target.closeInventory();
 				playSpellEffects(data);
-			}, delay);
+			}, delay, target);
 		} else {
 			target.closeInventory();
 			playSpellEffects(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CombustSpell.java
@@ -74,7 +74,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		playSpellEffects(data);
 
-		MagicSpells.scheduleDelayedTask(() -> combusting.remove(data.target().getUniqueId()), duration + 2);
+		MagicSpells.scheduleDelayedTask(() -> combusting.remove(data.target().getUniqueId()), duration + 2, data.target());
 
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
@@ -98,7 +98,7 @@ public class CombustSpell extends TargetedSpell implements TargetedEntitySpell {
 		EventUtil.call(new SpellApplyDamageEvent(this, data.spellData.caster(), target, fireTickDamage, DamageCause.FIRE_TICK, ""));
 		event.setDamage(fireTickDamage);
 
-		if (data.preventImmunity) MagicSpells.scheduleDelayedTask(() -> target.setNoDamageTicks(0), 0);
+		if (data.preventImmunity) MagicSpells.scheduleDelayedTask(() -> target.setNoDamageTicks(0), 0, target);
 	}
 
 	private record CombustData(SpellData spellData, double fireTickDamage, boolean constantFireTickDamage, boolean preventImmunity) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DisarmSpell.java
@@ -121,7 +121,7 @@ public class DisarmSpell extends TargetedSpell implements TargetedEntitySpell {
 					if (preventTheft.get(data)) disarmedItems.put(item, target.getUniqueId());
 				}
 			}
-		}, disarmDuration);
+		}, disarmDuration, target);
 
 		playSpellEffects(data);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/DotSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.UUID;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
@@ -117,7 +118,7 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		private SpellData data;
 
-		private int taskId = -1;
+		private ScheduledTask task = null;
 		private int duration;
 		private int interval;
 		private int dur = 0;
@@ -138,7 +139,7 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 
 		private void init() {
-			if (taskId != -1) MagicSpells.cancelTask(taskId);
+			if (task != null) MagicSpells.cancelTask(task);
 
 			interval = DotSpell.this.interval.get(data);
 			duration = DotSpell.this.duration.get(data);
@@ -153,7 +154,7 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 			spellDamageType = DotSpell.this.spellDamageType.get(data);
 			damageType = DotSpell.this.damageType.get(data);
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, delay.get(data), interval);
+			task = MagicSpells.scheduleRepeatingTask(this, delay.get(data), interval);
 		}
 
 		@Override
@@ -218,7 +219,7 @@ public class DotSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 
 		private void cancel() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			activeDots.remove(data.target().getUniqueId());
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntombSpell.java
@@ -112,7 +112,7 @@ public class EntombSpell extends TargetedSpell implements TargetedEntitySpell {
 		if (powerAffectsDuration.get(data)) duration = Math.round(duration * data.power());
 
 		if (duration > 0 && !tombBlocks.isEmpty())
-			MagicSpells.scheduleDelayedTask(() -> removeTomb(tombBlocks, data), duration);
+			MagicSpells.scheduleDelayedTask(() -> removeTomb(tombBlocks, data), duration, feet.getLocation());
 
 		playSpellEffects(data);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/FireballSpell.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.HashSet;
 import java.util.HashMap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.Material;
 import org.bukkit.util.Vector;
@@ -33,7 +34,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 
 	private final Map<Fireball, SpellData> fireballs;
 
-	private final int taskId;
+	private final ScheduledTask task;
 
 	private final ConfigData<Float> explosionSize;
 
@@ -84,13 +85,13 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 		relativeCastLocationOffset = getConfigDataVector("relative-cast-position-offset", new Vector());
 		absoluteCastLocationOffset = getConfigDataVector("absolute-cast-position-offset", new Vector());
 
-		taskId = MagicSpells.scheduleRepeatingTask(() -> fireballs.entrySet().removeIf(fireballFloatEntry ->
+		task = MagicSpells.scheduleRepeatingTask(() -> fireballs.entrySet().removeIf(fireballFloatEntry ->
 			fireballFloatEntry.getKey().isDead()), TimeUtil.TICKS_PER_MINUTE, TimeUtil.TICKS_PER_MINUTE);
 	}
 
 	@Override
 	public void turnOff() {
-		MagicSpells.cancelTask(taskId);
+		MagicSpells.cancelTask(task);
 	}
 
 	@Override
@@ -218,7 +219,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 				}
 				fireball.remove();
 				if (!fires.isEmpty()) {
-					MagicSpells.scheduleDelayedTask(() -> fires.stream().filter(b -> b.getType() == Material.FIRE).forEachOrdered(b -> b.setType(Material.AIR)), TimeUtil.TICKS_PER_SECOND);
+					MagicSpells.scheduleDelayedTask(() -> fires.stream().filter(b -> b.getType() == Material.FIRE).forEachOrdered(b -> b.setType(Material.AIR)), TimeUtil.TICKS_PER_SECOND, loc);
 				}
 			}
 		} else {
@@ -229,7 +230,7 @@ public class FireballSpell extends TargetedSpell implements TargetedEntityFromLo
 		}
 
 		if (noExplosion.get(data)) fireballs.remove(fireball);
-		else MagicSpells.scheduleDelayedTask(() -> fireballs.remove(fireball), 1);
+		else MagicSpells.scheduleDelayedTask(() -> fireballs.remove(fireball), 1, fireball);
 	}
 
 	@EventHandler(priority = EventPriority.HIGH, ignoreCancelled = true)

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.List;
 import java.util.HashSet;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
@@ -206,7 +207,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 
 		private final BoundingBox hitBox;
 		private final long startTime;
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private final Vector effectOffset;
 		private final Vector targetRelativeOffset;
@@ -298,7 +299,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 
 			if (data.hasCaster()) playSpellEffects(EffectPosition.CASTER, data.caster(), data);
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval, currentLocation);
 		}
 
 		@Override
@@ -463,7 +464,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			if (removeTracker) trackers.remove(this);
 
 			playSpellEffects(EffectPosition.DELAYED, currentLocation, data);
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			if (effectSet != null) {
 				for (EffectlibSpellEffect spellEffect : effectSet) {
 					spellEffect.getEffect().cancel();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.List;
 import java.util.ArrayList;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.entity.*;
@@ -234,7 +235,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 		private final Projectile projectile;
 		private final BoundingBox hitBox;
 		private final long startTime;
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private final boolean stopOnModifierFail;
 
@@ -311,7 +312,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 			monitors.add(this);
 
 			int tickInterval = HomingProjectileSpell.this.tickInterval.get(data);
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval, projectile);
 
 			playSpellEffects(EffectPosition.CASTER, currentLocation, data);
 			playSpellEffects(EffectPosition.PROJECTILE, projectile, data);
@@ -412,7 +413,7 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 
 		private void stop(boolean remove) {
 			playSpellEffects(EffectPosition.DELAYED, currentLocation, data);
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			projectile.remove();
 			if (remove) monitors.remove(this);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.ArrayList;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
@@ -196,7 +197,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		private final double yOffset;
 		private final int duration;
 		private final int tickRate;
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private double distance;
 		private int counter;
@@ -218,7 +219,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 			minDistance = LevitateSpell.this.minDistance.get(data);
 			yOffset = LevitateSpell.this.yOffset.get(data);
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickRate);
+			task = MagicSpells.scheduleRepeatingTask(this, 0, tickRate, data.caster());
 		}
 
 		@Override
@@ -257,7 +258,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 
 		private void stop() {
 			stopped = true;
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.LinkedListMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.Listener;
@@ -291,7 +292,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 		private final boolean skipFirstLoopLocationModifiers;
 		private final boolean skipFirstVariableModsTargetLoop;
 
-		private final int taskId;
+		private final ScheduledTask task;
 		private final long iterations;
 
 		private long count;
@@ -325,7 +326,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 			else activeLoops.put(null, this);
 
 			if (interval <= 0) {
-				taskId = -1;
+				task = null;
 
 				if (iterations <= 0) {
 					cancel();
@@ -344,10 +345,10 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				return;
 			}
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, delay, interval);
+			task = MagicSpells.scheduleRepeatingTask(this, delay, interval);
 
 			long duration = LoopSpell.this.duration.get(data);
-			if (duration > 0) MagicSpells.scheduleDelayedTask(this::cancel, duration);
+			if (duration > 0) MagicSpells.scheduleDelayedTask(this::cancel, duration, data.location());
 		}
 
 		@Override
@@ -455,7 +456,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 			cancelled = true;
 
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 
 			if (remove) {
 				UUID key = null;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MaterializeSpell.java
@@ -359,7 +359,7 @@ public class MaterializeSpell extends TargetedSpell implements TargetedLocationS
 					playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, block.getLocation(), data);
 					if (playBreakEffect) block.getWorld().playEffect(block.getLocation(), Effect.STEP_SOUND, block.getBlockData());
 				}
-			}, resetDelay);
+			}, resetDelay, block.getLocation());
 		}
 		return true;
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/MountSpell.java
@@ -54,7 +54,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 			caster.addPassenger(target);
 			if (duration > 0) {
 				LivingEntity finalTarget = target;
-				MagicSpells.scheduleDelayedTask(() -> caster.removePassenger(finalTarget), duration);
+				MagicSpells.scheduleDelayedTask(() -> caster.removePassenger(finalTarget), duration, caster);
 			}
 
 			playSpellEffects(data);
@@ -75,7 +75,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 			for (Entity e : passengers) {
 				veh.addPassenger(e);
 				if (duration > 0) {
-					MagicSpells.scheduleDelayedTask(() -> veh.removePassenger(e), duration);
+					MagicSpells.scheduleDelayedTask(() -> veh.removePassenger(e), duration, veh);
 				}
 			}
 
@@ -93,7 +93,7 @@ public class MountSpell extends TargetedSpell implements TargetedEntitySpell {
 		target.addPassenger(caster);
 		if (duration > 0) {
 			LivingEntity finalTarget = target;
-			MagicSpells.scheduleDelayedTask(() -> finalTarget.removePassenger(caster), duration);
+			MagicSpells.scheduleDelayedTask(() -> finalTarget.removePassenger(caster), duration, finalTarget);
 		}
 
 		playSpellEffects(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/NovaSpell.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.HashMap;
 import java.util.HashSet;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.Material;
@@ -136,7 +137,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 
 		protected final boolean removePreviousBlocks;
 
-		protected final int taskId;
+		protected final ScheduledTask task;
 		protected final int radius;
 		protected final int startRadius;
 		protected final int heightPerTick;
@@ -173,7 +174,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 			nearby = new HashSet<>();
 
 			this.data = data.noTarget();
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, expandInterval.get(data));
+			task = MagicSpells.scheduleRepeatingTask(this, 0, expandInterval.get(data), center);
 		}
 
 		protected boolean step() {
@@ -232,7 +233,7 @@ public class NovaSpell extends TargetedSpell implements TargetedLocationSpell, T
 
 		protected void stop() {
 			removeBlocks(spellOnEnd);
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
@@ -125,7 +125,7 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 				MagicSpells.scheduleDelayedTask(() -> {
 					editSession.undo(editSession);
 					sessions.remove(editSession);
-				}, undoDelay);
+				}, undoDelay, data.location());
 			}
 		} catch (WorldEditException e) {
 			e.printStackTrace();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PulserSpell.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.spells.targeted;
 
 import java.util.*;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Material;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
@@ -272,7 +273,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 		private final double maxDistanceSq;
 
-		private int taskId;
+		private ScheduledTask task;
 		private int pulseCount;
 
 		private Pulser(Block block, Material type, SpellData data) {
@@ -291,7 +292,7 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 
 			pulseCount = 0;
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, interval.get(data));
+			task = MagicSpells.scheduleRepeatingTask(this, 0, interval.get(data), location);
 		}
 
 		public LivingEntity getCaster() {
@@ -331,10 +332,9 @@ public class PulserSpell extends TargetedSpell implements TargetedLocationSpell 
 		}
 
 		private void stop(boolean remove) {
-			if (taskId < 0) return;
+			if (task.isCancelled()) return;
 
-			MagicSpells.cancelTask(taskId);
-			taskId = -1;
+			MagicSpells.cancelTask(task);
 
 			if (remove) pulsers.remove(block);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ReplaceSpell.java
@@ -217,7 +217,7 @@ public class ReplaceSpell extends TargetedSpell implements TargetedLocationSpell
 								}
 								finalBlock.setBlockData(previous);
 								playSpellEffects(EffectPosition.BLOCK_DESTRUCTION, finalBlock.getLocation(), subData);
-							}, replaceDuration);
+							}, replaceDuration, target);
 						}
 
 						replaced = true;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/RewindSpell.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.LinkedHashMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
@@ -105,7 +106,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		private final SpellData data;
 
-		private final int taskId;
+		private final ScheduledTask task;
 		private int counter = 0;
 
 		private final int startMana;
@@ -139,7 +140,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 			startDuration = RewindSpell.this.startDuration.get(data) / tickInterval;
 			specialEffectInterval = RewindSpell.this.specialEffectInterval.get(data);
 
-			this.taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
+			this.task = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
 			if (data.hasCaster()) entities.put(data.caster().getUniqueId(), this);
 
 			playSpellEffects(data);
@@ -163,14 +164,14 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 
 		private void rewind(boolean remove) {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			if (remove && data.hasCaster()) entities.remove(data.caster().getUniqueId(), this);
 			if (rewindSpell != null) rewindSpell.subcast(data.noTarget());
 			new ForceRewinder(data, locations, startHealth, startMana, rewindHealth, rewindMana);
 		}
 
 		private void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 		}
 
 	}
@@ -179,7 +180,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		private final SpellData data;
 
-		private final int taskId;
+		private final ScheduledTask task;
 		private int counter;
 
 		private final int startMana;
@@ -206,7 +207,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 			delayedEffectInterval = RewindSpell.this.delayedEffectInterval.get(data);
 
 			int rewindInterval = RewindSpell.this.rewindInterval.get(data);
-			this.taskId = MagicSpells.scheduleRepeatingTask(this, 0, rewindInterval);
+			this.task = MagicSpells.scheduleRepeatingTask(this, 0, rewindInterval);
 		}
 
 		@Override
@@ -230,7 +231,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 
 		private void stop() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			if (rewindHealth) data.target().setHealth(startHealth);
 			if (rewindMana && MagicSpells.isManaSystemEnabled() && startMana > -1 && data.target() instanceof Player player) {
 				ManaHandler handler = MagicSpells.getManaHandler();
@@ -239,7 +240,7 @@ public class RewindSpell extends TargetedSpell implements TargetedEntitySpell {
 		}
 
 		private void cancel() {
-			MagicSpells.cancelTask(taskId);
+			MagicSpells.cancelTask(task);
 			locations.clear();
 			locations = null;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SilenceSpell.java
@@ -7,6 +7,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import io.papermc.paper.event.player.AsyncChatEvent;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 import org.bukkit.event.Listener;
 import org.bukkit.event.EventHandler;
@@ -178,12 +179,12 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 	private class Unsilencer implements Runnable {
 
 		private final UUID uuid;
-		private final int taskId;
+		private final ScheduledTask task;
 		private boolean canceled = false;
 
 		private Unsilencer(UUID uuid, int delay) {
 			this.uuid = uuid;
-			taskId = MagicSpells.scheduleDelayedTask(this, delay);
+			task = MagicSpells.scheduleDelayedTask(this, delay);
 		}
 
 		@Override
@@ -193,7 +194,7 @@ public class SilenceSpell extends TargetedSpell implements TargetedEntitySpell {
 
 		private void cancel() {
 			canceled = true;
-			if (taskId > 0) MagicSpells.cancelTask(taskId);
+			if (!task.isCancelled()) MagicSpells.cancelTask(task);
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -4,6 +4,7 @@ import java.util.*;
 
 import com.google.common.collect.Multimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.World;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -472,7 +473,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 				AttackMonitor monitor = new AttackMonitor(mob, data);
 				MagicSpells.registerEvents(monitor);
 
-				if (duration > 0) MagicSpells.scheduleDelayedTask(() -> HandlerList.unregisterAll(monitor), duration);
+				if (duration > 0) MagicSpells.scheduleDelayedTask(() -> HandlerList.unregisterAll(monitor), duration, source);
 			}
 		}
 
@@ -671,19 +672,19 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		private final Mob mob;
 
 		private final SpellData data;
-		private final int taskId;
+		private final ScheduledTask task;
 
 		private Targeter(Mob mob, SpellData data, int interval) {
 			this.data = data.noTargeting();
 			this.mob = mob;
 
-			this.taskId = MagicSpells.scheduleRepeatingTask(this, 1, interval);
+			this.task = MagicSpells.scheduleRepeatingTask(this, 1, interval, mob);
 		}
 
 		@Override
 		public void run() {
 			if (!mob.isValid()) {
-				MagicSpells.cancelTask(taskId);
+				MagicSpells.cancelTask(task);
 				return;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/TotemSpell.java
@@ -5,6 +5,7 @@ import java.util.*;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.HashMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.block.Block;
 import org.bukkit.entity.ArmorStand;
@@ -233,7 +234,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		totems.put(data.hasCaster() ? data.caster().getUniqueId() : null, totem);
 
 		int maxDuration = this.maxDuration.get(data);
-		if (maxDuration > 0) MagicSpells.scheduleDelayedTask(totem::stop, maxDuration);
+		if (maxDuration > 0) MagicSpells.scheduleDelayedTask(totem::stop, maxDuration, loc);
 
 		playSpellEffects(data);
 	}
@@ -294,7 +295,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		private final boolean allowCasterTarget;
 		private final boolean onlyCountOnSuccess;
 
-		private int taskId;
+		private ScheduledTask task;
 		private int pulseCount;
 		private final int totalPulses;
 
@@ -342,7 +343,7 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 
 			if (spellOnSpawn != null) spellOnSpawn.subcast(this.data.retarget(armorStand, null));
 
-			taskId = MagicSpells.scheduleRepeatingTask(this, 0, interval.get(data));
+			task = MagicSpells.scheduleRepeatingTask(this, 0, interval.get(data));
 		}
 
 		@Override
@@ -381,10 +382,10 @@ public class TotemSpell extends TargetedSpell implements TargetedLocationSpell {
 		}
 
 		private void stop(boolean remove) {
-			if (taskId < 0) return;
+			if (task == null) return;
 
-			MagicSpells.cancelTask(taskId);
-			taskId = -1;
+			MagicSpells.cancelTask(task);
+			task = null;
 
 			if (remove) totems.remove(data.hasCaster() ? data.caster().getUniqueId() : null, this);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spells.targeted;
 import java.util.List;
 import java.util.ArrayList;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Registry;
@@ -156,7 +157,7 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 		private final Location target;
 
 		private final int arrows;
-		private final int taskId;
+		private final ScheduledTask task;
 		private final boolean resolveOptionsPerArrow;
 
 		private boolean gravity;
@@ -197,8 +198,8 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 			int shootInterval = VolleySpell.this.shootInterval.get(data);
 			if (shootInterval <= 0) {
 				for (int i = 0; i < arrows; i++) run();
-				taskId = -1;
-			} else taskId = MagicSpells.scheduleRepeatingTask(this, 0, shootInterval);
+				task = null;
+			} else task = MagicSpells.scheduleRepeatingTask(this, 0, shootInterval, from);
 
 			playSpellEffects(data);
 		}
@@ -262,9 +263,9 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 			playSpellEffects(EffectPosition.PROJECTILE, arrow, data);
 			playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, from, arrow.getLocation(), data.caster(), arrow, data);
 
-			if (taskId != -1) {
+			if (task != null) {
 				count++;
-				if (count >= arrows) MagicSpells.cancelTask(taskId);
+				if (count >= arrows) MagicSpells.cancelTask(task);
 			}
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ext/GlowSpell.java
@@ -7,6 +7,7 @@ import java.util.Collection;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.LinkedListMultimap;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.ChatColor;
 import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
@@ -84,8 +85,8 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 			// If casted by the same spell, extend duration, otherwise fail
 			if (!glowData.getInternalName().equals(internalName)) return;
 
-			MagicSpells.cancelTask(glowData.getTaskId());
-			glowData.setTaskId(MagicSpells.scheduleDelayedTask(() -> {
+			MagicSpells.cancelTask(glowData.getTask());
+			glowData.setTask(MagicSpells.scheduleDelayedTask(() -> {
 				// Make the target hidden if it has an invisibility spell active
 				if (target instanceof Player targetPlayer) {
 					Set<BuffSpell> buffSpells = MagicSpells.getBuffManager().getActiveBuffs(target);
@@ -116,7 +117,7 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 		glow.display(caster);
 
 		glowData = new GlowData(glow, internalName);
-		glowData.setTaskId(MagicSpells.scheduleDelayedTask(() -> {
+		glowData.setTask(MagicSpells.scheduleDelayedTask(() -> {
 			// Make the target hidden if it has an invisibility spell active
 			if (target instanceof Player targetPlayer) {
 				Set<BuffSpell> buffSpells = MagicSpells.getBuffManager().getActiveBuffs(targetPlayer);
@@ -154,7 +155,7 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 	private static class GlowData {
 
 		private Glow glow;
-		private int taskId;
+		private ScheduledTask task;
 		private String internalName;
 
 		private GlowData(Glow glow, String internalName) {
@@ -170,12 +171,12 @@ public class GlowSpell extends TargetedSpell implements TargetedEntitySpell {
 			this.glow = glow;
 		}
 
-		public int getTaskId() {
-			return taskId;
+		public ScheduledTask getTask() {
+			return task;
 		}
 
-		public void setTaskId(int taskId) {
-			this.taskId = taskId;
+		public void setTask(ScheduledTask task) {
+			this.task = task;
 		}
 
 		public String getInternalName() {

--- a/core/src/main/java/com/nisovin/magicspells/util/DelayableEntity.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/DelayableEntity.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.util;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.ApiStatus;
@@ -110,13 +111,13 @@ public class DelayableEntity<E extends Entity> {
 			}
 		};
 
-		int taskId = -1;
+		ScheduledTask task = null;
 		if (delay <= 0) spawnEntity.run();
-		else taskId = MagicSpells.scheduleDelayedTask(spawnEntity, delay);
+		else task = MagicSpells.scheduleDelayedTask(spawnEntity, delay, location);
 
-		int id = taskId;
+		ScheduledTask id = task;
 		future.whenComplete((result, throwable) -> {
-			if (future.isCancelled() && id != -1) MagicSpells.cancelTask(id);
+			if (future.isCancelled() && id != null) MagicSpells.cancelTask(id);
 			if (throwable == null) return;
 			MagicSpells.handleException(new Exception("Delayed entity failed to spawn", throwable));
 		});

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellAnimation.java
@@ -2,9 +2,10 @@ package com.nisovin.magicspells.util;
 
 import java.util.Set;
 import java.util.HashSet;
+import java.util.concurrent.TimeUnit;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
-import org.bukkit.scheduler.BukkitTask;
 
 import com.nisovin.magicspells.MagicSpells;
 
@@ -21,7 +22,7 @@ public abstract class SpellAnimation implements Runnable {
 
 	private final boolean async;
 
-	private BukkitTask task;
+	private ScheduledTask task;
 	private int delay;
 	private int interval;
 	private int tick;
@@ -72,8 +73,8 @@ public abstract class SpellAnimation implements Runnable {
 	 * Start the spell animation.
 	 */
 	public void play() {
-		if (async) task = Bukkit.getScheduler().runTaskTimerAsynchronously(MagicSpells.getInstance(), this, delay, interval);
-		else task = Bukkit.getScheduler().runTaskTimer(MagicSpells.getInstance(), this, delay, interval);
+		if (async) task = Bukkit.getAsyncScheduler().runAtFixedRate(MagicSpells.getInstance(), t -> run(), delay, interval * 50L, TimeUnit.MILLISECONDS);
+		else task = Bukkit.getGlobalRegionScheduler().runAtFixedRate(MagicSpells.getInstance(), t -> run(), delay, interval);
 	}
 
 	/**

--- a/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/SpellUtil.java
@@ -222,7 +222,7 @@ public class SpellUtil {
 	public static void updateManaBar(Player player) {
 		if (!(MagicSpells.getManaHandler() instanceof ManaSystem system)) return;
 		if (!system.usingHungerBar()) return;
-		MagicSpells.scheduleDelayedTask(() -> system.showMana(player), 1);
+		MagicSpells.scheduleDelayedTask(() -> system.showMana(player), 1, player);
 	}
 	
 }

--- a/core/src/main/java/com/nisovin/magicspells/util/TemporaryBlockSet.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/TemporaryBlockSet.java
@@ -83,7 +83,7 @@ public class TemporaryBlockSet implements Runnable {
 	public void removeAfter(int ticks, BlockSetRemovalCallback callback) {
 		if (blocks.isEmpty()) return;
 		this.callback = callback;
-		MagicSpells.scheduleDelayedTask(this, ticks);
+		MagicSpells.scheduleDelayedTask(this, ticks, livingEntity); // loc ?
 	}
 	
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
@@ -1,5 +1,6 @@
 package com.nisovin.magicspells.util.trackers;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Item;
@@ -78,7 +79,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 	private boolean groundSpellCasted = false;
 	private boolean stopped = false;
 
-	private int taskId;
+	private ScheduledTask task;
 	private int count = 0;
 
 	public ItemProjectileTracker(SpellData data) {
@@ -115,14 +116,14 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			spell.playTrackingLinePatterns(EffectPosition.DYNAMIC_CASTER_PROJECTILE_LINE, startLocation, entity.getLocation(), data.caster(), entity, data);
 		}
 
-		taskId = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval);
+		task = MagicSpells.scheduleRepeatingTask(this, tickInterval, tickInterval, entity);
 
 		MagicSpells.scheduleDelayedTask(() -> {
 			entity.customName(itemName);
 			entity.setCustomNameVisible(true);
-		}, itemNameDelay);
+		}, itemNameDelay, entity);
 
-		MagicSpells.scheduleDelayedTask(this::stop, removeDelay);
+		MagicSpells.scheduleDelayedTask(this::stop, removeDelay, entity);
 	}
 
 	@Override
@@ -184,7 +185,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			if (!landed) MagicSpells.scheduleDelayedTask(() -> {
 				if (spellOnDelay != null) spellOnDelay.subcast(data.location(entity.getLocation()));
 				stop();
-			}, spellDelay);
+			}, spellDelay, entity);
 			landed = true;
 		}
 	}
@@ -200,7 +201,7 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 			if (removeTracker) ItemProjectileSpell.getProjectileTrackers().remove(this);
 		}
 		if (entity != null) entity.remove();
-		MagicSpells.cancelTask(taskId);
+		MagicSpells.cancelTask(task);
 		stopped = true;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.util.function.Predicate;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import it.unimi.dsi.fastutil.doubles.DoubleArrays;
 import it.unimi.dsi.fastutil.doubles.DoubleArraySet;
 
@@ -57,7 +58,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 	private Vector currentVelocity;
 	private Vector effectOffset;
 	private int counter;
-	private int taskId;
+	private ScheduledTask task;
 	private BoundingBox hitBox;
 	private BoundingBox groundHitBox;
 	private Set<LivingEntity> immune;
@@ -250,7 +251,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			ParticleProjectileSpell.getProjectileTrackers().add(this);
 		}
 
-		taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
+		task = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval, currentLocation);
 	}
 
 	@Override
@@ -638,7 +639,7 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 	public void stop(Location location, boolean removeTracker) {
 		if (removeTracker && spell != null) ParticleProjectileSpell.getProjectileTrackers().remove(this);
 		if (spell != null) spell.playEffects(EffectPosition.DELAYED, location, data.location(location));
-		MagicSpells.cancelTask(taskId);
+		MagicSpells.cancelTask(task);
 		if (effectSet != null) {
 			for (EffectlibSpellEffect spellEffect : effectSet) {
 				spellEffect.getEffect().cancel();
@@ -724,12 +725,12 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 		this.currentVelocity = currentVelocity;
 	}
 
-	public int getTaskId() {
-		return taskId;
+	public ScheduledTask getTask() {
+		return task;
 	}
 
-	public void setTaskId(int taskId) {
-		this.taskId = taskId;
+	public void setTask(ScheduledTask task) {
+		this.task = task;
 	}
 
 	public BoundingBox getHitBox() {

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -5,6 +5,7 @@ import java.util.Set;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Color;
 import org.bukkit.entity.*;
 import org.bukkit.Location;
@@ -91,7 +92,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 
 	private ValidTargetList targetList;
 
-	private int taskId;
+	private ScheduledTask task;
 	private int counter = 0;
 
 	private boolean stopped = false;
@@ -109,7 +110,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 	public void initialize() {
 		zoneManager = MagicSpells.getNoMagicZoneManager();
 		startTime = System.currentTimeMillis();
-		taskId = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval);
+		task = MagicSpells.scheduleRepeatingTask(this, 0, tickInterval, projectile);
 
 		startLocation.add(0, relativeOffset.getY(), 0);
 		Util.applyRelativeOffset(startLocation, relativeOffset.setY(0));
@@ -315,7 +316,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 			spell.playEffects(EffectPosition.DELAYED, currentLocation, data);
 			if (removeTracker) ProjectileSpell.getProjectileTrackers().remove(this);
 		}
-		MagicSpells.cancelTask(taskId);
+		MagicSpells.cancelTask(task);
 		if (effectSet != null) {
 			for (EffectlibSpellEffect spellEffect : effectSet) {
 				spellEffect.getEffect().cancel();

--- a/core/src/main/java/com/nisovin/magicspells/volatilecode/ManagerVolatile.java
+++ b/core/src/main/java/com/nisovin/magicspells/volatilecode/ManagerVolatile.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.volatilecode;
 
 import java.util.Map;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 import org.bukkit.Bukkit;
 
 import com.nisovin.magicspells.MagicSpells;
@@ -20,7 +21,7 @@ public class ManagerVolatile {
 		}
 
 		@Override
-		public int scheduleDelayedTask(Runnable task, long delay) {
+		public ScheduledTask scheduleDelayedTask(Runnable task, long delay) {
 			return MagicSpells.scheduleDelayedTask(task, delay);
 		}
 

--- a/core/src/main/resources/plugin.yml
+++ b/core/src/main/resources/plugin.yml
@@ -4,6 +4,7 @@ version: $version
 authors: [nisovin, TheComputerGeek2, Chronoken, tonythemacaroni, JasperLorelai]
 website: "https://github.com/TheComputerGeek2/MagicSpells/"
 api-version: "1.21.4"
+folia-supported: true
 softdepend:
     - GriefPrevention
     - Vault

--- a/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHelper.java
+++ b/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHelper.java
@@ -1,9 +1,11 @@
 package com.nisovin.magicspells.volatilecode;
 
+import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
+
 public interface VolatileCodeHelper {
 
 	void error(String message);
 
-	int scheduleDelayedTask(Runnable task, long delay);
+	ScheduledTask scheduleDelayedTask(Runnable task, long delay);
 
 }


### PR DESCRIPTION
This PR adds support for servers running Folia.
Note that this is a work-in-progress, untested, and many features are definitely broken and will need more probing. However, it does build and run.

To my knowledge the Folia schedulers do not have any equivalency to `BukkitTask` integer ids. All instances of these have been replaced with `ScheduledTask` objects.

Additionally, while sifting through to get this to compile, I noticed that there are instances of single global schedulers that iterate thru a set of blocks, players, etc. and modify their state. These are guaranteed to be broken and will need to be looked at.