### PR TITLE
Fix intermediate special effects option in HomingMissileSpell to not always zero out the number of intermediate effects.

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -279,7 +279,7 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			airSpellInterval = HomingMissileSpell.this.airSpellInterval.get(data);
 			specialEffectInterval = HomingMissileSpell.this.specialEffectInterval.get(data);
 
-			intermediateSpecialEffects = Math.min(HomingMissileSpell.this.intermediateSpecialEffects.get(data), 0);
+			intermediateSpecialEffects = Math.max(HomingMissileSpell.this.intermediateSpecialEffects.get(data), 0);
 
 			float hitRadius = HomingMissileSpell.this.hitRadius.get(data);
 			float verticalHitRadius = HomingMissileSpell.this.verticalHitRadius.get(data);


### PR DESCRIPTION
Take maximum between configured value and zero rather than minimum between the two.