### PR TITLE
Support replacement for BuffSpell duration, default to tick based duration

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -422,7 +422,7 @@ public class MagicSpells extends JavaPlugin {
 		zoneManager = new NoMagicZoneManager();
 		cleanserManager = new CleanserManager();
 		customGoalsManager = new CustomGoalsManager();
-		buffManager = new BuffManager(config.getInt(path + "buff-check-interval", 100));
+		buffManager = new BuffManager(config.getInt(path + "buff-check-interval", 1));
 		expBarManager = new ExperienceBarManager();
 		bossBarManager = new BossBarManager();
 		if (CompatBasics.pluginEnabled("Vault")) moneyHandler = new MoneyHandler();

--- a/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/BuffSpell.java
@@ -226,14 +226,20 @@ public abstract class BuffSpell extends TargetedSpell implements TargetedEntityS
 
 			if (!realTimeDuration) {
 				MagicSpells.scheduleDelayedTask(
-					() -> turnOff(data.target()),
+					() -> {
+						if (isExpired(data.target()))
+							turnOff(data.target());
+					},
 					Math.round(duration * TimeUtil.TICKS_PER_SECOND)
 				);
 			} else {
 				MagicSpells instance = MagicSpells.getInstance();
 				Bukkit.getAsyncScheduler().runDelayed(
 					instance,
-					task -> Bukkit.getScheduler().runTask(instance, () -> turnOff(data.target())),
+					task -> {
+						if (isExpired(data.target()))
+							Bukkit.getScheduler().runTask(instance, () -> turnOff(data.target()));
+					},
 					Math.round(duration * TimeUtil.MILLISECONDS_PER_SECOND),
 					TimeUnit.MILLISECONDS
 				);

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -120,7 +120,7 @@ str-wrong-world: You cannot cast that spell here.
 str-console-name: Admin
 str-xp-auto-learned: You have learned the %s spell!
 allow-anticheat-integrations: false
-buff-check-interval: 100
+buff-check-interval: 1
 ops-ignore-reagents: true
 ops-ignore-cooldowns: true
 ops-ignore-cast-times: true


### PR DESCRIPTION
- Added the `real-time-duration` option to `.BuffSpell`. Defaults to `false`. When `true`, buffs are measured in real time rather than based on ticks.
- The `duration` option of `.BuffSpell` now supports replacement.
- Changed the default value of the `buff-check-interval` option in `general.yml` from `100` to `1`.
- Fixed an issue that prevented certain option types from functioning in `defaults.yml`.