### PR TITLE
Add predicate for registry entries

### DIFF
--- a/core/src/main/antlr/com/nisovin/magicspells/util/grammars/RegistryEntryPredicate.g4
+++ b/core/src/main/antlr/com/nisovin/magicspells/util/grammars/RegistryEntryPredicate.g4
@@ -1,0 +1,27 @@
+grammar RegistryEntryPredicate;
+
+options {
+    language = Java;
+    caseInsensitive = true;
+}
+
+parse: expr=expression EOF;
+
+expression
+    : '(' expr=expression ')' # parenthesis
+    | '!' expr=expression # not
+    | left=expression '&' right=expression # and
+    | left=expression '^' right=expression # xor
+    | left=expression '|' right=expression # or
+    | '#' tag=RESOURCE_LOCATION # tag
+    | entry=RESOURCE_LOCATION # entry
+    ;
+
+WHITESPACE: [\p{White_Space}]+ -> skip;
+
+RESOURCE_LOCATION: (NAMESPACE ':')? PATH;
+
+NAMESPACE: [-._0-9a-z]+;
+
+PATH: [-._/0-9a-z]+;
+

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -963,6 +963,15 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		return SpellFilter.fromSection(config.getMainConfig(), internalKey);
 	}
 
+	protected <T extends Keyed> Predicate<T> getConfigRegistryEntryPredicate(String path, RegistryKey<T> registryKey) {
+		if (config.isList(internalKey + path)) {
+			Set<Key> keys = getConfigRegistryKeys(path, registryKey);
+			return entry -> keys.contains(entry.key());
+		}
+
+		return RegistryEntryPredicate.fromString(registryKey, config.getString(internalKey + path, null));
+	}
+
 	@SuppressWarnings("UnstableApiUsage")
 	protected <T extends Keyed> Set<Key> getConfigRegistryKeys(String path, RegistryKey<T> registryKey) {
 		List<String> keyStrings = config.getStringList(internalKey + path, null);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/InvulnerabilitySpell.java
@@ -1,12 +1,12 @@
 package com.nisovin.magicspells.spells.buff;
 
 import java.util.*;
+import java.util.function.Predicate;
 
 import org.jetbrains.annotations.NotNull;
 
-import net.kyori.adventure.key.Key;
-
 import org.bukkit.entity.Entity;
+import org.bukkit.damage.DamageType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -31,14 +31,14 @@ public class InvulnerabilitySpell extends BuffSpell {
 	);
 
 	private final Set<UUID> entities;
-	private final Set<Key> damageTypes;
-	private final Set<DamageCause> damageCauses;
 	private final Set<String> spellDamageTypes;
+	private final Set<DamageCause> damageCauses;
+	private final Predicate<DamageType> damageTypes;
 
 	public InvulnerabilitySpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		damageTypes = getConfigRegistryKeys("damage-types", RegistryKey.DAMAGE_TYPE);
+		damageTypes = getConfigRegistryEntryPredicate("damage-types", RegistryKey.DAMAGE_TYPE);
 
 		damageCauses = new HashSet<>();
 		List<String> causes = getConfigStringList("damage-causes", null);
@@ -117,7 +117,7 @@ public class InvulnerabilitySpell extends BuffSpell {
 	public void onEntityDamage(EntityDamageEvent event) {
 		Entity entity = event.getEntity();
 		if (!(entity instanceof LivingEntity livingEntity)) return;
-		if (damageTypes != null && !damageTypes.contains(event.getDamageSource().getDamageType().key())) return;
+		if (damageTypes != null && !damageTypes.test(event.getDamageSource().getDamageType())) return;
 		if (!damageCauses.isEmpty() && !damageCauses.contains(event.getCause())) return;
 		if (!isActive(livingEntity)) return;
 		if (isExpired(livingEntity)) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ResistSpell.java
@@ -1,12 +1,12 @@
 package com.nisovin.magicspells.spells.buff;
 
 import java.util.*;
-
-import net.kyori.adventure.key.Key;
+import java.util.function.Predicate;
 
 import org.jetbrains.annotations.NotNull;
 
 import org.bukkit.entity.Entity;
+import org.bukkit.damage.DamageType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.entity.EntityDamageEvent;
@@ -34,8 +34,8 @@ public class ResistSpell extends BuffSpell {
 
 	private final Map<UUID, ResistData> entities;
 
-	private final Set<Key> damageTypes;
 	private final Set<String> spellDamageTypes;
+	private final Predicate<DamageType> damageTypes;
 	private final Set<DamageCause> normalDamageTypes;
 
 	private final ConfigData<Double> flatModifier;
@@ -60,7 +60,7 @@ public class ResistSpell extends BuffSpell {
 		powerAffectsMultiplier = getConfigDataBoolean("power-affects-multiplier", true);
 		powerAffectsFlatModifier = getConfigDataBoolean("power-affects-flat-modifier", true);
 
-		damageTypes = getConfigRegistryKeys("damage-types", RegistryKey.DAMAGE_TYPE);
+		damageTypes = getConfigRegistryEntryPredicate("damage-types", RegistryKey.DAMAGE_TYPE);
 		damageWildcard = getConfigBoolean("damage-types", false);
 
 		List<String> causes = getConfigStringList("normal-damage-types", null);
@@ -161,7 +161,7 @@ public class ResistSpell extends BuffSpell {
 			if (damageTypes == null && normalDamageTypes == null) return;
 
 			if (damageTypes != null) {
-				if (!damageTypes.contains(event.getDamageSource().getDamageType().key())) return;
+				if (!damageTypes.test(event.getDamageSource().getDamageType())) return;
 			} else if (!normalDamageTypes.contains(event.getCause())) return;
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/RegistryEntryPredicate.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/RegistryEntryPredicate.java
@@ -1,0 +1,50 @@
+package com.nisovin.magicspells.util;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import java.util.function.Predicate;
+
+import org.antlr.v4.runtime.CharStreams;
+import org.antlr.v4.runtime.CommonTokenStream;
+
+import org.bukkit.Keyed;
+
+import io.papermc.paper.registry.RegistryKey;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.grammars.GrammarUtils;
+import com.nisovin.magicspells.util.grammars.RegistryEntryPredicateLexer;
+import com.nisovin.magicspells.util.grammars.RegistryEntryPredicateParser;
+import com.nisovin.magicspells.util.grammars.RegistryEntryPredicateVisitorImpl;
+
+public final class RegistryEntryPredicate {
+
+	public static <T extends Keyed> Predicate<T> fromString(@NotNull RegistryKey<T> registryKey, @Nullable String string) {
+		if (string == null || string.isEmpty()) return null;
+
+		try {
+			RegistryEntryPredicateLexer lexer = new RegistryEntryPredicateLexer(CharStreams.fromString(string));
+			lexer.removeErrorListeners();
+			lexer.addErrorListener(GrammarUtils.LEXER_LISTENER);
+
+			RegistryEntryPredicateParser parser = new RegistryEntryPredicateParser(new CommonTokenStream(lexer));
+			parser.removeErrorListeners();
+			parser.addErrorListener(GrammarUtils.PARSER_LISTENER);
+
+			RegistryEntryPredicateVisitorImpl<@NotNull T> visitor = new RegistryEntryPredicateVisitorImpl<>(string, registryKey);
+			return visitor.visit(parser.parse());
+		} catch (Exception e) {
+			MagicSpells.error("Encountered an error while parsing " + getRegistryName(registryKey) + " predicate '" + string + "'");
+			e.printStackTrace();
+
+			return null;
+		}
+	}
+
+	public static String getRegistryName(@NotNull RegistryKey<?> key) {
+		String name = key.key().value();
+		return name.replace('_', ' ');
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/grammars/RegistryEntryPredicateVisitorImpl.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/grammars/RegistryEntryPredicateVisitorImpl.java
@@ -1,0 +1,96 @@
+package com.nisovin.magicspells.util.grammars;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+import java.util.NoSuchElementException;
+
+import net.kyori.adventure.key.InvalidKeyException;
+
+import org.bukkit.Keyed;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+
+import io.papermc.paper.registry.tag.Tag;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.tag.TagKey;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.RegistryAccess;
+
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.RegistryEntryPredicate;
+import com.nisovin.magicspells.util.grammars.RegistryEntryPredicateParser.*;
+
+public class RegistryEntryPredicateVisitorImpl<T extends Keyed> extends RegistryEntryPredicateBaseVisitor<Predicate<T>> {
+
+	private final Registry<@NotNull T> registry;
+	private final RegistryKey<T> registryKey;
+	private final String originalText;
+
+	public RegistryEntryPredicateVisitorImpl(@NotNull String originalText, @NotNull RegistryKey<T> registryKey) {
+		this.originalText = originalText;
+		this.registryKey = registryKey;
+
+		registry = RegistryAccess.registryAccess().getRegistry(registryKey);
+	}
+
+	@Override
+	public Predicate<T> visitParse(ParseContext ctx) {
+		return ctx.expr.accept(this);
+	}
+
+	@Override
+	public Predicate<T> visitParenthesis(ParenthesisContext ctx) {
+		return ctx.expr.accept(this);
+	}
+
+	@Override
+	public Predicate<T> visitNot(NotContext ctx) {
+		return ctx.expr.accept(this).negate();
+	}
+
+	@Override
+	public Predicate<T> visitAnd(AndContext ctx) {
+		return AndPredicate.and(ctx.left.accept(this), ctx.right.accept(this));
+	}
+
+	@Override
+	public Predicate<T> visitXor(XorContext ctx) {
+		return XorPredicate.xor(ctx.left.accept(this), ctx.right.accept(this));
+	}
+
+	@Override
+	public Predicate<T> visitOr(OrContext ctx) {
+		return OrPredicate.or(ctx.left.accept(this), ctx.right.accept(this));
+	}
+
+	@SuppressWarnings({"UnstableApiUsage", "PatternValidation"})
+	@Override
+	public Predicate<T> visitTag(TagContext ctx) {
+		String text = ctx.tag.getText();
+
+		try {
+			TagKey<T> tagKey = registryKey.tagKey(text);
+			Tag<@NotNull T> tag = registry.getTag(tagKey);
+
+			return entry -> tag.contains(TypedKey.create(registryKey, entry.key()));
+		} catch (InvalidKeyException | NoSuchElementException e) {
+			MagicSpells.error("Invalid tag '" + text + "' at line " + ctx.start.getLine() + " position " + ctx.start.getCharPositionInLine() + " of '" + RegistryEntryPredicate.getRegistryName(registryKey) + "' filter '" + originalText + "'.");
+			return entry -> false;
+		}
+	}
+
+	@Override
+	public Predicate<T> visitEntry(EntryContext ctx) {
+		String text = ctx.entry.getText();
+
+		NamespacedKey key = NamespacedKey.fromString(text);
+		if (key == null || registry.get(key) == null) {
+			MagicSpells.error("Invalid entry '" + text + "' at line " + ctx.start.getLine() + " position " + ctx.start.getCharPositionInLine() + " of '" + RegistryEntryPredicate.getRegistryName(registryKey) + "' filter '" + originalText + "'.");
+			return entry -> false;
+		}
+
+		return entry -> key.equals(entry.key());
+	}
+
+}


### PR DESCRIPTION
Currently used in `InvulnerabilitySpell`, `ResistSpell` and the `damage` trigger.