### PR TITLE
Entity Data additions

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/listeners/MagicSpellListener.java
@@ -6,12 +6,17 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.entity.EntityDamageEvent;
+import org.bukkit.event.entity.EntityRemoveEvent;
+import org.bukkit.event.entity.EntityDismountEvent;
+import org.bukkit.persistence.PersistentDataContainer;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.inventory.InventoryPickupItemEvent;
 
 import com.nisovin.magicspells.Perm;
 import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.EntityData;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.spelleffects.effecttypes.*;
@@ -57,6 +62,26 @@ public class MagicSpellListener implements Listener {
 		Entity entity = event.getEntity();
 		if (!isMSEntity(entity)) return;
 		event.setCancelled(true);
+	}
+
+	@EventHandler
+	public void onEntityRemove(EntityRemoveEvent event) {
+		Util.forEachPassenger(event.getEntity(), passenger -> {
+			PersistentDataContainer container = passenger.getPersistentDataContainer();
+			if (!container.has(EntityData.MS_PASSENGER)) return;
+
+			if (passenger.isPersistent()) {
+				container.remove(EntityData.MS_PASSENGER);
+				return;
+			}
+
+			passenger.remove();
+		});
+	}
+
+	@EventHandler
+	public void onEntityDismount(EntityDismountEvent event) {
+		event.getEntity().getPersistentDataContainer().remove(EntityData.MS_PASSENGER);
 	}
 
 	private boolean isMSEntity(Entity entity) {

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
@@ -23,6 +23,7 @@ public class ArmorStandEffect extends SpellEffect {
 	private EntityData entityData;
 
 	private ConfigData<Boolean> gravity;
+	private ConfigData<Boolean> disableSlots;
 
 	private ItemStack headItem;
 	private ItemStack offhandItem;
@@ -36,6 +37,7 @@ public class ArmorStandEffect extends SpellEffect {
 		entityData = new EntityData(section);
 
 		gravity = ConfigDataUtil.getBoolean(section, "gravity", false);
+		disableSlots = ConfigDataUtil.getBoolean(section, "disable-slots", true);
 
 		MagicItem item = MagicItems.getMagicItemFromString(section.getString("head"));
 		if (item != null) headItem = item.getItemStack();
@@ -54,6 +56,7 @@ public class ArmorStandEffect extends SpellEffect {
 			stand.addScoreboardTag(ENTITY_TAG);
 
 			stand.setGravity(gravity.get(data));
+			if (disableSlots.get(data)) stand.setDisabledSlots(EquipmentSlot.values());
 
 			stand.setItem(EquipmentSlot.HEAD, headItem);
 			stand.setItem(EquipmentSlot.HAND, mainhandItem);

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ArmorStandEffect.java
@@ -7,6 +7,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.EntityData;
 import com.nisovin.magicspells.util.config.ConfigData;
@@ -61,7 +62,10 @@ public class ArmorStandEffect extends SpellEffect {
 			stand.setItem(EquipmentSlot.HEAD, headItem);
 			stand.setItem(EquipmentSlot.HAND, mainhandItem);
 			stand.setItem(EquipmentSlot.OFF_HAND, offhandItem);
-		}, stand -> stand.setPersistent(false));
+		}, stand -> {
+			stand.setPersistent(false);
+			Util.forEachPassenger(stand, e -> e.setPersistent(false));
+		});
 	}
 
 }

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/EntityEffect.java
@@ -8,6 +8,7 @@ import org.bukkit.entity.Entity;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.EntityData;
@@ -45,7 +46,10 @@ public class EntityEffect extends SpellEffect {
 		return entityData.spawn(location, data, entity -> {
 			entity.addScoreboardTag(ENTITY_TAG);
 			entity.setGravity(gravity.get(data));
-		}, entity -> entity.setPersistent(false));
+		}, entity -> {
+			entity.setPersistent(false);
+			Util.forEachPassenger(entity, e -> e.setPersistent(false));
+		});
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/MinionSpell.java
@@ -287,7 +287,10 @@ public class MinionSpell extends BuffSpell {
 			if (baby.get(data)) ageable.setBaby();
 			else ageable.setAdult();
 		});
-		else minion = entityData.spawn(loc, data, mobClass, mob -> prepareMob(mob, target, data), null);
+		else minion = entityData.spawn(loc, data, mobClass, mob -> prepareMob(mob, target, data), mob -> {
+			mob.setPersistent(false);
+			Util.forEachPassenger(mob, e -> e.setPersistent(false));
+		});
 
 		if (spawnSpell != null) {
 			SpellData castData = data.builder().caster(target).target(minion).location(minion.getLocation()).recipient(null).build();

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ApplyEntityDataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ApplyEntityDataSpell.java
@@ -1,0 +1,35 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+
+public class ApplyEntityDataSpell extends TargetedSpell implements TargetedEntitySpell {
+
+	private final EntityData entityData;
+
+	public ApplyEntityDataSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		entityData = new EntityData(getConfigSection("entity"), true);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		TargetInfo<LivingEntity> info = getTargetedEntity(data);
+		if (info.noTarget()) return noTarget(info);
+
+		return castAtEntity(info.spellData());
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		entityData.apply(data.target(), data);
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityRemoveSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/EntityRemoveSpell.java
@@ -1,0 +1,34 @@
+package com.nisovin.magicspells.spells.targeted;
+
+import org.bukkit.entity.Player;
+import org.bukkit.entity.LivingEntity;
+
+import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.spells.TargetedSpell;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+
+public class EntityRemoveSpell extends TargetedSpell implements TargetedEntitySpell {
+
+	public EntityRemoveSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		TargetInfo<LivingEntity> info = getTargetedEntity(data);
+		if (info.noTarget()) return noTarget(info);
+
+		return castAtEntity(info.spellData());
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		if (data.target() instanceof Player) return noTarget(data);
+
+		data.target().remove();
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/SpawnEntitySpell.java
@@ -439,10 +439,11 @@ public class SpawnEntitySpell extends TargetedSpell implements TargetedLocationS
 		}
 
 		SpellData finalData = data;
-		Entity entity = entityData.spawn(loc, data,
-			mob -> prepMob(mob, finalData),
-			mob -> mob.setPersistent(!removeMob)
-		);
+		Entity entity = entityData.spawn(loc, data, mob -> prepMob(mob, finalData), mob -> {
+			if (!removeMob) return;
+			mob.setPersistent(false);
+			Util.forEachPassenger(mob, e -> e.setPersistent(false));
+		});
 		if (entity == null) return noTarget(data);
 
 		UUID uuid = entity.getUniqueId();

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -4,10 +4,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.jetbrains.annotations.ApiStatus;
 
-import java.util.Map;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Collection;
+import java.util.*;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.BiConsumer;
@@ -18,30 +15,43 @@ import org.joml.Quaternionf;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.MultimapBuilder;
 
+import net.kyori.adventure.util.TriState;
 import net.kyori.adventure.text.Component;
+
+import com.destroystokyo.paper.SkinParts;
+import com.destroystokyo.paper.entity.ai.Goal;
+import com.destroystokyo.paper.entity.ai.GoalKey;
+import com.destroystokyo.paper.entity.ai.GoalType;
 
 import org.bukkit.*;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
 import org.bukkit.util.EulerAngle;
+import org.bukkit.inventory.MainHand;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.util.Transformation;
 import org.bukkit.potion.PotionEffect;
 import org.bukkit.block.data.BlockData;
+import org.bukkit.profile.PlayerTextures;
 import org.bukkit.attribute.Attributable;
 import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.configuration.ConfigurationSection;
 
+import io.papermc.paper.entity.Frictional;
 import io.papermc.paper.registry.RegistryKey;
 import io.papermc.paper.entity.CollarColorable;
 import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.world.WeatheringCopperState;
+import io.papermc.paper.datacomponent.item.ResolvableProfile;
 import io.papermc.paper.threadedregions.scheduler.ScheduledTask;
 
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.ai.CustomGoal;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.util.config.FunctionData;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
@@ -116,6 +126,7 @@ public class EntityData {
 		this(config, false);
 	}
 
+	@SuppressWarnings("UnstableApiUsage")
 	public EntityData(ConfigurationSection config, boolean forceOptional) {
 		entityType = ConfigDataUtil.getEntityType(config, "entity", null);
 
@@ -129,8 +140,16 @@ public class EntityData {
 		addOptBoolean(transformers, config, "silent", Entity.class, Entity::setSilent);
 		addOptBoolean(transformers, config, "glowing", Entity.class, Entity::setGlowing);
 		addOptBoolean(transformers, config, "gravity", Entity.class, Entity::setGravity);
+		addOptBoolean(transformers, config, "no-physics", Entity.class, Entity::setNoPhysics);
+		addOptBoolean(transformers, config, "persistent", Entity.class, Entity::setPersistent);
+		addOptBoolean(transformers, config, "invulnerable", Entity.class, Entity::setInvulnerable);
 		addOptBoolean(transformers, config, "visible-by-default", Entity.class, Entity::setVisibleByDefault);
 		addOptBoolean(transformers, config, "custom-name-visible", Entity.class, Entity::setCustomNameVisible);
+
+		addOptEnum(transformers, config, "visual-fire", Entity.class, TriState.class, Entity::setVisualFire);
+
+		addOptInteger(transformers, config, "fire-ticks", Entity.class, Entity::setFireTicks);
+		addOptInteger(transformers, config, "freeze-ticks", Entity.class, Entity::setFreezeTicks);
 
 		addOptVector(transformers, config, "velocity", Entity.class, Entity::setVelocity);
 
@@ -169,6 +188,10 @@ public class EntityData {
 
 		// LivingEntity
 		addOptBoolean(transformers, config, "ai", LivingEntity.class, LivingEntity::setAI);
+		addOptBoolean(transformers, config, "can-pickup-items", LivingEntity.class, LivingEntity::setCanPickupItems);
+
+		addOptDouble(transformers, config, "max-health", LivingEntity.class, Util::setMaxHealth);
+
 		addOptEquipment(transformers, config, "equipment.main-hand", EquipmentSlot.HAND);
 		addOptEquipment(transformers, config, "equipment.off-hand", EquipmentSlot.OFF_HAND);
 		addOptEquipment(transformers, config, "equipment.helmet", EquipmentSlot.HEAD);
@@ -185,6 +208,8 @@ public class EntityData {
 		}
 
 		// Mob
+		addOptBoolean(transformers, config, "aware", Mob.class, Mob::setAware);
+
 		addOptEquipmentDropChance(transformers, config, "equipment.main-hand-drop-chance", EquipmentSlot.HAND);
 		addOptEquipmentDropChance(transformers, config, "equipment.off-hand-drop-chance", EquipmentSlot.OFF_HAND);
 		addOptEquipmentDropChance(transformers, config, "equipment.helmet-drop-chance", EquipmentSlot.HEAD);
@@ -195,6 +220,12 @@ public class EntityData {
 
 		// Tameable
 		tamed = addBoolean(transformers, config, "tamed", false, Tameable.class, Tameable::setTamed, forceOptional);
+		if (config.getBoolean("tamed-owner")) {
+			transformers.put(Tameable.class, (Tameable tameable, SpellData data) -> {
+				if (!(data.recipient() instanceof AnimalTamer tamer)) return;
+				tameable.setOwner(tamer);
+			});
+		}
 
 		// AbstractHorse
 		saddled = addBoolean(transformers, config, "saddled", false, AbstractHorse.class, (horse, saddled) -> {
@@ -257,11 +288,33 @@ public class EntityData {
 			"cat-variant", "type"
 		);
 
+		// Chicken
+		addOptRegistryEntry(transformers, config, "chicken-variant", Chicken.class, RegistryKey.CHICKEN_VARIANT, Chicken::setVariant);
+
+		// Copper Golem
+		addOptEnum(transformers, config, "copper-golem.weathering-state", CopperGolem.class, WeatheringCopperState.class, CopperGolem::setWeatheringState);
+		addOptLong(transformers, config, "copper-golem.oxidizing", CopperGolem.class, (golem, next) -> {
+			long time = golem.getWorld().getGameTime() + next;
+			golem.setOxidizing(CopperGolem.Oxidizing.atTime(time));
+		});
+		addOptString(transformers, config, "copper-golem.oxidizing", CopperGolem.class, (golem, value) -> {
+			switch (value) {
+				case "unset" -> golem.setOxidizing(CopperGolem.Oxidizing.unset());
+				case "waxed" -> golem.setOxidizing(CopperGolem.Oxidizing.waxed());
+			}
+		});
+
 		// CollarColorable
 		fallback(
 			key -> addOptEnum(transformers, config, key, CollarColorable.class, DyeColor.class, CollarColorable::setCollarColor),
 			"collar-color", "color"
 		);
+
+		// CommandMinecart
+		addOptString(transformers, config, "command", CommandMinecart.class, CommandMinecart::setCommand);
+
+		// Cow
+		addOptRegistryEntry(transformers, config, "cow-variant", Cow.class, RegistryKey.COW_VARIANT, Cow::setVariant);
 
 		// ChestedHorse
 		chested = addBoolean(transformers, config, "chested", false, ChestedHorse.class, ChestedHorse::setCarryingChest, forceOptional);
@@ -281,17 +334,36 @@ public class EntityData {
 			"falling-block", "material"
 		);
 
+		addOptBoolean(transformers, config, "cancel-drop", FallingBlock.class, FallingBlock::setCancelDrop);
+		addOptBoolean(transformers, config, "hurt-entities", FallingBlock.class, FallingBlock::setHurtEntities);
+
+		addOptFloat(transformers, config, "damage-per-block", FallingBlock.class, FallingBlock::setDamagePerBlock);
+
+		addOptInteger(transformers, config, "max-damage", FallingBlock.class, FallingBlock::setMaxDamage);
+
 		// Fox
 		fallback(
 			key -> addOptEnum(transformers, config, key, Fox.class, Fox.Type.class, Fox::setFoxType),
 			"fox-type", "type"
 		);
 
+		// Frictional
+		addOptEnum(transformers, config, "friction-state", Frictional.class, TriState.class, Frictional::setFrictionState);
+
 		// Frog
 		fallback(
 			key -> addOptRegistryEntry(transformers, config, key, Frog.class, RegistryKey.FROG_VARIANT, Frog::setVariant),
 			"frog-variant", "type"
 		);
+
+		// Goat
+		addOptBoolean(transformers, config, "left-horn", Goat.class, Goat::setLeftHorn);
+		addOptBoolean(transformers, config, "right-horn", Goat.class, Goat::setRightHorn);
+		addOptBoolean(transformers, config, "screaming", Goat.class, Goat::setScreaming);
+
+		// Hoglin
+		addOptBoolean(transformers, config, "immune-to-zombification", Hoglin.class, Hoglin::setImmuneToZombification);
+		addOptBoolean(transformers, config, "able-to-be-hunted", Hoglin.class, Hoglin::setIsAbleToBeHunted);
 
 		// Horse
 		horseColor = fallback(
@@ -330,6 +402,57 @@ public class EntityData {
 			"llama-decor", "material"
 		);
 
+		// Mannequin
+		addOptBoolean(transformers, config, "mannequin.immovable", Mannequin.class, Mannequin::setImmovable);
+
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.cape", SkinParts.Mutable::setCapeEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.jacket", SkinParts.Mutable::setJacketEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.left-sleeve", SkinParts.Mutable::setLeftSleeveEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.right-sleeve", SkinParts.Mutable::setRightSleeveEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.left-pants", SkinParts.Mutable::setLeftPantsEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.right-pants", SkinParts.Mutable::setRightPantsEnabled);
+		addOptSkinParts(transformers, config, "mannequin.skin-parts.hats", SkinParts.Mutable::setHatsEnabled);
+
+		addComponent(transformers, config, "mannequin.description", Mannequin.class, Mannequin::setDescription, null, forceOptional);
+
+		addOptEnum(transformers, config, "mannequin.main-hand", Mannequin.class, MainHand.class, Mannequin::setMainHand);
+
+		// noinspection PatternValidation
+		ConfigData<String> mannequinName = ConfigDataUtil.getString(config, "mannequin.profile.name", null);
+		ConfigData<UUID> mannequinId = ConfigDataUtil.getUniqueID(config, "mannequin.profile.uuid", null);
+		ConfigData<NamespacedKey> mannequinBody = ConfigDataUtil.getNamespacedKey(config, "mannequin.profile.body", null);
+		ConfigData<NamespacedKey> mannequinCape = ConfigDataUtil.getNamespacedKey(config, "mannequin.profile.cape", null);
+		ConfigData<NamespacedKey> mannequinElytra = ConfigDataUtil.getNamespacedKey(config, "mannequin.profile.elytra", null);
+		ConfigData<PlayerTextures.SkinModel> mannequinModel = ConfigDataUtil.getEnum(config, "mannequin.profile.model", PlayerTextures.SkinModel.class, null);
+		ConfigData<ResolvableProfile> mannequinProfile = data -> {
+			try {
+				// noinspection PatternValidation
+				return ResolvableProfile.resolvableProfile()
+					.name(mannequinName.get(data))
+					.uuid(mannequinId.get(data))
+					.skinPatch(builder -> {
+						builder.body(mannequinBody.get(data));
+						builder.cape(mannequinCape.get(data));
+						builder.elytra(mannequinElytra.get(data));
+						builder.model(mannequinModel.get(data));
+					})
+					.build();
+			} catch (IllegalArgumentException e) {
+				return null;
+			}
+		};
+
+		transformers.put(Mannequin.class, new TransformerImpl<>(mannequinProfile, Mannequin::setProfile, true));
+
+		// Minecart
+		addOptDouble(transformers, config, "max-speed", Minecart.class, Minecart::setMaxSpeed);
+
+		addOptBoolean(transformers, config, "slow-when-empty", Minecart.class, Minecart::setSlowWhenEmpty);
+
+		addOptInteger(transformers, config, "display-block-offset", Minecart.class, Minecart::setDisplayBlockOffset);
+
+		addOptBlockData(transformers, config, "display-block", Minecart.class, Minecart::setDisplayBlockData);
+
 		// Mushroom Cow
 		fallback(
 			key -> addOptEnum(transformers, config, key, MushroomCow.class, MushroomCow.Variant.class, MushroomCow::setVariant),
@@ -350,6 +473,13 @@ public class EntityData {
 		addInteger(transformers, config, "size", 0, Phantom.class, Phantom::setSize, forceOptional);
 		addOptBoolean(transformers, config, "should-burn-in-day", Phantom.class, Phantom::setShouldBurnInDay);
 
+		// Piglin
+		addOptBoolean(transformers, config, "able-to-hunt", Piglin.class, Piglin::setIsAbleToHunt);
+		addOptInteger(transformers, config, "dancing", Piglin.class, Piglin::setDancing);
+
+		// Piglin Abstract
+		addOptBoolean(transformers, config, "immune-to-zombification", PiglinAbstract.class, PiglinAbstract::setImmuneToZombification);
+
 		// Puffer Fish
 		size = addInteger(transformers, config, "size", 0, PufferFish.class, PufferFish::setPuffState, forceOptional);
 
@@ -358,6 +488,11 @@ public class EntityData {
 			key -> addOptEnum(transformers, config, key, Rabbit.class, Rabbit.Type.class, Rabbit::setRabbitType),
 			"rabbit-type", "type"
 		);
+
+		// Raider
+		addOptBoolean(transformers, config, "patrol-leader", Raider.class, Raider::setPatrolLeader);
+		addOptBoolean(transformers, config, "can-join-raid", Raider.class, Raider::setCanJoinRaid);
+		addOptBoolean(transformers, config, "celebrating", Raider.class, Raider::setCelebrating);
 
 		// Sheep
 		sheared = addBoolean(transformers, config, "sheared", false, Sheep.class, Sheep::setSheared, forceOptional);
@@ -395,6 +530,9 @@ public class EntityData {
 			"tropical-fish.pattern", "type"
 		);
 
+		// Salmon
+		addOptEnum(transformers, config, "salmon-variant", Salmon.class, Salmon.Variant.class, Salmon::setVariant);
+
 		// Villager
 		profession = fallback(
 			key -> addOptRegistryEntry(transformers, config, key, Villager.class, Registry.VILLAGER_PROFESSION, Villager::setProfession),
@@ -402,12 +540,19 @@ public class EntityData {
 		);
 		addOptRegistryEntry(transformers, config, "villager-type", Villager.class, Registry.VILLAGER_TYPE, Villager::setVillagerType);
 
+		// Vindicator
+		addOptBoolean(transformers, config, "johnny", Vindicator.class, Vindicator::setJohnny);
+
 		// Wolf
 		addBoolean(transformers, config, "angry", false, Wolf.class, Wolf::setAngry, forceOptional);
 		addOptRegistryEntry(transformers, config, "wolf-variant", Wolf.class, RegistryKey.WOLF_VARIANT, Wolf::setVariant);
 
 		// Zombie
 		addOptBoolean(transformers, config, "should-burn-in-day", Zombie.class, Zombie::setShouldBurnInDay);
+
+		// Zombie Villager
+		addOptRegistryEntry(transformers, config, "villager-profession", ZombieVillager.class, Registry.VILLAGER_PROFESSION, ZombieVillager::setVillagerProfession);
+		addOptRegistryEntry(transformers, config, "villager-type", ZombieVillager.class, Registry.VILLAGER_TYPE, ZombieVillager::setVillagerType);
 
 		// Display
 		ConfigData<Quaternionf> leftRotation = getQuaternion(config, "transformation.left-rotation");
@@ -499,6 +644,77 @@ public class EntityData {
 		addOptBoolean(transformers, config, "default-background", TextDisplay.class, TextDisplay::setDefaultBackground);
 		addOptEnum(transformers, config, "alignment", TextDisplay.class, TextDisplay.TextAlignment.class, TextDisplay::setAlignment);
 
+		// Mob Goals
+		ConfigurationSection mobGoals = config.getConfigurationSection("mob-goals");
+		if (mobGoals != null) {
+			if (mobGoals.getBoolean("remove-all"))
+				transformers.put(Mob.class, (Mob mob, SpellData data) -> Bukkit.getMobGoals().removeAllGoals(mob));
+
+			for (String string : mobGoals.getStringList("remove-types")) {
+				ConfigData<GoalType> typeData = ConfigDataUtil.getEnum(string, GoalType.class, null);
+
+				transformers.put(Mob.class, (Mob mob, SpellData data) -> {
+					GoalType type = typeData.get(data);
+					if (type == null) return;
+
+					Bukkit.getMobGoals().removeAllGoals(mob, type);
+				});
+			}
+
+			for (String string : mobGoals.getStringList("remove")) {
+				ConfigData<NamespacedKey> keyData = ConfigDataUtil.getNamespacedKey(string, null);
+
+				transformers.put(Mob.class, (Mob mob, SpellData data) -> {
+					NamespacedKey key = keyData.get(data);
+					if (key == null) return;
+
+					Bukkit.getMobGoals().removeGoal(mob, GoalKey.of(Mob.class, key));
+				});
+			}
+
+			for (String string : mobGoals.getStringList("remove-vanilla")) {
+				ConfigData<String> stringData = ConfigDataUtil.getString(string);
+
+				transformers.put(Mob.class, (Mob mob, SpellData data) -> {
+					String value = stringData.get(data);
+					if (value == null) return;
+
+					GoalKey<?> key = MagicSpells.getCustomGoalsManager().getVanillaGoal(value);
+					if (key == null) return;
+
+					// We have to loop through because casting to parameter types is tricky.
+					// It loops through on each MobGoals#removeGoal call anyway.
+					for (Goal<@NotNull Mob> goal : Bukkit.getMobGoals().getAllGoals(mob)) {
+						if (!goal.getKey().equals(key)) continue;
+						Bukkit.getMobGoals().removeGoal(mob, goal);
+					}
+				});
+			}
+
+			for (Object object : mobGoals.getList("add", new ArrayList<>())) {
+				if (!(object instanceof Map<?, ?> map)) continue;
+				ConfigurationSection section = ConfigReaderUtil.mapToSection(map);
+
+				ConfigData<Integer> priorityData = ConfigDataUtil.getInteger(section, "priority", 0);
+				ConfigData<String> goalNameData = ConfigDataUtil.getString(section, "goal", "");
+
+				ConfigurationSection goalSection = section.getConfigurationSection("data");
+				if (goalSection == null) continue;
+
+				transformers.put(Mob.class, (Mob mob, SpellData data) -> {
+					int priority = priorityData.get(data);
+					String goalName = goalNameData.get(data);
+
+					CustomGoal goal = MagicSpells.getCustomGoalsManager().getGoal(goalName, mob, data);
+					if (goal == null) return;
+
+					boolean success = goal.initialize(goalSection);
+					if (success) Bukkit.getMobGoals().addGoal(mob, priority, goal);
+				});
+			}
+		}
+
+		// Apply transformers
 		for (EntityType entityType : EntityType.values()) {
 			Class<? extends Entity> entityClass = entityType.getEntityClass();
 			if (entityClass == null) continue;
@@ -508,6 +724,7 @@ public class EntityData {
 					options.putAll(entityType, transformers.get(transformerType));
 		}
 
+		// Delayed Entity Data
 		List<?> delayedDataEntries = config.getList("delayed-entity-data");
 		if (delayedDataEntries == null || delayedDataEntries.isEmpty()) return;
 
@@ -701,6 +918,11 @@ public class EntityData {
 		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
 	}
 
+	private <T> void addOptLong(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, Long> setter) {
+		ConfigData<Long> supplier = ConfigDataUtil.getLong(config, name);
+		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
+	}
+
 	private <T> void addOptFloat(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, Float> setter) {
 		ConfigData<Float> supplier = ConfigDataUtil.getFloat(config, name);
 		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
@@ -708,6 +930,11 @@ public class EntityData {
 
 	private <T> void addOptDouble(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, Double> setter) {
 		ConfigData<Double> supplier = ConfigDataUtil.getDouble(config, name);
+		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
+	}
+
+	private <T> void addOptString(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, String> setter) {
+		ConfigData<String> supplier = ConfigDataUtil.getString(config, name, null);
 		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
 	}
 
@@ -738,6 +965,18 @@ public class EntityData {
 	private <T> void addOptComponent(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, Component> setter) {
 		ConfigData<Component> supplier = ConfigDataUtil.getComponent(config, name, null);
 		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
+	}
+
+	private <T> void addComponent(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, Component> setter, Component def, boolean forceOptional) {
+		ConfigData<Component> supplier;
+
+		if (forceOptional) {
+			supplier = ConfigDataUtil.getComponent(config, name, null);
+			transformers.put(type, new TransformerImpl<>(supplier, setter, true));
+		} else {
+			supplier = ConfigDataUtil.getComponent(config, name, def);
+			transformers.put(type, new TransformerImpl<>(supplier, setter));
+		}
 	}
 
 	private <T> ConfigData<BlockData> addOptBlockData(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, BlockData> setter) {
@@ -788,10 +1027,18 @@ public class EntityData {
 		});
 	}
 
-	private <T> void addOptEquipmentDropChance(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, EquipmentSlot slot) {
+	private void addOptEquipmentDropChance(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, EquipmentSlot slot) {
 		addOptFloat(transformers, config, name, Mob.class, (entity, chance) -> {
 			EntityEquipment equipment = entity.getEquipment();
 			equipment.setDropChance(slot, chance);
+		});
+	}
+
+	private void addOptSkinParts(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, BiConsumer<SkinParts.Mutable, Boolean> setter) {
+		addOptBoolean(transformers, config, name, Mannequin.class, (mannequin, bool) -> {
+			SkinParts.Mutable parts = mannequin.getSkinParts();
+			setter.accept(parts, bool);
+			mannequin.setSkinParts(parts);
 		});
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -39,6 +39,7 @@ import org.bukkit.inventory.EquipmentSlot;
 import org.bukkit.inventory.EntityEquipment;
 import org.bukkit.attribute.AttributeInstance;
 import org.bukkit.attribute.AttributeModifier;
+import org.bukkit.persistence.PersistentDataType;
 import org.bukkit.entity.minecart.CommandMinecart;
 import org.bukkit.configuration.ConfigurationSection;
 
@@ -60,6 +61,8 @@ import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.itemreader.AttributeHandler;
 
 public class EntityData {
+
+	public static final NamespacedKey MS_PASSENGER = new NamespacedKey(MagicSpells.getInstance(), "entity_passenger");
 
 	private final Multimap<EntityType, Transformer<?>> options = MultimapBuilder.enumKeys(EntityType.class).arrayListValues().build();
 	private final List<DelayedEntityData> delayedEntityData = new ArrayList<>();
@@ -643,6 +646,19 @@ public class EntityData {
 		addOptBoolean(transformers, config, "see-through", TextDisplay.class, TextDisplay::setSeeThrough);
 		addOptBoolean(transformers, config, "default-background", TextDisplay.class, TextDisplay::setDefaultBackground);
 		addOptEnum(transformers, config, "alignment", TextDisplay.class, TextDisplay.TextAlignment.class, TextDisplay::setAlignment);
+
+		// Passengers
+		for (Object object : config.getList("passengers", new ArrayList<>())) {
+			if (!(object instanceof Map<?, ?> map)) continue;
+			EntityData passengerData = new EntityData(ConfigReaderUtil.mapToSection(map));
+
+			transformers.put(Entity.class, (Entity entity, SpellData data) -> {
+				passengerData.spawn(entity.getLocation(), data, passenger -> {
+					entity.addPassenger(passenger);
+					passenger.getPersistentDataContainer().set(MS_PASSENGER, PersistentDataType.BOOLEAN, true);
+				});
+			});
+		}
 
 		// Mob Goals
 		ConfigurationSection mobGoals = config.getConfigurationSection("mob-goals");

--- a/core/src/main/java/com/nisovin/magicspells/util/Util.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/Util.java
@@ -582,6 +582,13 @@ public class Util {
 		Bukkit.getOnlinePlayers().forEach(consumer);
 	}
 
+	public static void forEachPassenger(Entity entity, Consumer<Entity> consumer) {
+		for (Entity passenger : entity.getPassengers()) {
+			forEachPassenger(passenger, consumer);
+			consumer.accept(passenger);
+		}
+	}
+
 	public static <C extends Collection<Material>> C getMaterialList(List<String> strings, Supplier<C> supplier) {
 		C ret = supplier.get();
 		strings.forEach(string -> ret.add(getMaterial(string)));

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -1,6 +1,7 @@
 package com.nisovin.magicspells.util.config;
 
 import java.util.List;
+import java.util.UUID;
 import java.util.function.Function;
 
 import org.jetbrains.annotations.NotNull;
@@ -787,7 +788,10 @@ public class ConfigDataUtil {
 	public static ConfigData<NamespacedKey> getNamespacedKey(@NotNull ConfigurationSection config, @NotNull String path, @Nullable NamespacedKey def) {
 		String value = config.getString(path);
 		if (value == null) return data -> def;
+		return getNamespacedKey(value, def);
+	}
 
+	public static ConfigData<NamespacedKey> getNamespacedKey(@NotNull String value, @Nullable NamespacedKey def) {
 		NamespacedKey val = NamespacedKey.fromString(value.toLowerCase());
 		if (val != null) return data -> val;
 
@@ -800,6 +804,22 @@ public class ConfigDataUtil {
 
 			NamespacedKey key = NamespacedKey.fromString(string.toLowerCase());
 			return key == null ? def : key;
+		};
+	}
+
+	public static ConfigData<UUID> getUniqueID(@NotNull ConfigurationSection config, @NotNull String path, @Nullable UUID def) {
+		ConfigData<String> supplier = getString(config, path, null);
+
+		return (VariableConfigData<UUID>) data -> {
+			String uuid = supplier.get(data);
+			if (uuid == null) return def;
+
+			try {
+				return UUID.fromString(uuid);
+			}
+			catch (IllegalArgumentException e) {
+				return def;
+			}
 		};
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -506,10 +506,16 @@ public class ConfigDataUtil {
 
 	@NotNull
 	public static <T extends Enum<T>> ConfigData<T> getEnum(@NotNull ConfigurationSection config,
-															@NotNull String path,
+	                                                        @NotNull String path,
+	                                                        @NotNull Class<T> type,
+	                                                        @Nullable T def) {
+		return ConfigDataUtil.getEnum(config.getString(path), type, def);
+	}
+
+	@NotNull
+	public static <T extends Enum<T>> ConfigData<T> getEnum(@Nullable String value,
 															@NotNull Class<T> type,
 															@Nullable T def) {
-		String value = config.getString(path);
 		if (value == null) return data -> def;
 
 		try {


### PR DESCRIPTION
## Changelog:

### Additions:

- Added `disable-slots` to `armorstand` spell effect. Boolean, defaulting to `true`.
- New Entity Data options:
  - [Entity](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/Entity.html):
    - `no-physics`, `persistent`, and `invulnerable` - Boolean
    - `fire-ticks` and `freeze-ticks` - Integer
    - `visual-fire` - `true`, `false`, or `not_set`.
    - `scoreboard-tags` - Aside from a list of strings of tags to add, you can now specify a list of configuration sections with `operation` (default `add`, `remove`, and `clear`), and `tag` string option to `add` or `remove`.
    - `passengers` - List of [Entity Data](https://github.com/TheComputerGeek2/MagicSpells/wiki/Entity-Data)
  - [Living Entity](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/LivingEntity.html):
    - `can-pickup-items` - Boolean
    - `max-health` - Double
  - [Mob](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/Mob.html):
    - `aware` - Boolean
    - `mob-goals`:
      - `remove-all` - Boolean
      - `remove-types` - List of [GoalType](https://jasperlorelai.eu/paperdocs/-/com/destroystokyo/paper/entity/ai/GoalType.html)
      - `remove-vanilla` - List of [VanillaGoal](https://jasperlorelai.eu/paperdocs/-/com/destroystokyo/paper/entity/ai/VanillaGoal.html)
      - `remove` - List of [Namespaced Keys](https://minecraft.wiki/w/Resource_location)
      - `add` - List of Mob Goal configurations
  - [Tameable](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/Tameable.html):
    - `tamed-owner` - Boolean - sets the entity as tamed and the recipient as its owner (caster of the spell or target of a Buff).
  - `armor_stand`:
    - `disable-slots` - Bool or a list of [EquipmentSlot](https://jasperlorelai.eu/paperdocs/-/org/bukkit/inventory/EquipmentSlot.html).
    - `equipment-locks` - List of configuration sections with options `slot` ([EquipmentSlot](https://jasperlorelai.eu/paperdocs/-/org/bukkit/inventory/EquipmentSlot.html)) and `lock` ([LockType](https://jasperlorelai.eu/paperdocs/-/org/bukkit/entity/ArmorStand.LockType.html)).
  - `chicken`:
    - `chicken-variant` - [Chicken Variant](https://github.com/TheComputerGeek2/MagicSpells/wiki/Registry#chicken-variants)
  - `copper_golem`:
    - `copper_golem` section:
      - `weathering-state` - [WeatheringCopperState](https://jasperlorelai.eu/paperdocs/-/io/papermc/paper/world/WeatheringCopperState.html)
      - `oxidizing` - May be `unset`, in which case oxidation happens naturally; `waxed`, in which case it is disabled; or a (Long type) number of ticks until the next weathering state.
  - `command_minecart`:
    - `command` - String
  - `cow`:
    - `cow-variant` - [Cow Variant](https://github.com/TheComputerGeek2/MagicSpells/wiki/Registry#cow-variants)
  - `falling_block`:
    - `cancel-drop` and `hurt-entities` - Boolean
    - `damage-per-block` - Float
    - `max-damage` - Integer
  - [Frictional](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/io/papermc/paper/entity/class-use/Frictional.html):
    - `friction-state` - `true`, `false`, or `not_set`
  - `goat`:
    - `left-horn`, `right-horn`, and `screaming` - Boolean
  - `hoglin`:
    - `immune-to-zombification` and `able-to-be-hunted` - Boolean
  - `mannequin`:
    - `mannequin` section:
      - `immovable` - Boolean
      - In a `skin-parts` section, boolean options for `cape`, `jacket`, `left-sleeve`, `right-sleeve`, `left-pants`, `right-pants`, and `hats`.
      - `description` - [Rich Text](https://github.com/TheComputerGeek2/MagicSpells/wiki/Expression#rich-text)
      - `main-hand` - [MainHand](https://jasperlorelai.eu/paperdocs/-/org/bukkit/inventory/MainHand.html)
      - `profile` section:
        - `name` - String
        - `uuid` - UUID formatted String
        - `body`, `cape`, `elytra` - [Namespaced Key](https://minecraft.wiki/w/Resource_location)
        - `model` - [SkinModel](https://jasperlorelai.eu/paperdocs/-/org/bukkit/profile/PlayerTextures.SkinModel.html)
  - `item`:
    - `dropped-item` - [Vanilla item format](https://minecraft.wiki/w/Argument_types#item_stack) or [Magic Item String](https://github.com/TheComputerGeek2/MagicSpells/wiki/Magic-Item-String)
  - [Minecart](https://jasperlorelai.eu/paperdocs/org.bukkit.entity.minecart/org/bukkit/entity/class-use/Minecart.html):
    - `max-speed` - Double
    - `slow-when-empty` - Boolean
    - `display-block-offset` - Integer
    - `display-block` - [Block Data](https://github.com/TheComputerGeek2/MagicSpells/wiki/Other-Data-Types#block-data)
  - `piglin`:
    - `able-to-hunt` - Boolean
    - `dancing` - Integer ticks
  - [Piglin Abstract](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/PiglinAbstract.html):
    - `immune-to-zombification` - Boolean
  - [Raider](https://jasperlorelai.eu/paperdocs/org.bukkit.entity/org/bukkit/entity/class-use/Raider.html):
    - `patrol-leader`, `can-join-raid`, and `celebrating` - Boolean
  - `salmon`:
    - `salmon-variant` - [Salmon Variant](https://jasperlorelai.eu/paperdocs/-/org/bukkit/entity/Salmon.Variant.html)
  - `vindicator`:
    - `johnny` - Boolean
  - `zombie_villager`:
    - `villager-profession` - [Villager Profession](https://jasperlorelai.eu/paperdocs/-/org/bukkit/entity/Villager.Profession.html)
    - `villager-type` - [Villager Type](https://jasperlorelai.eu/paperdocs/-/org/bukkit/entity/Villager.Type.html)
- Added `.targeted.ApplyEntityDataSpell` with `entity` [Entity Data](https://github.com/TheComputerGeek2/MagicSpells/wiki/Entity-Data) option. This spell applies the configured Entity Data to the targeted entity.
- Added `.targeted.EntityRemoveSpell`, which removes non-player entity targets from the world without the death animation.