### PR TITLE
Entity Data fixes

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -5,7 +5,6 @@ import java.util.HashSet;
 
 import org.bukkit.Location;
 import org.bukkit.entity.Entity;
-import org.bukkit.entity.LivingEntity;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Name;
@@ -27,9 +26,7 @@ public class EntityEffect extends SpellEffect {
 
 	private ConfigData<Integer> duration;
 
-	private ConfigData<Boolean> silent;
 	private ConfigData<Boolean> gravity;
-	private ConfigData<Boolean> enableAI;
 
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
@@ -40,9 +37,7 @@ public class EntityEffect extends SpellEffect {
 
 		duration = ConfigDataUtil.getInteger(section, "duration", 0);
 
-		silent = ConfigDataUtil.getBoolean(section, "silent", false);
 		gravity = ConfigDataUtil.getBoolean(section, "gravity", false);
-		enableAI = ConfigDataUtil.getBoolean(section, "ai", true);
 	}
 
 	@Override
@@ -50,11 +45,7 @@ public class EntityEffect extends SpellEffect {
 		return entityData.spawn(location, data, entity -> {
 			entity.addScoreboardTag(ENTITY_TAG);
 			entity.setGravity(gravity.get(data));
-			entity.setSilent(silent.get(data));
-			entity.setPersistent(false);
-
-			if (entity instanceof LivingEntity livingEntity) livingEntity.setAI(enableAI.get(data));
-		});
+		}, entity -> entity.setPersistent(false));
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -66,7 +66,7 @@ public class EntityEffect extends SpellEffect {
 
 	@Override
 	public void turnOff() {
-		for (Entity entity : entities) entity.remove();
+		entities.forEach(Entity::remove);
 		entities.clear();
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/MultiSpell.java
@@ -94,17 +94,18 @@ public final class MultiSpell extends InstantSpell {
 			}
 		} else {
 			if (customSpellCastChance.get(data)) {
-				double total = 0;
-				for (ActionChance actionChance : actions) total += actionChance.chance;
+				double total = actions.stream().mapToDouble(ActionChance::chance).sum();
+				if (total <= 0) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
-				double index = random.nextDouble(total);
+				double selected = random.nextDouble(total);
+
 				Action action = null;
-				double subChance = 0;
+				double current = 0;
 				for (ActionChance actionChance : actions) {
-					subChance += actionChance.chance;
-
+					current += actionChance.chance;
+					if (selected >= current) continue;
 					action = actionChance.action;
-					if (subChance > index) break;
+					break;
 				}
 
 				if (action != null && action.isSpell()) action.getSpell().subcast(data);
@@ -146,17 +147,19 @@ public final class MultiSpell extends InstantSpell {
 			}
 		} else {
 			if (customSpellCastChance.get(subData)) {
-				double total = 0;
-				for (ActionChance actionChance : actions) total += actionChance.chance;
+				double total = actions.stream().mapToDouble(ActionChance::chance).sum();
+				if (total <= 0) return false;
 
-				double index = random.nextDouble(total);
+				double selected = random.nextDouble(total);
+
 				Action action = null;
-				double subChance = 0;
+				double current = 0;
 				for (ActionChance actionChance : actions) {
-					subChance += actionChance.chance;
+					current += actionChance.chance;
+					if (selected >= current) continue;
 
 					action = actionChance.action;
-					if (subChance > index) break;
+					break;
 				}
 
 				if (action != null && action.isSpell()) action.getSpell().getSpell().castFromConsole(sender, args);

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -233,15 +233,14 @@ public class MinionSpell extends BuffSpell {
 		if (!(data.target() instanceof Player target)) return false;
 		// Selecting the mob
 		EntityType creatureType = null;
-		int num = random.nextInt(100);
+		int total = Arrays.stream(chances).sum();
+		int num = random.nextInt(total);
 		int n = 0;
 		for (int i = 0; i < creatureTypes.length; i++) {
-			if (num < chances[i] + n) {
-				creatureType = creatureTypes[i];
-				break;
-			}
-
 			n += chances[i];
+			if (num >= n) continue;
+			creatureType = creatureTypes[i];
+			break;
 		}
 
 		if (creatureType == null) return false;

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -36,26 +36,24 @@ import com.nisovin.magicspells.util.itemreader.AttributeHandler;
 
 public class MinionSpell extends BuffSpell {
 
-	private final Map<UUID, LivingEntity> minions;
-	private final Map<LivingEntity, UUID> players;
-	private final Map<UUID, LivingEntity> targets;
-
-	private final int[] chances;
+	private final Map<UUID, Mob> minions = new HashMap<>();
+	private final Map<LivingEntity, UUID> players = new HashMap<>();
+	private final Map<EntityType, Integer> mobChances = new HashMap<>();
+	private final Map<UUID, LivingEntity> targets = new ConcurrentHashMap<>();
 
 	private ValidTargetList minionTargetList;
-	private EntityType[] creatureTypes;
 
-	private final ConfigData<Boolean> powerAffectsHealth;
-	private final ConfigData<Boolean> gravity;
-	private final ConfigData<Boolean> baby;
 	private boolean preventCombust;
+	private final ConfigData<Boolean> baby;
+	private final ConfigData<Boolean> gravity;
+	private final ConfigData<Boolean> powerAffectsHealth;
 
-	private final ConfigData<Double> powerHealthFactor;
-	private final ConfigData<Double> maxHealth;
-	private final ConfigData<Double> health;
 	private double followRange;
 	private double followSpeed;
 	private double maxDistance;
+	private final ConfigData<Double> health;
+	private final ConfigData<Double> maxHealth;
+	private final ConfigData<Double> powerHealthFactor;
 
 	private final ConfigData<Vector> spawnOffset;
 
@@ -90,29 +88,24 @@ public class MinionSpell extends BuffSpell {
 	public MinionSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		minions = new HashMap<>();
-		players = new HashMap<>();
-		targets = new ConcurrentHashMap<>();
-
 		// Formatted as <entity type> <chance>
-		List<String> c = getConfigStringList("mob-chances", new ArrayList<>());
-		if (c.isEmpty()) c.add("Zombie 100");
+		List<String> mobChanceList = getConfigStringList("mob-chances", new ArrayList<>());
+		if (mobChanceList.isEmpty()) mobChanceList.add("Zombie 100");
 
-		creatureTypes = new EntityType[c.size()];
-		chances = new int[c.size()];
-		for (int i = 0; i < c.size(); i++) {
-			String[] data = c.get(i).split(" ");
-			EntityType creatureType = MobUtil.getEntityType(data[0]);
-			int chance = 0;
-			if (creatureType != null) {
-				try {
-					chance = Integer.parseInt(data[1]);
-				} catch (NumberFormatException e) {
-					// No op
-				}
+		for (int i = 0; i < mobChanceList.size(); i++) {
+			String[] splits = mobChanceList.get(i).split(" ");
+
+			EntityType type = MobUtil.getEntityType(splits[0]);
+			if (type == null) {
+				MagicSpells.error("MinionSpell '" + internalName + "' has an invalid Entity Type specified in 'mob-chances' at index " + i + ": " + splits[0]);
+				continue;
 			}
-			creatureTypes[i] = creatureType;
-			chances[i] = chance;
+
+			try {
+				mobChances.put(type, Integer.parseInt(splits[1]));
+			} catch (NumberFormatException ignored) {
+				MagicSpells.error("MinionSpell '" + internalName + "' has an invalid chance value specified in 'mob-chances' at index " + i + ": " + splits[1]);
+			}
 		}
 
 		// Potion effects
@@ -194,22 +187,24 @@ public class MinionSpell extends BuffSpell {
 		leggingsDropChance = getConfigFloat("leggings-drop-chance", 0) / 100F;
 		bootsDropChance = getConfigFloat("boots-drop-chance", 0) / 100F;
 
+		minionName = getConfigString("minion-name", "");
 		spawnSpellName = getConfigString("spell-on-spawn", "");
-		attackSpellName = getConfigString("spell-on-attack", "");
 		deathSpellName = getConfigString("spell-on-death", "");
+		attackSpellName = getConfigString("spell-on-attack", "");
 
 		spawnOffset = getConfigDataVector("spawn-offset", new Vector(1, 0, 0));
-		followRange = getConfigDouble("follow-range", 1.5) * -1;
+
+		health = getConfigDataDouble("health", 20);
 		followSpeed = getConfigDouble("follow-speed", 1);
 		maxDistance = getConfigDouble("max-distance", 30);
-		powerAffectsHealth = getConfigDataBoolean("power-affects-health", false);
-		powerHealthFactor = getConfigDataDouble("power-health-factor", 1);
 		maxHealth = getConfigDataDouble("max-health", 20);
-		health = getConfigDataDouble("health", 20);
-		minionName = getConfigString("minion-name", "");
-		gravity = getConfigDataBoolean("gravity", true);
+		followRange = getConfigDouble("follow-range", 1.5) * -1;
+		powerHealthFactor = getConfigDataDouble("power-health-factor", 1);
+
 		baby = getConfigDataBoolean("baby", false);
+		gravity = getConfigDataBoolean("gravity", true);
 		preventCombust = getConfigBoolean("prevent-sun-burn", true);
+		powerAffectsHealth = getConfigDataBoolean("power-affects-health", false);
 	}
 
 	@Override
@@ -232,43 +227,65 @@ public class MinionSpell extends BuffSpell {
 	public boolean castBuff(SpellData data) {
 		if (!(data.target() instanceof Player target)) return false;
 		// Selecting the mob
-		EntityType creatureType = null;
-		int total = Arrays.stream(chances).sum();
-		int num = random.nextInt(total);
-		int n = 0;
-		for (int i = 0; i < creatureTypes.length; i++) {
-			n += chances[i];
-			if (num >= n) continue;
-			creatureType = creatureTypes[i];
+		EntityType entityType = null;
+		int total = mobChances.values().stream().mapToInt(Integer::intValue).sum();
+		int selected = random.nextInt(total);
+
+		int current = 0;
+		for (Map.Entry<EntityType, Integer> entry : mobChances.entrySet()) {
+			current += entry.getValue();
+			if (selected >= current) continue;
+
+			entityType = entry.getKey();
 			break;
 		}
 
-		if (creatureType == null) return false;
+		if (entityType == null) {
+			MagicSpells.error("MinionSpell '" + internalName + "' is missing entity type!");
+			return false;
+		}
+		Class<? extends Entity> entityClass = entityType.getEntityClass();
+		if (!entityType.isSpawnable() || entityClass == null || !Mob.class.isAssignableFrom(entityClass)) {
+			MagicSpells.error("MinionSpell '" + internalName + "' can only summon mobs!");
+			return false;
+		}
+		//noinspection unchecked
+		Class<? extends Mob> mobClass = (Class<? extends Mob>) entityClass;
 
 		// Spawn location
 		Location loc = target.getLocation().clone();
 		loc.setPitch(0);
-
 		Vector spawnOffset = this.spawnOffset.get(data);
 		loc.add(0, spawnOffset.getY(), 0);
 		Util.applyRelativeOffset(loc, spawnOffset.setY(0));
 
 		// Spawn creature
-		LivingEntity minion = (LivingEntity) target.getWorld().spawnEntity(loc, creatureType);
-		if (!(minion instanceof Mob)) {
-			minion.remove();
-			MagicSpells.error("MinionSpell '" + internalName + "' can only summon mobs!");
-			return false;
-		}
+		Mob minion = target.getWorld().spawn(loc, mobClass, mob -> {
+			prepareMob(mob, target, data);
 
-		if (minion instanceof Ageable ageable) {
+			if (!(mob instanceof Ageable ageable)) return;
 			if (baby.get(data)) ageable.setBaby();
 			else ageable.setAdult();
+		});
+
+		if (spawnSpell != null) {
+			SpellData castData = data.builder().caster(target).target(minion).location(minion.getLocation()).recipient(null).build();
+			spawnSpell.subcast(castData);
 		}
 
+		minions.put(target.getUniqueId(), minion);
+		players.put(minion, target.getUniqueId());
+		return true;
+	}
+
+	private void prepareMob(Mob minion, Player target, SpellData data) {
 		minion.setGravity(gravity.get(data));
-		minion.customName(Util.getMiniMessage(MagicSpells.doReplacements(minionName, target, data, "%c", target.getName())));
-		minion.setCustomNameVisible(true);
+
+		String customName = MagicSpells.doReplacements(minionName, target, data, "%c", target.getName());
+		if (!customName.isEmpty()) {
+			minion.customName(Util.getMiniMessage(customName));
+			minion.setCustomNameVisible(true);
+		}
 
 		double powerHealthFactor = this.powerHealthFactor.get(data);
 		double maxHealth = this.maxHealth.get(data);
@@ -281,15 +298,8 @@ public class MinionSpell extends BuffSpell {
 			minion.setHealth(health);
 		}
 
-		if (spawnSpell != null) {
-			SpellData castData = data.builder().caster(target).target(minion).location(minion.getLocation()).recipient(null).build();
-			spawnSpell.subcast(castData);
-		}
-
-		// Apply potion effects
 		if (potionEffects != null) minion.addPotionEffects(potionEffects);
 
-		// Apply attributes
 		if (attributes != null) {
 			attributes.asMap().forEach((attribute, modifiers) -> {
 				AttributeInstance attributeInstance = minion.getAttribute(attribute);
@@ -299,8 +309,7 @@ public class MinionSpell extends BuffSpell {
 			});
 		}
 
-		// Equip the minion
-		final EntityEquipment eq = minion.getEquipment();
+		EntityEquipment eq = minion.getEquipment();
 		if (mainHandItem != null) eq.setItemInMainHand(mainHandItem.clone());
 		if (offHandItem != null) eq.setItemInOffHand(offHandItem.clone());
 		if (helmet != null) eq.setHelmet(helmet.clone());
@@ -308,17 +317,12 @@ public class MinionSpell extends BuffSpell {
 		if (leggings != null) eq.setLeggings(leggings.clone());
 		if (boots != null) eq.setBoots(boots.clone());
 
-		// Equipment drop chance
 		eq.setItemInMainHandDropChance(mainHandItemDropChance);
 		eq.setItemInOffHandDropChance(offHandItemDropChance);
 		eq.setHelmetDropChance(helmetDropChance);
 		eq.setChestplateDropChance(chestplateDropChance);
 		eq.setLeggingsDropChance(leggingsDropChance);
 		eq.setBootsDropChance(bootsDropChance);
-
-		minions.put(target.getUniqueId(), minion);
-		players.put(minion, target.getUniqueId());
-		return true;
 	}
 
 	@Override
@@ -327,7 +331,7 @@ public class MinionSpell extends BuffSpell {
 	}
 
 	public boolean isMinion(LivingEntity entity) {
-		return minions.containsValue(entity);
+		return minions.values().stream().anyMatch(mob -> mob.getUniqueId().equals(entity.getUniqueId()));
 	}
 
 	@Override
@@ -353,7 +357,7 @@ public class MinionSpell extends BuffSpell {
 		Player pl = Bukkit.getPlayer(players.get(minion));
 		if (pl == null) return;
 
-		if (targets.get(pl.getUniqueId()) == null || !targets.containsKey(pl.getUniqueId()) || !targets.get(pl.getUniqueId()).isValid()) {
+		if (!targets.containsKey(pl.getUniqueId()) || !targets.get(pl.getUniqueId()).isValid()) {
 			e.setCancelled(true);
 			return;
 		}
@@ -450,7 +454,7 @@ public class MinionSpell extends BuffSpell {
 			// Check if the entity can be targeted by the minion
 			if (!minionTargetList.canTarget(pl, entity)) return;
 
-			targets.put(pl.getUniqueId(),entity);
+			targets.put(pl.getUniqueId(), entity);
 			MobUtil.setTarget(minions.get(pl.getUniqueId()), entity);
 			addUseAndChargeCost(pl);
 
@@ -476,7 +480,7 @@ public class MinionSpell extends BuffSpell {
 
 				Location loc = pl.getLocation().clone();
 				loc.add(loc.getDirection().setY(0).normalize().multiply(followRange));
-				((Mob) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
+				minions.get(pl.getUniqueId()).getPathfinder().moveTo(loc, followSpeed);
 			}
 		}
 	}
@@ -524,10 +528,9 @@ public class MinionSpell extends BuffSpell {
 		if (e.getFrom().getBlock().equals(e.getTo().getBlock())) return;
 		Player pl = e.getPlayer();
 		if (!isActive(pl)) return;
-		LivingEntity minion = minions.get(pl.getUniqueId());
+		Mob minion = minions.get(pl.getUniqueId());
 
 		if ((pl.getWorld().equals(minion.getWorld()) && pl.getLocation().distanceSquared(minion.getLocation()) > maxDistance * maxDistance) || targets.get(pl.getUniqueId()) == null || !targets.containsKey(pl.getUniqueId())) {
-
 			// The minion has a target, but he is far away from his owner, remove his current target
 			if (targets.get(pl.getUniqueId()) != null) {
 				targets.remove(pl.getUniqueId());
@@ -537,7 +540,7 @@ public class MinionSpell extends BuffSpell {
 			// The distance between minion and his owner is greater that the defined max distance or the minion has no targets, he will follow his owner
 			Location loc = pl.getLocation().clone();
 			loc.add(loc.getDirection().setY(0).normalize().multiply(followRange));
-			((Mob) minions.get(pl.getUniqueId())).getPathfinder().moveTo(loc, followSpeed);
+			minion.getPathfinder().moveTo(loc, followSpeed);
 		}
 	}
 
@@ -564,7 +567,7 @@ public class MinionSpell extends BuffSpell {
 		}
 	}
 
-	public Map<UUID, LivingEntity> getMinions() {
+	public Map<UUID, Mob> getMinions() {
 		return minions;
 	}
 
@@ -590,14 +593,6 @@ public class MinionSpell extends BuffSpell {
 
 	public void setMinionTargetList(ValidTargetList minionTargetList) {
 		this.minionTargetList = minionTargetList;
-	}
-
-	public EntityType[] getCreatureTypes() {
-		return creatureTypes;
-	}
-
-	public void setCreatureTypes(EntityType[] creatureTypes) {
-		this.creatureTypes = creatureTypes;
 	}
 
 	public boolean shouldPreventCombust() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ext/DisguiseSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ext/DisguiseSpell.java
@@ -7,7 +7,6 @@ import org.jetbrains.annotations.NotNull;
 import org.bukkit.DyeColor;
 import org.bukkit.entity.Villager;
 import org.bukkit.entity.LivingEntity;
-import org.bukkit.inventory.ItemStack;
 
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.DependsOn;
@@ -151,7 +150,7 @@ public class DisguiseSpell extends BuffSpell {
 			creeperWatcher.setPowered(entityData.getPowered().get(data));
 
 		if (watcher instanceof DroppedItemWatcher droppedItemWatcher)
-			droppedItemWatcher.setItemStack(new ItemStack(entityData.getDroppedItemStack().get(data)));
+			droppedItemWatcher.setItemStack(entityData.getDroppedItemStack().get(data));
 
 		if (watcher instanceof EndermanWatcher endermanWatcher)
 			endermanWatcher.setItemInMainHand(entityData.getCarriedBlockData().get(data).getMaterial());

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -33,7 +33,6 @@ import org.bukkit.event.entity.EntityTargetLivingEntityEvent;
 
 import net.kyori.adventure.text.Component;
 
-import com.destroystokyo.paper.entity.ai.MobGoals;
 import com.destroystokyo.paper.event.entity.EntityRemoveFromWorldEvent;
 
 import com.nisovin.magicspells.util.*;
@@ -185,11 +184,11 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		setOwner = getConfigDataBoolean("set-owner", true);
 		removeAI = getConfigDataBoolean("remove-ai", false);
 		invulnerable = getConfigDataBoolean("invulnerable", false);
+		cancelAttack = getConfigDataBoolean("cancel-attack", true);
 		useCasterName = getConfigDataBoolean("use-caster-name", false);
 		centerLocation = getConfigDataBoolean("center-location", false);
 		addLookAtPlayerAI = getConfigDataBoolean("add-look-at-player-ai", false);
 		allowSpawnInMidair = getConfigDataBoolean("allow-spawn-in-midair", false);
-		cancelAttack = getConfigDataBoolean("cancel-attack", true);
 
 		attackSpellName = getConfigString("attack-spell", "");
 		spellOnSpawnName = getConfigString("spell-on-spawn", "");
@@ -547,10 +546,8 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 
 			if (removeAI.get(data)) {
 				if (addLookAtPlayerAI.get(data) && livingEntity instanceof Mob mob) {
-					MobGoals mobGoals = Bukkit.getMobGoals();
-
-					mobGoals.removeAllGoals(mob);
-					mobGoals.addGoal(mob, 1, new LookAtEntityTypeGoal(mob, data));
+					Bukkit.getMobGoals().removeAllGoals(mob);
+					Bukkit.getMobGoals().addGoal(mob, 1, new LookAtEntityTypeGoal(mob, data));
 				} else livingEntity.setAI(false);
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -440,7 +440,10 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		}
 
 		SpellData finalData = data;
-		Entity entity = entityData.spawn(loc, data, mob -> prepMob(mob, finalData));
+		Entity entity = entityData.spawn(loc, data,
+			mob -> prepMob(mob, finalData),
+			mob -> mob.setPersistent(!removeMob)
+		);
 		if (entity == null) return noTarget(data);
 
 		UUID uuid = entity.getUniqueId();
@@ -484,8 +487,6 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 	}
 
 	private void prepMob(Entity entity, SpellData data) {
-		if (removeMob) entity.setPersistent(false);
-
 		entity.setGravity(gravity.get(data));
 		entity.setInvulnerable(invulnerable.get(data));
 

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -474,7 +474,7 @@ public class EntityData {
 			Class<? extends Entity> entityClass = entityType.getEntityClass();
 			if (entityClass == null) continue;
 
-			for (Class<?> transformerType : transformers.keys())
+			for (Class<?> transformerType : transformers.keySet())
 				if (transformerType.isAssignableFrom(entityClass))
 					options.putAll(entityType, transformers.get(transformerType));
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -85,7 +85,7 @@ public class EntityData {
 	private final ConfigData<Horse.Style> horseStyle;
 
 	// Item
-	private final ConfigData<Material> dropItemMaterial;
+	private final ConfigData<ItemStack> dropItem;
 
 	// Llama
 	private final ConfigData<Llama.Color> llamaColor;
@@ -274,7 +274,10 @@ public class EntityData {
 		);
 
 		// Item
-		dropItemMaterial = addOptMaterial(transformers, config, "material", Item.class, (item, material) -> item.setItemStack(new ItemStack(material)));
+		dropItem = fallback(
+			key -> addOptItemStack(transformers, config, key, Item.class, Item::setItemStack),
+			"material", "item"
+		);
 
 		addOptInteger(transformers, config, "pickup-delay", Item.class, Item::setPickupDelay);
 
@@ -714,17 +717,20 @@ public class EntityData {
 		return supplier;
 	}
 
-	private <T> void addOptItemStack(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, ItemStack> setter) {
+	private <T> ConfigData<ItemStack> addOptItemStack(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, ItemStack> setter) {
 		ConfigData<String> supplier = ConfigDataUtil.getString(config, name, null);
 		if (supplier.isConstant()) {
 			ItemStack item = getItemStack(supplier.get());
-			if (item == null) return;
+			if (item == null) return data -> null;
 
 			transformers.put(type, new TransformerImpl<>(data -> item, setter, true));
-			return;
+			return data -> item;
 		}
 
-		transformers.put(type, new TransformerImpl<>(data -> getItemStack(supplier.get(data)), setter, true));
+		ConfigData<ItemStack> itemSupplier = data -> getItemStack(supplier.get(data));
+		transformers.put(type, new TransformerImpl<>(itemSupplier, setter, true));
+
+		return itemSupplier;
 	}
 
 	private ItemStack getItemStack(String string) {
@@ -1029,8 +1035,8 @@ public class EntityData {
 	}
 
 	@ApiStatus.Internal
-	public ConfigData<Material> getDroppedItemStack() {
-		return dropItemMaterial;
+	public ConfigData<ItemStack> getDroppedItemStack() {
+		return dropItem;
 	}
 
 	@ApiStatus.Internal

--- a/core/src/main/java/com/nisovin/magicspells/util/ai/goals/PathToGoal.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/ai/goals/PathToGoal.java
@@ -35,7 +35,7 @@ public class PathToGoal extends CustomGoal {
 	@Override
 	public boolean initialize(@Nullable ConfigurationSection config) {
 		if (config == null) return false;
-		speed = ConfigDataUtil.getDouble(config, "speed", 0.2);
+		speed = ConfigDataUtil.getDouble(config, "speed", 1);
 		position = ConfigDataUtil.getVector(config, "position", new Vector());
 		distanceAllowed = ConfigDataUtil.getDouble(config, "distance-allowed", 1);
 		return true;


### PR DESCRIPTION
## Changelog:

### Additions:

- Added `minion` option to `MinionSpell` which accepts an [Entity Data](https://github.com/TheComputerGeek2/MagicSpells/wiki/Entity-Data) configuration section. Due to conflicts, if `minion` is used, `baby` has to be configured within it, not the spell option.
- New Entity Data options:
  - [Nameable](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/class-use/Nameable.html):
    - `custom-name` - [Rich Text](https://github.com/TheComputerGeek2/MagicSpells/wiki/Expression#rich-text)
  - [Entity](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/Entity.html):
    - `custom-name-visible` - Boolean
  - `item`:
    - `item` - [Vanilla item format](https://minecraft.wiki/w/Argument_types#item_stack) or [Magic Item String](https://github.com/TheComputerGeek2/MagicSpells/wiki/Magic-Item-String)



### Changes:

- Entity Data changes:
  - Spells and spell effect options no longer override the Entity Data configuration with their defaults (e.g. in `SpawnEntitySpell`, the `gravity` of Entity Data is overridden by the spell's `gravity`, whether set or left as default).
  - The `armorstand` spell effect options `gravity` and `custom-name-visibility` now support expressions.



### Fixes:

- Fixed a rounding issue with `MultiSpell` when using `enable-custom-spell-cast-chance`.
- Fixed an issue with `MinionSpell` option `mob-chances` not properly accounting for weighted probability total being `> 100`.
- Fixed an issue with the `path_to` mob goal default speed being too slow.



---
## Notes For Reviewers:

Entity "transformer" refers to any setter on a Bukkit entity. Here are the steps taken on spell/effect transformers regarding the Entity Data override fix for places where Entity Data is supported:
- If the spell transformer should be hard-coded (e.g. spell effect entity permanence), or its default differs from Vanilla (e.g. `SpawnEntitySpell`'s `remove-mob` should always have priority), it will keep priority over the one in Entity Data and be applied in the post-consumer.
- If the Entity Data transformer is optional, the spell transformer is now set in the pre-consumer, so that Entity Data may optionally override it.
- If the spell default aligns with Entity Data (Vanilla):
    - If it's read from the same config path, it was safely removed as a duplicate (e.g. `silent` and `ai` in `entity` spell effect).
    - If the Entity Data one is not optional, the spell option has been deprecated to avoid conflicts (conflict only happens with `baby` in `MinionSpell` if `entity` Entity Data is used).
 