### PR TITLE
QOL

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1748,7 +1748,7 @@ public class MagicSpells extends JavaPlugin {
 		return message;
 	}
 
-	private static final Pattern ARGUMENT_PATTERN = Pattern.compile("%arg:(\\d+):([^%]+)%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
+	private static final Pattern ARGUMENT_PATTERN = Pattern.compile("%arg:(\\d+)(?::([^%]+))?%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
 	public static String doArgumentSubstitution(String string, String[] args) {
 		if (string == null || string.isEmpty()) return string;
 
@@ -1759,6 +1759,7 @@ public class MagicSpells extends JavaPlugin {
 			int argIndex = Integer.parseInt(matcher.group(1)) - 1;
 
 			String newValue = matcher.group(2);
+			if (newValue == null) newValue = "";
 			if (args != null && argIndex >= 0 && argIndex < args.length) newValue = args[argIndex];
 
 			matcher.appendReplacement(builder, Matcher.quoteReplacement(newValue));

--- a/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
+++ b/core/src/main/java/com/nisovin/magicspells/MagicSpells.java
@@ -1864,7 +1864,7 @@ public class MagicSpells extends JavaPlugin {
 	 * @return the formatted string
 	 */
 	public static String formatMessage(String message, SpellData data, String... replacements) {
-		if (message == null || message.isEmpty()) return message;
+		if (message == null || message.isEmpty()) return "";
 
 		List<String> replacementList = new ArrayList<>();
 		if (replacements != null) replacementList.addAll(Arrays.asList(replacements));

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevitatedCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevitatedCondition.java
@@ -1,0 +1,47 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+import com.nisovin.magicspells.spells.targeted.LevitateSpell;
+
+@Name("levitated")
+public class LevitatedCondition extends Condition {
+
+	private LevitateSpell levitateSpell;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Spell spell = MagicSpells.getSpellByInternalName(var);
+		if (!(spell instanceof LevitateSpell levitate)) return false;
+		levitateSpell = levitate;
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		return levitateSpell.isBeingLevitated(caster);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		for (LevitateSpell.Levitator levitator : levitateSpell.getLevitating().values()) {
+			if (!levitator.getData().target().equals(caster)) continue;
+			if (!levitator.getData().caster().equals(target)) continue;
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevitatingCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/LevitatingCondition.java
@@ -1,0 +1,47 @@
+package com.nisovin.magicspells.castmodifiers.conditions;
+
+import org.bukkit.Location;
+import org.bukkit.entity.LivingEntity;
+
+import org.jetbrains.annotations.NotNull;
+
+import com.nisovin.magicspells.Spell;
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.castmodifiers.Condition;
+import com.nisovin.magicspells.spells.targeted.LevitateSpell;
+
+@Name("levitating")
+public class LevitatingCondition extends Condition {
+
+	private LevitateSpell levitateSpell;
+
+	@Override
+	public boolean initialize(@NotNull String var) {
+		Spell spell = MagicSpells.getSpellByInternalName(var);
+		if (!(spell instanceof LevitateSpell levitate)) return false;
+		levitateSpell = levitate;
+		return true;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster) {
+		return levitateSpell.isLevitating(caster);
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, LivingEntity target) {
+		for (LevitateSpell.Levitator levitator : levitateSpell.getLevitating().values()) {
+			if (!levitator.getData().caster().equals(caster)) continue;
+			if (!levitator.getData().target().equals(target)) continue;
+			return true;
+		}
+		return false;
+	}
+
+	@Override
+	public boolean check(LivingEntity caster, Location location) {
+		return false;
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/commands/DebugCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/DebugCommand.java
@@ -15,8 +15,8 @@ import org.incendo.cloud.parser.standard.IntegerParser;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 
 import com.nisovin.magicspells.Perm;
-import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.Util;
+import com.nisovin.magicspells.MagicSpells;
 
 public class DebugCommand {
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicCommands.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicCommands.java
@@ -2,7 +2,6 @@ package com.nisovin.magicspells.commands;
 
 import java.util.Map;
 
-import org.incendo.cloud.parser.standard.*;
 import org.jetbrains.annotations.NotNull;
 
 import io.leangen.geantyref.TypeToken;
@@ -13,6 +12,7 @@ import net.kyori.adventure.text.format.NamedTextColor;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
 
+import org.incendo.cloud.parser.standard.*;
 import org.incendo.cloud.parser.ArgumentParser;
 import org.incendo.cloud.paper.PaperCommandManager;
 import org.incendo.cloud.caption.StandardCaptionKeys;
@@ -36,11 +36,11 @@ import org.bukkit.command.CommandSender;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 import io.papermc.paper.command.brigadier.MessageComponentSerializer;
 
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.commands.parsers.*;
 import com.nisovin.magicspells.commands.exceptions.GenericCommandException;
 import com.nisovin.magicspells.commands.exceptions.InvalidCommandArgumentException;
-import com.nisovin.magicspells.util.Util;
 
 public class MagicCommands {
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/MagicItemCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/MagicItemCommand.java
@@ -2,10 +2,10 @@ package com.nisovin.magicspells.commands;
 
 import org.jetbrains.annotations.NotNull;
 
+import java.util.List;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.List;
 
 import org.incendo.cloud.key.CloudKey;
 import org.incendo.cloud.context.CommandContext;

--- a/core/src/main/java/com/nisovin/magicspells/commands/ManaCommands.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/ManaCommands.java
@@ -32,11 +32,11 @@ import org.bukkit.command.CommandSender;
 import io.papermc.paper.command.brigadier.CommandSourceStack;
 
 import com.nisovin.magicspells.Perm;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.mana.ManaHandler;
 import com.nisovin.magicspells.mana.ManaChangeReason;
 import com.nisovin.magicspells.commands.exceptions.InvalidCommandArgumentException;
-import com.nisovin.magicspells.util.Util;
 
 public class ManaCommands {
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/ReloadCommands.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/ReloadCommands.java
@@ -2,9 +2,9 @@ package com.nisovin.magicspells.commands;
 
 import org.jetbrains.annotations.NotNull;
 
-import java.util.Collection;
 import java.util.Map;
 import java.util.UUID;
+import java.util.Collection;
 import java.util.stream.Collectors;
 
 import net.kyori.adventure.text.Component;
@@ -24,9 +24,9 @@ import io.papermc.paper.command.brigadier.CommandSourceStack;
 
 import com.nisovin.magicspells.Perm;
 import com.nisovin.magicspells.Spellbook;
+import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.events.SpellbookReloadEvent;
-import com.nisovin.magicspells.util.Util;
 
 public class ReloadCommands {
 

--- a/core/src/main/java/com/nisovin/magicspells/commands/TaskInfoCommand.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/TaskInfoCommand.java
@@ -33,9 +33,7 @@ public class TaskInfoCommand {
 			.count();
 
 		int effectLibTasks = MagicSpells.getEffectManager().getEffects().size();
-
 		VolatileCodeHandle handler = MagicSpells.getVolatileCodeHandler();
-		MagicSpells instance = MagicSpells.getInstance();
 
 		context.sender().getSender().sendMessage(Util.getMessageText(
 			Component.text()

--- a/core/src/main/java/com/nisovin/magicspells/commands/parsers/SpellParser.java
+++ b/core/src/main/java/com/nisovin/magicspells/commands/parsers/SpellParser.java
@@ -68,7 +68,7 @@ public class SpellParser<C> implements ArgumentParser<C, Spell>, BlockingSuggest
 
 	private static boolean shouldQuote(char c) {
 		return switch (c) {
-			case ' ',  '"',  '\'',  '[',  ']',  '{',  '}' -> true;
+			case ' ', '"', '\'', '[', ']', '{', '}' -> true;
 			default -> false;
 		};
 	}

--- a/core/src/main/java/com/nisovin/magicspells/mana/ManaRank.java
+++ b/core/src/main/java/com/nisovin/magicspells/mana/ManaRank.java
@@ -1,7 +1,5 @@
 package com.nisovin.magicspells.mana;
 
-import net.kyori.adventure.text.format.Style;
-
 public class ManaRank {
 	
 	private String name;

--- a/core/src/main/java/com/nisovin/magicspells/mana/ManaSystem.java
+++ b/core/src/main/java/com/nisovin/magicspells/mana/ManaSystem.java
@@ -3,7 +3,6 @@ package com.nisovin.magicspells.mana;
 import java.util.*;
 
 import net.kyori.adventure.text.Component;
-import net.kyori.adventure.text.format.Style;
 import net.kyori.adventure.text.format.NamedTextColor;
 import net.kyori.adventure.text.minimessage.MiniMessage;
 import net.kyori.adventure.text.minimessage.tag.resolver.Placeholder;

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemCooldownEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ItemCooldownEffect.java
@@ -1,6 +1,6 @@
 package com.nisovin.magicspells.spelleffects.effecttypes;
 
-import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.Player;
 import org.bukkit.configuration.ConfigurationSection;
@@ -10,25 +10,36 @@ import com.nisovin.magicspells.util.TimeUtil;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
 
 @Name("itemcooldown")
 public class ItemCooldownEffect extends SpellEffect {
 
+	private ConfigData<String> item;
 	private ConfigData<Integer> duration;
-	private ConfigData<Material> type;
+	private ConfigData<NamespacedKey> key;
 
 	@Override
 	protected void loadFromConfig(ConfigurationSection config) {
+		item = ConfigDataUtil.getString(config, "item", "stone");
+		key = ConfigDataUtil.getNamespacedKey(config, "key", null);
 		duration = ConfigDataUtil.getInteger(config, "duration", TimeUtil.TICKS_PER_SECOND);
-		type = ConfigDataUtil.getMaterial(config, "item", Material.STONE);
 	}
 
 	@Override
 	protected Runnable playEffectEntity(Entity entity, SpellData data) {
 		if (!(entity instanceof Player player)) return null;
 
-		player.setCooldown(type.get(data), duration.get(data));
+		int duration = this.duration.get(data);
+
+		NamespacedKey key = this.key.get(data);
+		if (key == null) {
+			MagicItem item = MagicItems.getMagicItemFromString(this.item.get(data));
+			if (item != null) player.setCooldown(item.getItemStack(), duration);
+		} else player.setCooldown(key, duration);
+
 		return null;
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/command/ImbueSpell.java
@@ -109,7 +109,7 @@ public class ImbueSpell extends CommandSpell implements BlockingSuggestionProvid
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}
 
-		if (!inHand.hasItemMeta() || inHand.getItemMeta().getPersistentDataContainer().has(KEY)) {
+		if (inHand.hasItemMeta() && inHand.getItemMeta().getPersistentDataContainer().has(KEY)) {
 			sendMessage(strCantImbueItem, caster, data);
 			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -91,7 +91,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		TargetInfo<LivingEntity> info = getTargetedEntity(data);
 		if (info.noTarget()) return noTarget(info);
 
-		return castAtEntity(info.spellData());
+		return levitate(info.spellData());
 	}
 
 	@Override
@@ -103,6 +103,15 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 	public CastResult castAtEntity(SpellData data) {
 		if (!data.hasCaster()) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
+		if (isLevitating(data.caster())) {
+			levitating.remove(data.caster().getUniqueId()).stop();
+			return new CastResult(PostCastAction.ALREADY_HANDLED, data);
+		}
+
+		return levitate(data);
+	}
+
+	public CastResult levitate(SpellData data) {
 		LivingEntity caster = data.caster();
 		LivingEntity target = data.target();
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LevitateSpell.java
@@ -129,6 +129,10 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
+	public Map<UUID, Levitator> getLevitating() {
+		return levitating;
+	}
+
 	public boolean isBeingLevitated(LivingEntity entity) {
 		for (Levitator levitator : levitating.values()) {
 			if (levitator.data.target().equals(entity)) return true;
@@ -149,7 +153,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		toRemove.clear();
 	}
 
-	private boolean isLevitating(LivingEntity entity) {
+	public boolean isLevitating(LivingEntity entity) {
 		return levitating.containsKey(entity.getUniqueId());
 	}
 
@@ -195,7 +199,7 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 
 	}
 
-	private class Levitator implements Runnable {
+	public class Levitator implements Runnable {
 
 		private final SpellData data;
 
@@ -267,6 +271,10 @@ public class LevitateSpell extends TargetedSpell implements TargetedEntitySpell 
 		private void stop() {
 			stopped = true;
 			MagicSpells.cancelTask(taskId);
+		}
+
+		public SpellData getData() {
+			return data;
 		}
 
 	}

--- a/core/src/main/java/com/nisovin/magicspells/util/MagicConfig.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/MagicConfig.java
@@ -89,24 +89,32 @@ public class MagicConfig {
 				}
 			}
 
-			// Load spell folders
-			for (File directoryFile : folder.listFiles(DIRECTORY_FILTER)) {
-				if (!directoryFile.isDirectory()) continue;
-				for (File spellConfigFile : directoryFile.listFiles(FILENAME_FILTER)) {
-					loadSpellFiles(spellConfigFile);
-				}
-			}
-
-			// load spell configs
-			for (File spellConfigFile : folder.listFiles(FILENAME_FILTER)) {
-				loadSpellFiles(spellConfigFile);
-			}
+			// Load spells and folders
+			loadSpellDirectory(folder);
 
 			// Load mini configs
 			File spellConfigsFolder = new File(folder, "spellconfigs");
 			if (spellConfigsFolder.exists()) loadSpellConfigs(spellConfigsFolder);
 		} catch (Exception ex) {
 			MagicSpells.handleException(ex);
+		}
+	}
+
+	private void loadSpellDirectory(File directory) {
+		File[] files = directory.listFiles(FILENAME_FILTER);
+		if (files != null) {
+			for (File file : files) {
+				if (!file.isFile()) continue;
+				loadSpellFiles(file);
+			}
+		}
+
+		files = directory.listFiles(DIRECTORY_FILTER);
+		if (files != null) {
+			for (File file : files) {
+				if (!file.isDirectory()) continue;
+				loadSpellDirectory(file);
+			}
 		}
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/FunctionData.java
@@ -33,7 +33,7 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 	private static final Pattern PLACEHOLDER_PATTERN = Pattern.compile("%(?:" +
 		"(?<var>(?<varOwner>var|castervar|targetvar):(?<varName>\\w+)(?::(?<varPrecision>\\d+))?)|" +
 		"(?<pVar>playervar:(?<pVarUser>[^:]+):(?<pVarName>\\w+)(?::(?<pVarPrecision>\\d+))?)|" +
-		"(?<arg>arg:(?<argValue>\\d+):(?<argDefault>" + RegexUtil.DOUBLE_PATTERN + "))|" +
+		"(?<arg>arg:(?<argValue>\\d+)(?::(?<argDefault>" + RegexUtil.DOUBLE_PATTERN + "))?)|" +
 		"(?<papi>(?<papiOwner>papi|casterpapi|targetpapi):(?<papiValue>[^%]+))|" +
 		"(?<playerPapi>playerpapi:(?<playerPapiUser>[^:]+):(?<playerPapiValue>[^%]+))" +
 		")%", Pattern.CASE_INSENSITIVE | Pattern.MULTILINE);
@@ -187,7 +187,6 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 		}
 
 		if (matcher.group("arg") != null) {
-			String def = matcher.group("argDefault");
 
 			int index;
 			try {
@@ -197,7 +196,8 @@ public class FunctionData<T extends Number> implements ConfigData<T> {
 			}
 			if (index == 0) return data -> 0d;
 
-			return new ArgumentData(index - 1, def);
+			String def = matcher.group("argDefault");
+			return new ArgumentData(index - 1, def == null ? "" : def);
 		}
 
 		if (matcher.group("papi") != null) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/StringData.java
@@ -27,7 +27,7 @@ public class StringData implements ConfigData<String> {
 		%(?:\
 		(?<var>(?<varOwner>var|castervar|targetvar):(?<varName>\\w+)(?::(?<varPrecision>\\d+))?)|\
 		(?<pVar>playervar:(?<pVarUser>[^:]+):(?<pVarName>\\w+)(?::(?<pVarPrecision>\\d+))?)|\
-		(?<arg>arg:(?<argValue>\\d+):(?<argDefault>[^%]+))|\
+		(?<arg>arg:(?<argValue>\\d+)(?::(?<argDefault>[^%]+))?)|\
 		(?<papi>(?<papiOwner>papi|casterpapi|targetpapi):(?<papiValue>[^%]+))|\
 		(?<playerPapi>playerpapi:(?<playerPapiUser>[^:]+):(?<playerPapiValue>[^%]+))\
 		)%|\
@@ -98,8 +98,6 @@ public class StringData implements ConfigData<String> {
 		}
 
 		if (matcher.group("arg") != null) {
-			String def = matcher.group("argDefault");
-
 			int index;
 			try {
 				index = Integer.parseInt(matcher.group("argValue"));
@@ -108,7 +106,8 @@ public class StringData implements ConfigData<String> {
 			}
 			if (index == 0) return null;
 
-			return new ArgumentData(index - 1, def);
+			String def = matcher.group("argDefault");
+			return new ArgumentData(index - 1, def == null ? "" : def);
 		}
 
 		if (matcher.group("papi") != null) {

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/ConditionManager.java
@@ -216,6 +216,8 @@ public class ConditionManager {
 		addCondition(ClimbingCondition.class);
 		addCondition(EntityTypeTagCondition.class);
 		addCondition(LeashedCondition.class);
+		addCondition(LevitatedCondition.class);
+		addCondition(LevitatingCondition.class);
 		addCondition(SleepingCondition.class);
 		addCondition(UnderWaterCondition.class);
 		addCondition(FixedTimeCondition.class);

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/AbsorptionVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/AbsorptionVariable.java
@@ -1,11 +1,18 @@
 package com.nisovin.magicspells.variables.meta;
 
 import org.bukkit.Bukkit;
+import org.bukkit.NamespacedKey;
 import org.bukkit.entity.Player;
+import org.bukkit.attribute.Attribute;
+import org.bukkit.attribute.AttributeInstance;
+import org.bukkit.attribute.AttributeModifier;
 
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.variables.variabletypes.MetaVariable;
 
 public class AbsorptionVariable extends MetaVariable {
+
+	private static final NamespacedKey KEY = new NamespacedKey(MagicSpells.getInstance(), "meta_absorption");
 
 	@Override
 	public double getValue(String p) {
@@ -18,6 +25,12 @@ public class AbsorptionVariable extends MetaVariable {
 	public void set(String p, double amount) {
 		Player player = Bukkit.getPlayerExact(p);
 		if (player == null) return;
+
+		AttributeInstance attribute = player.getAttribute(Attribute.MAX_ABSORPTION);
+		if (attribute == null) return;
+		attribute.removeModifier(KEY);
+		attribute.addModifier(new AttributeModifier(KEY, amount, AttributeModifier.Operation.ADD_NUMBER));
+
 		player.setAbsorptionAmount(amount);
 	}
 

--- a/core/src/main/resources/mana.yml
+++ b/core/src/main/resources/mana.yml
@@ -17,7 +17,6 @@ show-mana-on-experience-bar: true
 
 ranks:
     master:
-        prefix: "Mana:"
         symbol: '='
         size: 35
         max-mana: 200
@@ -26,7 +25,6 @@ ranks:
         regen-interval: 20
         bar-format: "<dark_aqua>Mana: {<dark_blue><full_segment></dark_blue><black><empty_segment></black>} [<mana>/<max_mana>]</dark_aqua>"
     adept:
-        prefix: "Mana:"
         symbol: '='
         size: 35
         max-mana: 150
@@ -35,7 +33,6 @@ ranks:
         regen-interval: 20
         bar-format: "<dark_aqua>Mana: {<blue><full_segment></blue><black><empty_segment></black>} [<mana>/<max_mana>]</dark_aqua>"
     novice:
-        prefix: "Mana:"
         symbol: '='
         size: 35
         max-mana: 100


### PR DESCRIPTION
## Changes:

- The `default` parameter in the `%arg:<index>:<default>%` placeholder is now optional (evaluates into an empty string).
- The `item` option in `itemcooldown` now supports **Magic Item String**.
- Spell files (files named `spell*.yml`) can now recursively be stored in spell folders (named `spells*`), not just on the first level - applies to spell folders too.



## Additions:

- Added `levitating` and `levitated` modifier conditions.
- Added `key` (namespaced key) option to `itemcooldown`, referring to all items with the cooldown group with that key. This option takes precedence over `item`.



## Fixes:

- Fixed an issue with `ImbueSpell` failing to accept items without any item components.
- Fixed an issue with `LevitateSpell` not toggling off active levitation when cast as a sub-spell.
- Fixed issue [#1070](https://github.com/TheComputerGeek2/MagicSpells/issues/1070) where the the `meta_absorption` meta variable did not update the `max_absorption` attribute introduced in `1.20.2` before setting absorption, causing the value to be clamped down to the existing max absorption, which is `0` by default.