### PR TITLE
Particle Cloud Improvements

### DIFF
--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -44,7 +44,10 @@ jobs:
             // Create or update comment, linking the artifact.
             const artifact_url = `https://nightly.link/${owner}/${repo}/actions/artifacts/${artifact.id}.zip`;
             const marker = `<!-- bot: ${label} -->`;
-            const body = `${marker}\nBuilt artifact: [\`${artifact.name}\`](${artifact_url})`;
+            
+            let body = `${marker}\nBuilt artifact: [\`${artifact.name}\`](${artifact_url})`;
+            const {behind_by} = await github.rest.repos.compareCommitsWithBasehead({owner: pr_owner, repo, basehead: `${pr_branch}...${owner}:main`});
+            if (behind_by > 0) body += `\n\n[(Behind by \`${behind_by}\` commits)](https://github.com/${pr_owner}/${repo}/compare/${pr_branch}...${owner}:main)`;
 
             const issue_number = pull_request.number;
             const {data: comments} = await github.rest.issues.listComments({owner, repo, issue_number});

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
@@ -3,6 +3,7 @@ package com.nisovin.magicspells.spelleffects.effecttypes;
 import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.Particle;
+import org.bukkit.entity.Entity;
 import org.bukkit.entity.AreaEffectCloud;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -31,6 +32,11 @@ public class ParticleCloudEffect extends ParticlesEffect {
 		radius = ConfigDataUtil.getFloat(config, "radius", 5);
 		yOffset = ConfigDataUtil.getFloat(config, "y-offset", 0);
 		radiusPerTick = ConfigDataUtil.getFloat(config, "radius-per-tick", 0);
+	}
+
+	@Override
+	protected Runnable playEffectEntity(Entity entity, SpellData data) {
+		return playEffectLocation(applyOffsets(entity.getLocation(), data), data);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
@@ -15,7 +15,6 @@ import com.nisovin.magicspells.util.config.ConfigDataUtil;
 @Name("particlecloud")
 public class ParticleCloudEffect extends ParticlesEffect {
 
-	private ConfigData<Integer> color;
 	private ConfigData<Integer> duration;
 
 	private ConfigData<Float> radius;
@@ -26,7 +25,9 @@ public class ParticleCloudEffect extends ParticlesEffect {
 	public void loadFromConfig(ConfigurationSection config) {
 		super.loadFromConfig(config);
 
-		color = ConfigDataUtil.getInteger(config, "color", 0xFF0000);
+		ConfigData<Integer> color = ConfigDataUtil.getInteger(config, "color", 0xFF0000);
+		argbColor = argbColor.orDefault(data -> Color.fromRGB(color.get(data)));
+
 		duration = ConfigDataUtil.getInteger(config, "duration", 60);
 
 		radius = ConfigDataUtil.getFloat(config, "radius", 5);
@@ -45,7 +46,6 @@ public class ParticleCloudEffect extends ParticlesEffect {
 		if (particle == null) return null;
 
 		location.getWorld().spawn(location.clone().add(0, yOffset.get(data), 0), AreaEffectCloud.class, cloud -> {
-			cloud.setColor(Color.fromRGB(color.get(data)));
 			cloud.setRadius(radius.get(data));
 			cloud.setDuration(duration.get(data));
 			cloud.setRadiusPerTick(radiusPerTick.get(data));

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticleCloudEffect.java
@@ -16,6 +16,7 @@ import com.nisovin.magicspells.util.config.ConfigDataUtil;
 public class ParticleCloudEffect extends ParticlesEffect {
 
 	private ConfigData<Integer> duration;
+	private ConfigData<Integer> waitTime;
 
 	private ConfigData<Float> radius;
 	private ConfigData<Float> yOffset;
@@ -28,6 +29,7 @@ public class ParticleCloudEffect extends ParticlesEffect {
 		ConfigData<Integer> color = ConfigDataUtil.getInteger(config, "color", 0xFF0000);
 		argbColor = argbColor.orDefault(data -> Color.fromRGB(color.get(data)));
 
+		waitTime = ConfigDataUtil.getInteger(config, "wait-time", 0);
 		duration = ConfigDataUtil.getInteger(config, "duration", 60);
 
 		radius = ConfigDataUtil.getFloat(config, "radius", 5);
@@ -46,6 +48,7 @@ public class ParticleCloudEffect extends ParticlesEffect {
 		if (particle == null) return null;
 
 		location.getWorld().spawn(location.clone().add(0, yOffset.get(data), 0), AreaEffectCloud.class, cloud -> {
+			cloud.setWaitTime(waitTime.get(data));
 			cloud.setRadius(radius.get(data));
 			cloud.setDuration(duration.get(data));
 			cloud.setRadiusPerTick(radiusPerTick.get(data));

--- a/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MenuSpell.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells.spells;
 import org.jetbrains.annotations.NotNull;
 
 import java.util.*;
-import java.util.concurrent.ThreadLocalRandom;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
@@ -281,7 +280,7 @@ public class MenuSpell extends TargetedSpell implements TargetedEntitySpell, Tar
 				if (event.isCancelled()) continue;
 			}
 			// Select and finalise item to display.
-			ItemStack item = option.item != null ? option.item : option.items.get(ThreadLocalRandom.current().nextInt(option.items.size()));
+			ItemStack item = option.item != null ? option.item : option.items.get(random.nextInt(option.items.size()));
 			item.editMeta(meta -> meta.getPersistentDataContainer().set(OPTION_KEY, PersistentDataType.STRING, option.menuOptionName));
 			item = translateItem(opener, item, menu.data);
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
@@ -127,20 +127,14 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 			if (!info.noTarget()) {
 				Location location = info.target().getLocation();
 				location.setDirection(data.caster().getLocation().getDirection());
-				data = info.spellData().location(location);
-
-				spawnCloud(data);
-				return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+				return spawnCloud(info.spellData().location(location));
 			}
 		}
 
 		if (canTargetLocation.get(data)) {
 			TargetInfo<Location> info = getTargetedBlockLocation(data, 0.5, 1, 0.5, false);
 			if (info.noTarget()) return noTarget(info);
-			data = info.spellData();
-
-			spawnCloud(data);
-			return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+			return spawnCloud(info.spellData());
 		}
 
 		return noTarget(data);
@@ -148,18 +142,15 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 
 	@Override
 	public CastResult castAtLocation(SpellData data) {
-		spawnCloud(data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return spawnCloud(data);
 	}
 
 	@Override
 	public CastResult castAtEntity(SpellData data) {
-		data = data.location(data.target().getLocation());
-		spawnCloud(data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return spawnCloud(data.location(data.target().getLocation()));
 	}
 
-	private void spawnCloud(SpellData data) {
+	private CastResult spawnCloud(SpellData data) {
 		Location location = data.location();
 
 		//apply relative offset
@@ -181,6 +172,7 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 
 			cloud.setSource(finalData.caster());
 			cloud.setColor(Color.fromRGB(color.get(finalData)));
+
 			cloud.setRadius(radius.get(finalData));
 			cloud.setGravity(useGravity.get(finalData));
 			cloud.setWaitTime(waitTime.get(finalData));
@@ -199,8 +191,8 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 			}
 		});
 
-		if (data.hasTarget()) playSpellEffects(data.caster(), data.target(), data);
-		else playSpellEffects(data.caster(), location, data);
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
@@ -1,9 +1,6 @@
 package com.nisovin.magicspells.spells.targeted;
 
-import java.util.Set;
 import java.util.List;
-import java.util.HashSet;
-import java.util.ArrayList;
 
 import org.bukkit.Color;
 import org.bukkit.Material;
@@ -16,7 +13,6 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.Particle.DustOptions;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.entity.AreaEffectCloud;
-import org.bukkit.potion.PotionEffectType;
 
 import net.kyori.adventure.text.Component;
 
@@ -26,7 +22,6 @@ import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.util.config.ConfigDataUtil;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
-import com.nisovin.magicspells.handlers.PotionEffectHandler;
 
 public class ParticleCloudSpell extends TargetedSpell implements TargetedLocationSpell, TargetedEntitySpell {
 
@@ -53,7 +48,7 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 	private final ConfigData<Boolean> canTargetEntities;
 	private final ConfigData<Boolean> canTargetLocation;
 
-	private final Set<PotionEffect> potionEffects;
+	private final List<ConfigData<PotionEffect>> potionEffects;
 
 	public ParticleCloudSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -94,28 +89,7 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 		canTargetEntities = getConfigDataBoolean("can-target-entities", true);
 		canTargetLocation = getConfigDataBoolean("can-target-location", true);
 
-		List<String> potionEffectStrings = getConfigStringList("potion-effects", null);
-		if (potionEffectStrings == null) potionEffectStrings = new ArrayList<>();
-
-		potionEffects = new HashSet<>();
-
-		for (String effect : potionEffectStrings) {
-			potionEffects.add(getPotionEffectFromString(effect));
-		}
-	}
-
-	private static PotionEffect getPotionEffectFromString(String s) {
-		String[] splits = s.split(" ");
-		PotionEffectType type = PotionEffectHandler.getPotionEffectType(splits[0]);
-
-		int durationTicks = Integer.parseInt(splits[1]);
-		int amplifier = Integer.parseInt(splits[2]);
-
-		boolean ambient = Boolean.parseBoolean(splits[3]);
-		boolean particles = Boolean.parseBoolean(splits[4]);
-		boolean icon = Boolean.parseBoolean(splits[5]);
-
-		return new PotionEffect(type, durationTicks, amplifier, ambient, particles, icon);
+		potionEffects = Util.getPotionEffects(getConfigList("potion-effects", null), internalName);
 	}
 
 	@Override
@@ -182,7 +156,9 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 			cloud.setRadiusPerTick(radiusPerTick.get(finalData));
 			cloud.setReapplicationDelay(reapplicationDelay.get(finalData));
 
-			for (PotionEffect eff : potionEffects) cloud.addCustomEffect(eff, true);
+			if (potionEffects != null)
+				for (ConfigData<PotionEffect> eff : potionEffects)
+					cloud.addCustomEffect(eff.get(finalData), true);
 
 			Component customName = this.customName.get(finalData);
 			if (customName != null) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -224,7 +224,7 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 					ambient = split.length > 3 && split[3].equalsIgnoreCase("ambient");
 					potionEffects.add(new PotionEffect(type, duration, strength, ambient));
 				} catch (Exception e) {
-					MagicSpells.error("SpawnMonsterSpell '" + spellName + "' has an invalid potion effect defined: " + data);
+					MagicSpells.error("SpawnEntitySpell '" + spellName + "' has an invalid potion effect defined: " + data);
 				}
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -91,7 +91,7 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 
 		color = getConfigDataColor("color", null);
 		potionType = getConfigDataRegistryEntry("potion-type", Registry.POTION, null);
-		potionEffects = Util.getPotionEffects(getConfigList("potion-effects", null), internalName, false, false);
+		potionEffects = Util.getPotionEffects(getConfigList("potion-effects", null), internalName);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -386,7 +386,7 @@ public class EntityData {
 		ConfigData<Vector3f> translation = getVector(config, "transformation.translation");
 		ConfigData<Vector3f> scale = getVector(config, "transformation.scale");
 		ConfigData<Transformation> transformation = data -> null;
-		if (checkNull(leftRotation) && checkNull(rightRotation) && checkNull(translation) && checkNull(scale)) {
+		if (!leftRotation.isNull() && !rightRotation.isNull() && !translation.isNull() && !scale.isNull()) {
 			if (leftRotation.isConstant() && rightRotation.isConstant() && translation.isConstant() && scale.isConstant()) {
 				Quaternionf lr = leftRotation.get();
 				Quaternionf rr = rightRotation.get();
@@ -429,7 +429,7 @@ public class EntityData {
 		ConfigData<Integer> blockLight = ConfigDataUtil.getInteger(config, "brightness.block");
 		ConfigData<Integer> skyLight = ConfigDataUtil.getInteger(config, "brightness.sky");
 		ConfigData<Display.Brightness> brightness = data -> null;
-		if (checkNull(blockLight) && checkNull(skyLight)) {
+		if (!blockLight.isNull() && !skyLight.isNull()) {
 			if (blockLight.isConstant() && skyLight.isConstant()) {
 				int bl = blockLight.get();
 				int sl = skyLight.get();
@@ -756,7 +756,7 @@ public class EntityData {
 	private <T> ConfigData<T> fallback(Function<String, ConfigData<T>> function, String... keys) {
 		for (String key : keys) {
 			ConfigData<T> data = function.apply(key);
-			if (checkNull(data)) return data;
+			if (!data.isNull()) return data;
 		}
 
 		return data -> null;
@@ -823,7 +823,7 @@ public class EntityData {
 			return data -> null;
 		}
 
-		if (!checkNull(x) || !checkNull(y) || !checkNull(z)) return data -> null;
+		if (x.isNull() || y.isNull() || z.isNull()) return data -> null;
 
 		if (x.isConstant() && y.isConstant() && z.isConstant()) {
 			Vector3f vector = new Vector3f(x.get(), y.get(), z.get());
@@ -873,7 +873,7 @@ public class EntityData {
 
 		ConfigData<Float> angle = ConfigDataUtil.getFloat(config, path + ".angle");
 		ConfigData<Vector3f> axis = getVector(config, path + ".axis");
-		if (checkNull(angle) && checkNull(axis)) {
+		if (!angle.isNull() && !axis.isNull()) {
 			if (angle.isConstant() && axis.isConstant()) {
 				Vector3f ax = axis.get();
 				float ang = angle.get();
@@ -960,7 +960,7 @@ public class EntityData {
 			return data -> null;
 		}
 
-		if (!checkNull(x) || !checkNull(y) || !checkNull(z) || !checkNull(w)) return data -> null;
+		if (x.isNull() || y.isNull() || z.isNull() || w.isNull()) return data -> null;
 
 		if (x.isConstant() && y.isConstant() && z.isConstant() && w.isConstant()) {
 			Quaternionf rot = new Quaternionf(x.get(), y.get(), z.get(), w.get());
@@ -993,10 +993,6 @@ public class EntityData {
 
 		};
 
-	}
-
-	private boolean checkNull(ConfigData<?> data) {
-		return !data.isConstant() || data.get() != null;
 	}
 
 	public ConfigData<EntityType> getEntityType() {

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -27,6 +27,7 @@ import org.bukkit.util.EulerAngle;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Transformation;
+import org.bukkit.potion.PotionEffect;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.inventory.EquipmentSlot;
@@ -178,6 +179,16 @@ public class EntityData {
 		addOptEquipment(transformers, config, "equipment.leggings", EquipmentSlot.LEGS);
 		addOptEquipment(transformers, config, "equipment.boots", EquipmentSlot.FEET);
 		addOptEquipment(transformers, config, "equipment.body", Mob.class, EquipmentSlot.BODY);
+
+		List<?> potionEffectData = config.getList("potion-effects");
+		if (potionEffectData != null && !potionEffectData.isEmpty()) {
+			List<ConfigData<PotionEffect>> effects = Util.getPotionEffects(potionEffectData, null);
+			if (effects != null) {
+				transformers.put(LivingEntity.class, (LivingEntity entity, SpellData data) -> {
+					effects.forEach(effect -> entity.addPotionEffect(effect.get(data)));
+				});
+			}
+		}
 
 		// Mob
 		addOptEquipmentDropChance(transformers, config, "equipment.main-hand-drop-chance", EquipmentSlot.HAND);

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -145,7 +145,13 @@ public class Util {
 		return c;
 	}
 
-	public static List<ConfigData<PotionEffect>> getPotionEffects(@Nullable List<?> potionEffectData, @NotNull String internalName, boolean spellPowerAffectsDuration, boolean spellPowerAffectsStrength) {
+	@Nullable
+	public static List<ConfigData<PotionEffect>> getPotionEffects(@Nullable List<?> potionEffectData, @Nullable String internalName) {
+		return getPotionEffects(potionEffectData, internalName, false, false);
+	}
+
+	@Nullable
+	public static List<ConfigData<PotionEffect>> getPotionEffects(@Nullable List<?> potionEffectData, @Nullable String internalName, boolean spellPowerAffectsDuration, boolean spellPowerAffectsStrength) {
 		if (potionEffectData == null || potionEffectData.isEmpty()) return null;
 
 		List<ConfigData<PotionEffect>> potionEffects = new ArrayList<>();
@@ -156,7 +162,7 @@ public class Util {
 
 				PotionEffectType type = PotionEffectHandler.getPotionEffectType(data[0]);
 				if (type == null) {
-					MagicSpells.error("Invalid potion effect string '" + potionEffectString + "' in spell '" + internalName + "'.");
+					MagicSpells.error("Invalid potion effect string '" + potionEffectString + "'" + (internalName == null ? "" : " in spell '" + internalName + "'."));
 					continue;
 				}
 
@@ -165,7 +171,7 @@ public class Util {
 					try {
 						duration = Integer.parseInt(data[1]);
 					} catch (NumberFormatException e) {
-						MagicSpells.error("Invalid duration '" + duration + "' in potion effect string '" + potionEffectString + "' in spell '" + internalName + "'.");
+						MagicSpells.error("Invalid duration '" + duration + "' in potion effect string '" + potionEffectString + "'" + (internalName == null ? "" : " in spell '" + internalName + "'."));
 						continue;
 					}
 				}
@@ -175,7 +181,7 @@ public class Util {
 					try {
 						strength = Integer.parseInt(data[2]);
 					} catch (NumberFormatException e) {
-						MagicSpells.error("Invalid strength '" + strength + "' in potion effect string '" + potionEffectString + "' in spell '" + internalName + "'.");
+						MagicSpells.error("Invalid strength '" + strength + "' in potion effect string '" + potionEffectString + "'" + (internalName == null ? "" : " in spell '" + internalName + "'."));
 						continue;
 					}
 				}
@@ -185,7 +191,7 @@ public class Util {
 				boolean icon = data.length < 6 || Boolean.parseBoolean(data[5]);
 
 				if (data.length > 6)
-					MagicSpells.error("Trailing data found in potion effect string '" + potionEffectString + "' in spell '" + internalName + "'.");
+					MagicSpells.error("Trailing data found in potion effect string '" + potionEffectString + "'" + (internalName == null ? "" : " in spell '" + internalName + "'."));
 
 				if (spellPowerAffectsDuration || spellPowerAffectsStrength) {
 					int finalDuration = duration;

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -66,20 +66,20 @@ public class Util {
 		return Material.matchMaterial(name);
 	}
 
-	// - <potionEffectType> (level) (duration) (ambient)
+	// - <potionEffectType> (amplifier) (duration) (ambient) (particles) (icon)
 	public static PotionEffect buildPotionEffect(String effectString) {
 		String[] data = effectString.split(" ");
-		PotionEffectType t = PotionEffectHandler.getPotionEffectType(data[0]);
+		PotionEffectType type = PotionEffectHandler.getPotionEffectType(data[0]);
 
-		if (t == null) {
+		if (type == null) {
 			MagicSpells.error('\'' + data[0] + "' could not be connected to a potion effect type");
 			return null;
 		}
 
-		int level = 0;
+		int amplifier = 0;
 		if (data.length > 1) {
 			try {
-				level = Integer.parseInt(data[1]);
+				amplifier = Integer.parseInt(data[1]);
 			} catch (NumberFormatException ex) {
 				DebugHandler.debugNumberFormat(ex);
 			}
@@ -100,7 +100,7 @@ public class Util {
 
 		boolean icon = data.length > 5 && (BooleanUtils.isYes(data[5]) || data[5].equalsIgnoreCase("icon"));
 
-		return new PotionEffect(t, duration, level, ambient, particles, icon);
+		return new PotionEffect(type, duration, amplifier, ambient, particles, icon);
 	}
 
 	// - <potionEffectType> (duration)

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -186,8 +186,8 @@ public class Util {
 					}
 				}
 
-				boolean ambient = data.length >= 4 && Boolean.parseBoolean(data[4]);
-				boolean particles = data.length < 5 || !Boolean.parseBoolean(data[3]);
+				boolean particles = data.length < 4 || !Boolean.parseBoolean(data[3]);
+				boolean ambient = data.length >= 5 && Boolean.parseBoolean(data[4]);
 				boolean icon = data.length < 6 || Boolean.parseBoolean(data[5]);
 
 				if (data.length > 6)

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -606,7 +606,7 @@ public class ConfigDataUtil {
 		if (value == null) return data -> def;
 
 		Particle val = ParticleUtil.getParticle(value);
-		if (val != null) return ata -> val;
+		if (val != null) return data -> val;
 
 		ConfigData<String> supplier = getString(value);
 		if (supplier.isConstant()) return data -> def;


### PR DESCRIPTION
## Breaking Changes:

- The `ParticleCloudSpell` option `potion-effects` now relies on the common [Potion Effects List](https://github.com/TheComputerGeek2/MagicSpells/wiki/Potion-Effect-List) format, which causes a minor breaking change in the string variant of the format (`<potion> <duration> <amplifier> <ambient> <particles> <icon>`), where `ambient` now refers toggles `hidden`, and `particles` now toggles `ambient`.



## Changes:

- The `particlecloud` spell effect can now utilise the `argb-color` option to color the `entity_effect` particle.
- Restored the `particle-name` option to `ParticleCloudSpell` as an alias to the `particle` option, as it was unintentionally renamed in `4.0 Beta 13`.


## Additions:

- Added [`potion-effects`](https://github.com/TheComputerGeek2/MagicSpells/wiki/Potion-Effect-List) to Entity Data.
- Added options `ParticleCloudSpell` to configure particles:
  - `dust_color_transition` - `color`, `to-color` and `size` options under a `dust-transition` section
  - `entity_effect` - `argb-color` option
- Added `apply-physics` to `ReplaceSpell`, a boolean option, defaulting to `true`.
- Added `wait-time` (Integer, defaults to `0`) to `particlecloud` spell effect. This overrides the default behaviour where radius is ignored for 20 ticks and particles only spawn at the center of the cloud.



## Fixes:

- Fixed an issue with the `particlecloud` spell effect not playing correctly when played on an entity rather than a location.
- Fixed an issue with the color of the `entity_effect` particle in the `ParticleCloudSpell` being overridden by the `potion-effects` color.