### PR TITLE
Boolean replacement bugfix, subspell additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -43,6 +43,7 @@ public class Subspell {
 
 	private boolean invert = false;
 	private boolean passPower = true;
+	private boolean passArguments = false;
 	private ConfigData<Integer> delay = data -> -1;
 	private ConfigData<Double> chance = data -> -1D;
 	private ConfigData<Float> subPower = data -> 1F;
@@ -83,6 +84,7 @@ public class Subspell {
 					}
 					case "invert" -> invert = Boolean.parseBoolean(value);
 					case "pass-power" -> passPower = Boolean.parseBoolean(value);
+					case "pass-arguments" -> passArguments = Boolean.parseBoolean(value);
 					case "pass-targeting" -> {
 						ConfigData<String> supplier = ConfigDataUtil.getString(value);
 
@@ -335,7 +337,11 @@ public class Subspell {
 
 	@NotNull
 	private SpellCastResult cast(@NotNull SpellData data) {
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+		data = data.builder()
+			.recipient(null)
+			.power((passPower ? data.power() : 1) * subPower.get(data))
+			.args(passArguments ? data.args() : args.get(data))
+			.build();
 
 		double chance = this.chance.get(data);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return fail(data);
@@ -381,7 +387,11 @@ public class Subspell {
 			return fail(data);
 		}
 
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+		data = data.builder()
+			.recipient(null)
+			.power((passPower ? data.power() : 1) * subPower.get(data))
+			.args(passArguments ? data.args() : args.get(data))
+			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {
 			ValidTargetList canTarget = spell.getValidTargetList();
@@ -458,7 +468,11 @@ public class Subspell {
 	private SpellCastResult castAtLocation(@NotNull SpellData data) {
 		if (!isTargetedLocation) return fail(data);
 
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+		data = data.builder()
+			.recipient(null)
+			.power((passPower ? data.power() : 1) * subPower.get(data))
+			.args(passArguments ? data.args() : args.get(data))
+			.build();
 
 		double chance = this.chance.get(data);
 		if ((chance > 0 && chance < 1) && random.nextDouble() > chance) return fail(data);
@@ -535,7 +549,11 @@ public class Subspell {
 	private SpellCastResult castAtEntityFromLocation(@NotNull SpellData data, boolean passTargeting) {
 		if (!isTargetedEntityFromLocation) return fail(data);
 
-		data = data.builder().recipient(null).power((passPower ? data.power() : 1) * subPower.get(data)).args(args.get(data)).build();
+		data = data.builder()
+			.recipient(null)
+			.power((passPower ? data.power() : 1) * subPower.get(data))
+			.args(passArguments ? data.args() : args.get(data))
+			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {
 			ValidTargetList canTarget = spell.getValidTargetList();

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -47,9 +47,9 @@ public class Subspell {
 	private ConfigData<String[]> args = data -> null;
 
 	private ConfigData<Boolean> invert = data -> false;
+	private ConfigData<Boolean> passArgs = data -> false;
 	private ConfigData<Boolean> passPower = data -> true;
 	private ConfigData<Boolean> passTargeting = data -> null;
-	private ConfigData<Boolean> passArguments = data -> false;
 
 	private boolean isTargetedEntity = false;
 	private boolean isTargetedLocation = false;
@@ -84,8 +84,8 @@ public class Subspell {
 						}
 					}
 					case "invert" -> invert = ConfigDataUtil.getBoolean(value, false);
+					case "pass-args" -> passArgs = ConfigDataUtil.getBoolean(value, false);
 					case "pass-power" -> passPower = ConfigDataUtil.getBoolean(value, true);
-					case "pass-arguments" -> passArguments = ConfigDataUtil.getBoolean(value, false);
 					case "pass-targeting" -> {
 						ConfigData<String> supplier = ConfigDataUtil.getString(value);
 
@@ -341,7 +341,7 @@ public class Subspell {
 		data = data.builder()
 			.recipient(null)
 			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
-			.args(passArguments.get(data) ? data.args() : args.get(data))
+			.args(passArgs.get(data) ? data.args() : args.get(data))
 			.build();
 
 		double chance = this.chance.get(data);
@@ -391,7 +391,7 @@ public class Subspell {
 		data = data.builder()
 			.recipient(null)
 			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
-			.args(passArguments.get(data) ? data.args() : args.get(data))
+			.args(passArgs.get(data) ? data.args() : args.get(data))
 			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {
@@ -472,7 +472,7 @@ public class Subspell {
 		data = data.builder()
 			.recipient(null)
 			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
-			.args(passArguments.get(data) ? data.args() : args.get(data))
+			.args(passArgs.get(data) ? data.args() : args.get(data))
 			.build();
 
 		double chance = this.chance.get(data);
@@ -553,7 +553,7 @@ public class Subspell {
 		data = data.builder()
 			.recipient(null)
 			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
-			.args(passArguments.get(data) ? data.args() : args.get(data))
+			.args(passArgs.get(data) ? data.args() : args.get(data))
 			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {

--- a/core/src/main/java/com/nisovin/magicspells/Subspell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Subspell.java
@@ -41,14 +41,15 @@ public class Subspell {
 	private CastMode mode = CastMode.PARTIAL;
 	private CastTargeting targeting = CastTargeting.NORMAL;
 
-	private boolean invert = false;
-	private boolean passPower = true;
-	private boolean passArguments = false;
 	private ConfigData<Integer> delay = data -> -1;
 	private ConfigData<Double> chance = data -> -1D;
 	private ConfigData<Float> subPower = data -> 1F;
 	private ConfigData<String[]> args = data -> null;
+
+	private ConfigData<Boolean> invert = data -> false;
+	private ConfigData<Boolean> passPower = data -> true;
 	private ConfigData<Boolean> passTargeting = data -> null;
+	private ConfigData<Boolean> passArguments = data -> false;
 
 	private boolean isTargetedEntity = false;
 	private boolean isTargetedLocation = false;
@@ -82,9 +83,9 @@ public class Subspell {
 							DebugHandler.debugIllegalArgumentException(e);
 						}
 					}
-					case "invert" -> invert = Boolean.parseBoolean(value);
-					case "pass-power" -> passPower = Boolean.parseBoolean(value);
-					case "pass-arguments" -> passArguments = Boolean.parseBoolean(value);
+					case "invert" -> invert = ConfigDataUtil.getBoolean(value, false);
+					case "pass-power" -> passPower = ConfigDataUtil.getBoolean(value, true);
+					case "pass-arguments" -> passArguments = ConfigDataUtil.getBoolean(value, false);
 					case "pass-targeting" -> {
 						ConfigData<String> supplier = ConfigDataUtil.getString(value);
 
@@ -273,7 +274,7 @@ public class Subspell {
 
 	@NotNull
 	public SpellCastResult subcast(@NotNull SpellData data, boolean passTargeting, boolean useTargetForLocation, @NotNull CastTargeting @NotNull [] ordering) {
-		if (invert) data = data.invert();
+		if (invert.get(data)) data = data.invert();
 
 		boolean hasCaster = data.caster() != null;
 		boolean hasTarget = data.target() != null;
@@ -339,8 +340,8 @@ public class Subspell {
 	private SpellCastResult cast(@NotNull SpellData data) {
 		data = data.builder()
 			.recipient(null)
-			.power((passPower ? data.power() : 1) * subPower.get(data))
-			.args(passArguments ? data.args() : args.get(data))
+			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
+			.args(passArguments.get(data) ? data.args() : args.get(data))
 			.build();
 
 		double chance = this.chance.get(data);
@@ -389,8 +390,8 @@ public class Subspell {
 
 		data = data.builder()
 			.recipient(null)
-			.power((passPower ? data.power() : 1) * subPower.get(data))
-			.args(passArguments ? data.args() : args.get(data))
+			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
+			.args(passArguments.get(data) ? data.args() : args.get(data))
 			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {
@@ -470,8 +471,8 @@ public class Subspell {
 
 		data = data.builder()
 			.recipient(null)
-			.power((passPower ? data.power() : 1) * subPower.get(data))
-			.args(passArguments ? data.args() : args.get(data))
+			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
+			.args(passArguments.get(data) ? data.args() : args.get(data))
 			.build();
 
 		double chance = this.chance.get(data);
@@ -551,8 +552,8 @@ public class Subspell {
 
 		data = data.builder()
 			.recipient(null)
-			.power((passPower ? data.power() : 1) * subPower.get(data))
-			.args(passArguments ? data.args() : args.get(data))
+			.power((passPower.get(data) ? data.power() : 1) * subPower.get(data))
+			.args(passArguments.get(data) ? data.args() : args.get(data))
 			.build();
 
 		if (mode != CastMode.HARD && !this.passTargeting.getOr(data, passTargeting)) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/VariableConfigData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/VariableConfigData.java
@@ -1,0 +1,10 @@
+package com.nisovin.magicspells.util.config;
+
+public interface VariableConfigData<T> extends ConfigData<T> {
+
+	@Override
+	default boolean isConstant() {
+		return false;
+	}
+
+}


### PR DESCRIPTION
- Fixed an issue where variable replacement for booleans used `false` for invalid values, instead of the supplied default value.
- Added the `pass-args` subspell cast argument. With `pass-args=true`, arguments from the parent spell cast are used for the subspell cast, instead of the value of the `args` subspell cast argument.
- The `invert` and `pass-power` subspell cast arguments now support replacement.
