### PR TITLE
Change "ops-ignore-" default to "false"

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -886,9 +886,9 @@ public class MagicSpells extends JavaPlugin {
 		permissions.add(new Permission(Perm.ADVANCED_SCROLL.getNode(), PermissionDefault.FALSE));
 		advancedChildren.put(Perm.ADVANCED_SCROLL.getNode(), true);
 
-		boolean opsIgnoreReagents = config.getBoolean("general.ops-ignore-reagents", true);
-		boolean opsIgnoreCooldowns = config.getBoolean("general.ops-ignore-cooldowns", true);
-		boolean opsIgnoreCastTimes = config.getBoolean("general.ops-ignore-cast-times", true);
+		boolean opsIgnoreReagents = config.getBoolean("general.ops-ignore-reagents", false);
+		boolean opsIgnoreCooldowns = config.getBoolean("general.ops-ignore-cooldowns", false);
+		boolean opsIgnoreCastTimes = config.getBoolean("general.ops-ignore-cast-times", false);
 
 		// Op permissions
 		permissions.add(new Permission(

--- a/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZone.java
+++ b/core/src/main/java/com/nisovin/magicspells/zones/NoMagicZone.java
@@ -51,9 +51,7 @@ public abstract class NoMagicZone implements Comparable<NoMagicZone> {
 		if (!inZone(location)) return ZoneCheckResult.IGNORED;
 		if (disallowAll) return ZoneCheckResult.DENY;
 		if (allowAll) return ZoneCheckResult.ALLOW;
-		if (!spellFilter.check(spell)) return ZoneCheckResult.DENY;
-		if (spellFilter.check(spell)) return ZoneCheckResult.ALLOW;
-		return ZoneCheckResult.IGNORED;
+		return spellFilter.check(spell) ? ZoneCheckResult.ALLOW : ZoneCheckResult.DENY;
 	}
 	
 	public abstract boolean inZone(Location location);

--- a/core/src/main/resources/general.yml
+++ b/core/src/main/resources/general.yml
@@ -121,9 +121,9 @@ str-console-name: Admin
 str-xp-auto-learned: You have learned the %s spell!
 allow-anticheat-integrations: false
 buff-check-interval: 1
-ops-ignore-reagents: true
-ops-ignore-cooldowns: true
-ops-ignore-cast-times: true
+ops-ignore-reagents: false
+ops-ignore-cooldowns: false
+ops-ignore-cast-times: false
 hide-magic-items-tooltips: false
 enable-magic-xp: false
 enable-dance-casting: true

--- a/core/src/main/resources/spells-regular.yml
+++ b/core/src/main/resources/spells-regular.yml
@@ -1149,7 +1149,7 @@ silence:
     prevent-chat: false
     prevent-commands: false
     duration: 200
-    allowed-spells:
+    spells:
         - list
         - help
     cost: [mana 15]

--- a/core/src/main/resources/zones.yml
+++ b/core/src/main/resources/zones.yml
@@ -5,7 +5,7 @@ zone1:
     point1: -30,0,-30
     point2: 30,128,30
     message: An anti-magic aura makes your spell fizzle.
-    allowed-spells:
+    spells:
         - list
         - help
 zone2:
@@ -14,7 +14,7 @@ zone2:
     type: worldguard
     region: arena
     message: You cannot use that spell in the arena.
-    disallowed-spells:
+    denied-spells:
         - blink
         - gate
         - mark


### PR DESCRIPTION
The default value for `ops-ignore-(reagents/cooldowns/cast-times)` in `general.yml` has been changed to `false`.