### PR TITLE
Properly check weapon item for `hitarrow` trigger

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/HitArrowListener.java
@@ -8,7 +8,7 @@ import org.jetbrains.annotations.NotNull;
 import org.bukkit.entity.Arrow;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
 import com.nisovin.magicspells.util.Name;
@@ -43,28 +43,22 @@ public class HitArrowListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDamage(EntityDamageByEntityEvent event) {
-		if (!(event.getEntity() instanceof LivingEntity attacked)) return;
 		if (!isCancelStateOk(event.isCancelled())) return;
 
-		LivingEntity caster = getAttacker(event);
-		if (caster == null || !canTrigger(caster)) return;
+		if (!(event.getDamager() instanceof Arrow arrow)) return;
+		if (!(event.getEntity() instanceof LivingEntity attacked)) return;
+		if (!(arrow.getShooter() instanceof LivingEntity caster) || !canTrigger(caster)) return;
 
 		if (!items.isEmpty()) {
-			EntityEquipment eq = caster.getEquipment();
-			if (eq == null) return;
+			ItemStack item = arrow.getWeapon();
+			if (item == null) return;
 
-			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(eq.getItemInMainHand());
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
 			if (itemData == null || !contains(itemData)) return;
 		}
 
 		boolean casted = passiveSpell.activate(caster, attacked);
 		if (cancelDefaultAction(casted)) event.setCancelled(true);
-	}
-	
-	private LivingEntity getAttacker(EntityDamageByEntityEvent event) {
-		if (!(event.getDamager() instanceof Arrow arrow)) return null;
-		if (arrow.getShooter() != null && arrow.getShooter() instanceof LivingEntity shooter) return shooter;
-		return null;
 	}
 
 	private boolean contains(MagicItemData itemData) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/passive/MissArrowListener.java
@@ -11,7 +11,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.inventory.EntityEquipment;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.metadata.FixedMetadataValue;
 import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.ProjectileLaunchEvent;
@@ -62,7 +62,7 @@ public class MissArrowListener extends PassiveListener {
 	@OverridePriority
 	@EventHandler
 	public void onDamage(ProjectileHitEvent event) {
-		if (!(event.getEntity() instanceof Arrow)) return;
+		if (!(event.getEntity() instanceof Arrow arrow)) return;
 
 		LivingEntity caster = getAttacker(event);
 		if (caster == null || !canTrigger(caster)) return;
@@ -77,10 +77,10 @@ public class MissArrowListener extends PassiveListener {
 		if (arrowParticle.isHitEntity()) return;
 
 		if (!items.isEmpty()) {
-			EntityEquipment eq = caster.getEquipment();
-			if (eq == null) return;
+			ItemStack item = arrow.getWeapon();
+			if (item == null) return;
 
-			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(eq.getItemInMainHand());
+			MagicItemData itemData = MagicItems.getMagicItemDataFromItemStack(item);
 			if (!contains(itemData)) return;
 		}
 


### PR DESCRIPTION
- Properly use the weapon that fired the arrow, instead of the current main hand item, for the `hitarrow` and `missarrow` passive triggers.
- Properly check for arrow misses for the `missarrow` trigger.