### PR TITLE
feat: Add UUID placeholders

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1848,16 +1848,25 @@ public class MagicSpells extends JavaPlugin {
 		if (replacements != null) replacementList.addAll(Arrays.asList(replacements));
 
 		if (data.hasRecipient()) {
+			replacementList.add("%r_uuid");
+			replacementList.add(data.recipient().getUniqueId().toString());
+
 			replacementList.add("%r");
 			replacementList.add(getTargetName(data.recipient()));
 		}
 
 		if (data.hasCaster()) {
+			replacementList.add("%a_uuid");
+			replacementList.add(data.caster().getUniqueId().toString());
+
 			replacementList.add("%a");
 			replacementList.add(getTargetName(data.caster()));
 		}
 
 		if (data.hasTarget()) {
+			replacementList.add("%t_uuid");
+			replacementList.add(data.target().getUniqueId().toString());
+
 			replacementList.add("%t");
 			replacementList.add(getTargetName(data.target()));
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -31,7 +31,7 @@ public class StringData implements ConfigData<String> {
 		(?<papi>(?<papiOwner>papi|casterpapi|targetpapi):(?<papiValue>[^%]+))|\
 		(?<playerPapi>playerpapi:(?<playerPapiUser>[^:]+):(?<playerPapiValue>[^%]+))\
 		)%|\
-		(?<entityName>%[art])""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+		(?<entityData>%[art](?:_uuid)?)""", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 
 	private final List<ConfigData<String>> values;
 	private final List<String> fragments;
@@ -129,10 +129,13 @@ public class StringData implements ConfigData<String> {
 			return new PlayerPAPIData(matcher.group(), papiPlaceholder, player);
 		}
 
-		return switch (matcher.group("entityName")) {
+		return switch (matcher.group("entityData")) {
 			case "%r" -> new DefaultNameData();
+			case "%r_uuid" -> new DefaultUUIDData();
 			case "%a" -> new CasterNameData();
+			case "%a_uuid" -> new CasterUUIDData();
 			case "%t" -> new TargetNameData();
+			case "%t_uuid" -> new TargetUUIDData();
 			default -> null;
 		};
 	}
@@ -420,6 +423,20 @@ public class StringData implements ConfigData<String> {
 
 	}
 
+	public static class DefaultUUIDData extends PlaceholderData {
+
+		public DefaultUUIDData() {
+			super("%r_uuid");
+		}
+
+		@Override
+		public String get(@NotNull SpellData data) {
+			if (!data.hasRecipient()) return placeholder;
+			return data.recipient().getUniqueId().toString();
+		}
+
+	}
+
 	public static class CasterNameData extends PlaceholderData {
 
 		public CasterNameData() {
@@ -434,6 +451,20 @@ public class StringData implements ConfigData<String> {
 
 	}
 
+	public static class CasterUUIDData extends PlaceholderData {
+
+		public CasterUUIDData() {
+			super("%a_uuid");
+		}
+
+		@Override
+		public String get(@NotNull SpellData data) {
+			if (!data.hasCaster()) return placeholder;
+			return data.caster().getUniqueId().toString();
+		}
+
+	}
+
 	public static class TargetNameData extends PlaceholderData {
 
 		public TargetNameData() {
@@ -444,6 +475,20 @@ public class StringData implements ConfigData<String> {
 		public String get(@NotNull SpellData data) {
 			if (!data.hasTarget()) return placeholder;
 			return MagicSpells.getTargetName(data.target());
+		}
+
+	}
+
+	public static class TargetUUIDData extends PlaceholderData {
+
+		public TargetUUIDData() {
+			super("%t_uuid");
+		}
+
+		@Override
+		public String get(@NotNull SpellData data) {
+			if (!data.hasTarget()) return placeholder;
+			return data.target().getUniqueId().toString();
 		}
 
 	}


### PR DESCRIPTION
### Additions:

- Adds `%a_uuid`, `%t_uuid`, and `%r_uuid` placeholders.



### Changes:

- The `ExternalCommandSpell` option `command-to-execute-later` can now use the rest of the placeholders.
