### PR TITLE
Fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/BuffEffectlibTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/BuffEffectlibTracker.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells.spelleffects.trackers;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 
 import de.slikey.effectlib.Effect;
 import de.slikey.effectlib.effect.ModifiedEffect;
@@ -13,10 +14,6 @@ import com.nisovin.magicspells.spelleffects.SpellEffect.SpellEffectActiveChecker
 public class BuffEffectlibTracker extends AsyncEffectTracker implements Runnable {
 
 	private final Effect effectlibEffect;
-
-	private Location entityLoc;
-
-	private Effect modifiedEffect;
 
 	public BuffEffectlibTracker(Entity entity, SpellEffectActiveChecker checker, SpellEffect effect, SpellData data) {
 		super(entity, checker, effect, data);
@@ -32,11 +29,16 @@ public class BuffEffectlibTracker extends AsyncEffectTracker implements Runnable
 			return;
 		}
 
-		entityLoc = effect.applyOffsets(entity.getLocation(), data);
+		if (!entity.isValid()) {
+			if (!(entity instanceof Player)) stop();
+			return;
+		}
+
+		Location entityLoc = effect.applyOffsets(entity.getLocation(), data);
 
 		effectlibEffect.setLocation(entityLoc);
 		if (effectlibEffect instanceof ModifiedEffect) {
-			modifiedEffect = ((ModifiedEffect) effectlibEffect).getInnerEffect();
+			Effect modifiedEffect = ((ModifiedEffect) effectlibEffect).getInnerEffect();
 			if (modifiedEffect != null) modifiedEffect.setLocation(entityLoc);
 		}
 	}
@@ -53,7 +55,6 @@ public class BuffEffectlibTracker extends AsyncEffectTracker implements Runnable
 
 	public boolean canRun() {
 		if (entity == null) return false;
-		if (!entity.isValid()) return false;
 		if (!checker.isActive(entity)) return false;
 		if (effect == null) return false;
 		if (effectlibEffect == null) return false;

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/BuffTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/BuffTracker.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells.spelleffects.trackers;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.SpellData;
@@ -20,8 +21,13 @@ public class BuffTracker extends EffectTracker implements Runnable {
 
 	@Override
 	public void run() {
-		if (!entity.isValid() || !checker.isActive(entity) || effect == null) {
+		if (!checker.isActive(entity) || effect == null) {
 			stop();
+			return;
+		}
+
+		if (!entity.isValid()) {
+			if (!(entity instanceof Player)) stop();
 			return;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitEffectlibTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitEffectlibTracker.java
@@ -4,6 +4,7 @@ import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitTask;
 
 import com.nisovin.magicspells.util.Util;
@@ -38,10 +39,6 @@ public class OrbitEffectlibTracker extends AsyncEffectTracker implements Runnabl
 	private final boolean counterClockwise;
 
 	private final Effect effectlibEffect;
-
-	private Location loc;
-
-	private Effect modifiedEffect;
 
 	public OrbitEffectlibTracker(Entity entity, SpellEffectActiveChecker checker, SpellEffect effect, SpellData data) {
 		super(entity, checker, effect, data);
@@ -82,15 +79,20 @@ public class OrbitEffectlibTracker extends AsyncEffectTracker implements Runnabl
 			return;
 		}
 
+		if (!entity.isValid()) {
+			if (!(entity instanceof Player)) stop();
+			return;
+		}
+
 		xAxis += orbitXAxis;
 		yAxis += orbitYAxis;
 		zAxis += orbitZAxis;
 
-		loc = effect.applyOffsets(getLocation(), data);
+		Location loc = effect.applyOffsets(getLocation(), data);
 
 		effectlibEffect.setLocation(loc);
 		if (effectlibEffect instanceof ModifiedEffect) {
-			modifiedEffect = ((ModifiedEffect) effectlibEffect).getInnerEffect();
+			Effect modifiedEffect = ((ModifiedEffect) effectlibEffect).getInnerEffect();
 			if (modifiedEffect != null) modifiedEffect.setLocation(loc);
 		}
 	}
@@ -119,7 +121,6 @@ public class OrbitEffectlibTracker extends AsyncEffectTracker implements Runnabl
 
 	public boolean canRun() {
 		if (entity == null) return false;
-		if (!entity.isValid()) return false;
 		if (!checker.isActive(entity)) return false;
 		if (effect == null) return false;
 		if (effectlibEffect == null) return false;

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/trackers/OrbitTracker.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spelleffects.trackers;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
 import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.util.Util;
@@ -66,8 +67,13 @@ public class OrbitTracker extends EffectTracker implements Runnable {
 
 	@Override
 	public void run() {
-		if (!entity.isValid() || !checker.isActive(entity) || effect == null) {
+		if (!checker.isActive(entity) || effect == null) {
 			stop();
+			return;
+		}
+
+		if (!entity.isValid()) {
+			if (!(entity instanceof Player)) stop();
 			return;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -28,7 +28,7 @@ public class InvulnerabilitySpell extends BuffSpell {
 	private static final DeprecationNotice DEPRECATION_NOTICE = new DeprecationNotice(
 		"The 'damage-causes' option does not function properly.",
 		"Use the 'damage-types' option.",
-		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#buffinvulernabilityspell-damage-causes"
+		"https://github.com/TheComputerGeek2/MagicSpells/wiki/Deprecations#buffinvulnerabilityspell-damage-causes"
 	);
 
 	private final Set<UUID> entities;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -352,8 +352,9 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 
 		@Override
 		public void run() {
-			if (data.hasTarget() && !data.target().isValid()) {
-				cancel();
+			LivingEntity loopingEntity = data.hasTarget() ? data.target() : data.hasCaster() ? data.caster() : null;
+			if (loopingEntity != null && !loopingEntity.isValid()) {
+				if (loopingEntity instanceof Player) cancel();
 				return;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LoopSpell.java
@@ -380,7 +380,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				}
 			}
 
-			if (loopModifiers != null && (!skipFirstLoopModifiers || !firstIteration)) {
+			if (data.hasCaster() && loopModifiers != null && (!skipFirstLoopModifiers || !firstIteration)) {
 				ModifierResult result = loopModifiers.apply(data.caster(), data);
 				data = result.data();
 
@@ -390,7 +390,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				}
 			}
 
-			if (data.hasTarget() && loopTargetModifiers != null && (!skipFirstLoopTargetModifiers || !firstIteration)) {
+			if (data.hasCaster() && data.hasTarget() && loopTargetModifiers != null && (!skipFirstLoopTargetModifiers || !firstIteration)) {
 				ModifierResult result = loopTargetModifiers.apply(data.caster(), data.target(), data);
 				data = result.data();
 
@@ -400,7 +400,7 @@ public class LoopSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				}
 			}
 
-			if (data.hasLocation() && loopLocationModifiers != null && (!skipFirstLoopLocationModifiers || !firstIteration)) {
+			if (data.hasCaster() && data.hasLocation() && loopLocationModifiers != null && (!skipFirstLoopLocationModifiers || !firstIteration)) {
 				ModifierResult result = loopLocationModifiers.apply(data.caster(), data.location(), data);
 				data = result.data();
 


### PR DESCRIPTION
- Fixed an issue where orbit and buff spell effects stopped playing after player death even if the buff remained active. It will now resume after respawn.
- Fixed issues with `LoopSpell`:
  - If the target was a Player, the loop used to end instead of pausing.
  - If there was no target, the Loop didn't check if the caster was invalid to cancel the loop or pause it if the caster was a Player.
  - If the Loop was cast without a caster, some errors might get thrown.