### PR TITLE
Weather and Time

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout project sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{github.event.pull_request.head.sha || github.sha}}
 
@@ -45,13 +45,13 @@ jobs:
         run: echo "version=$(grep version gradle.properties | cut -d"=" -f2 | xargs)" >> $GITHUB_OUTPUT
 
       - name: Setup Java
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           distribution: temurin
           java-version: 25
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@v6
 
       - name: Run build with Gradle Wrapper
         run: ./gradlew "-Pversion=${{steps.version.outputs.version}}-${{steps.hash.outputs.sha_short}}" core:build
@@ -59,7 +59,7 @@ jobs:
       - name: Upload artifact
         if: github.event_name == 'push' || contains(github.event.pull_request.labels.*.name, 'Build PR Jar')
         id: artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: MagicSpells-${{steps.version.outputs.version}}-${{steps.hash.outputs.sha_short}}
           if-no-files-found: error

--- a/.github/workflows/pr_comment.yml
+++ b/.github/workflows/pr_comment.yml
@@ -12,7 +12,7 @@ jobs:
       github.event.workflow_run.event == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const label = "Build PR Jar";

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -62,6 +62,10 @@ shadowJar {
     archiveClassifier.set("")
 }
 
+jar {
+    enabled = false
+}
+
 generateGrammarSource {
     packageName = "com.nisovin.magicspells.util.grammars"
     arguments += ["-visitor", "-no-listener"]

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -6,7 +6,7 @@ plugins {
 dependencies {
     shadow("org.apache.commons:commons-math4-core:4.0-beta1")
     shadow("com.github.ben-manes.caffeine:caffeine:3.2.2")
-    shadow("com.github.Chronoken:EffectLib:4e37625")
+    shadow("com.github.Chronoken:EffectLib:1da888c")
     shadow("org.incendo:cloud-paper:2.0.0-beta.16")
     shadow("org.incendo:cloud-minecraft-extras:2.0.0-beta.16")
     shadow("org.incendo:cloud-processors-requirements:1.0.0-rc.1")

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -7,8 +7,8 @@ dependencies {
     shadow("org.apache.commons:commons-math4-core:4.0-beta1")
     shadow("com.github.ben-manes.caffeine:caffeine:3.2.2")
     shadow("com.github.Chronoken:EffectLib:4e37625")
-    shadow("org.incendo:cloud-paper:2.0.0-beta.14")
-    shadow("org.incendo:cloud-minecraft-extras:2.0.0-beta.15")
+    shadow("org.incendo:cloud-paper:2.0.0-beta.16")
+    shadow("org.incendo:cloud-minecraft-extras:2.0.0-beta.16")
     shadow("org.incendo:cloud-processors-requirements:1.0.0-rc.1")
     shadow("org.bstats:bstats-bukkit:3.2.1")
     shadow("com.github.ezylang:EvalEx:3.6.2")
@@ -18,6 +18,7 @@ dependencies {
 
     shadow(project(path: ":nms:shared", configuration: "apiElements"))
     shadow(project(path: ":nms:latest")) { transitive = false }
+    shadow(project(path: ":nms:v26_1_2")) { transitive = false }
 
     implementation("com.github.retrooper:packetevents-spigot:2.11.2")
     implementation("net.dmulloy2:ProtocolLib:5.4.0") { transitive = false }

--- a/core/build.gradle
+++ b/core/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     shadow("org.incendo:cloud-minecraft-extras:2.0.0-beta.15")
     shadow("org.incendo:cloud-processors-requirements:1.0.0-rc.1")
     shadow("org.bstats:bstats-bukkit:3.2.1")
-    shadow("com.github.ezylang:EvalEx:3.6.0")
+    shadow("com.github.ezylang:EvalEx:3.6.2")
 
     shadow("org.antlr:antlr4-runtime:4.13.2")
     antlr("org.antlr:antlr4:4.13.2")

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 
 import de.slikey.effectlib.Effect;
 
@@ -684,6 +685,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	/**
 	 * This method is called immediately after all spells have been loaded.
 	 */
+	@MustBeInvokedByOverriders
 	protected void initialize() {
 		// Process shared cooldowns
 		List<?> rawSharedCooldowns = config.getList(internalKey + "shared-cooldowns", null);

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1236,7 +1236,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	public void sendMessages(SpellData data, String... replacements) {
 		sendMessage(strCastSelf, data.caster(), data, replacements);
 		sendMessage(strCastTarget, data.target(), data, replacements);
-		sendMessageNear(strCastOthers, data, broadcastRange.get(data), replacements);
+		sendMessageNear(strCastOthers, data, replacements);
 	}
 
 	protected boolean preCastTimeCheck(LivingEntity livingEntity, String[] args) {
@@ -2296,8 +2296,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	 */
 	@Deprecated
 	protected void sendMessageNear(LivingEntity livingEntity, String message) {
-		SpellData data = new SpellData(livingEntity);
-		sendMessageNear(message, data, broadcastRange.get(data));
+		sendMessageNear(message, new SpellData(livingEntity));
 	}
 
 	/**
@@ -2323,6 +2322,17 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	@Deprecated
 	protected void sendMessageNear(LivingEntity livingEntity, Player ignore, String message, int range, String[] args, String... replacements) {
 		sendMessageNear(message, new SpellData(livingEntity, ignore, 1f, args), range, replacements);
+	}
+
+	/**
+	 * Sends a message to all players near the specified player, within the default broadcast range.
+	 *
+	 * @param message      the message to send
+	 * @param data         the associated spell data
+	 * @param replacements replacements to be done on message
+	 */
+	protected void sendMessageNear(String message, SpellData data, String... replacements) {
+		sendMessageNear(message, data, broadcastRange.get(data), replacements);
 	}
 
 	/**

--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -2,6 +2,7 @@ package com.nisovin.magicspells;
 
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.annotations.MustBeInvokedByOverriders;
 
 import de.slikey.effectlib.Effect;
 
@@ -537,6 +538,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		return reagents;
 	}
 
+	@MustBeInvokedByOverriders
 	protected void initializeVariables() {
 		// Variable options
 		if (varModsCast != null && !varModsCast.isEmpty()) {
@@ -584,6 +586,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		if (reagents == null) reagents = new SpellReagents();
 	}
 
+	@MustBeInvokedByOverriders
 	protected void initializeSpellEffects() {
 		// Graphical effects
 		effectTrackerSet = new HashSet<>();
@@ -652,6 +655,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 
 	// DEBUG INFO: level 2, adding modifiers to internalname
 	// DEBUG INFO: level 2, adding target modifiers to internalname
+	@MustBeInvokedByOverriders
 	protected void initializeModifiers() {
 		// Modifiers
 		if (modifierStrings != null && !modifierStrings.isEmpty()) {
@@ -684,6 +688,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	/**
 	 * This method is called immediately after all spells have been loaded.
 	 */
+	@MustBeInvokedByOverriders
 	protected void initialize() {
 		// Process shared cooldowns
 		List<?> rawSharedCooldowns = config.getList(internalKey + "shared-cooldowns", null);

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeDefaultCondition.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/conditions/AttributeDefaultCondition.java
@@ -6,6 +6,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.bukkit.Location;
+import org.bukkit.entity.EntityType;
 import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.attribute.AttributeInstance;
@@ -48,10 +49,13 @@ public class AttributeDefaultCondition extends OperatorCondition {
 
 	@Override
 	public boolean check(LivingEntity caster) {
-		AttributeInstance instance = caster.getAttribute(attribute);
+		EntityType entityType = caster.getType();
+		if (!entityType.hasDefaultAttributes()) return false;
+
+		AttributeInstance instance = entityType.getDefaultAttributes().getAttribute(attribute);
 		if (instance == null) return false;
 
-		return compare(instance.getDefaultValue(), value);
+		return compare(instance.getBaseValue(), value);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ExperienceEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ExperienceEffect.java
@@ -1,0 +1,50 @@
+package com.nisovin.magicspells.spelleffects.effecttypes;
+
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spelleffects.SpellEffect;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+
+@Name("experience")
+public class ExperienceEffect extends SpellEffect {
+
+	private ConfigData<Integer> level;
+	private ConfigData<Integer> progress;
+
+	private ConfigData<Boolean> reset;
+
+	@Override
+	protected void loadFromConfig(ConfigurationSection config) {
+		level = ConfigDataUtil.getInteger(config, "level");
+		progress = ConfigDataUtil.getInteger(config, "progress");
+
+		reset = ConfigDataUtil.getBoolean(config, "reset", false);
+	}
+
+	@Override
+	protected Runnable playEffectEntity(Entity entity, SpellData data) {
+		if (!(entity instanceof Player player)) return null;
+
+		boolean reset = this.reset.get(data);
+
+		Integer l = this.level.get(data);
+		int level = l == null || reset ? player.getLevel() : l;
+
+		Integer p = this.progress.get(data);
+		float progress = p == null || reset ? player.getExp() : p / 100f;
+
+		try {
+			player.sendExperienceChange(progress, level);
+		} catch (IllegalArgumentException e) {
+			// debug
+		}
+
+		return null;
+	}
+}
+

--- a/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesEffect.java
+++ b/core/src/main/java/com/nisovin/magicspells/spelleffects/effecttypes/ParticlesEffect.java
@@ -20,6 +20,7 @@ import org.bukkit.Particle.DustTransition;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.Name;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
@@ -32,41 +33,46 @@ public class ParticlesEffect extends SpellEffect {
 
 	protected ConfigData<Particle> particle;
 
-	protected ConfigData<Color> rgbColor;
+	private ConfigData<Color> rgbColor;
 	protected ConfigData<Color> argbColor;
 
-	protected ConfigData<Material> material;
-	protected ConfigData<BlockData> blockData;
-	protected ConfigData<DustOptions> dustOptions;
-	protected ConfigData<Particle.Spell> spellOptions;
-	protected ConfigData<DustTransition> dustTransition;
+	private ConfigData<Material> material;
+	private ConfigData<BlockData> blockData;
+	private ConfigData<DustOptions> dustOptions;
+	private ConfigData<Particle.Spell> spellOptions;
+	private ConfigData<DustTransition> dustTransition;
 
-	protected ConfigData<Vector> vibrationOffset;
-	protected ConfigData<Vector> vibrationRelativeOffset;
-	protected ConfigData<ParticlePosition> vibrationOrigin;
-	protected ConfigData<ParticlePosition> vibrationDestination;
+	private ConfigData<Vector> vibrationOffset;
+	private ConfigData<Vector> vibrationRelativeOffset;
+	private ConfigData<ParticlePosition> vibrationOrigin;
+	private ConfigData<ParticlePosition> vibrationDestination;
 
-	protected ConfigData<Color> trailColor;
-	protected ConfigData<Integer> trailDuration;
-	protected ConfigData<Vector> trailTargetOffset;
-	protected ConfigData<ParticlePosition> trailOrigin;
-	protected ConfigData<ParticlePosition> trailTarget;
-	protected ConfigData<Vector> trailTargetRelativeOffset;
+	private ConfigData<Color> trailColor;
+	private ConfigData<Integer> trailDuration;
+	private ConfigData<Vector> trailTargetOffset;
+	private ConfigData<ParticlePosition> trailOrigin;
+	private ConfigData<ParticlePosition> trailTarget;
+	private ConfigData<Vector> trailTargetRelativeOffset;
+
+	private ConfigData<Integer> geyserWaterBlocks;
+	private ConfigData<Float> geyserBurstImpulse;
 
 	protected ConfigData<Integer> count;
-	protected ConfigData<Integer> radius;
-	protected ConfigData<Integer> arrivalTime;
-	protected ConfigData<Integer> shriekDelay;
+	private ConfigData<Integer> radius;
+	private ConfigData<Integer> arrivalTime;
+	private ConfigData<Integer> shriekDelay;
 
 	protected ConfigData<Float> speed;
+
 	protected ConfigData<Float> xSpread;
 	protected ConfigData<Float> ySpread;
 	protected ConfigData<Float> zSpread;
-	protected ConfigData<Float> dragonBreathPower;
-	protected ConfigData<Float> sculkChargeRotation;
+
+	private ConfigData<Float> dragonBreathPower;
+	private ConfigData<Float> sculkChargeRotation;
 
 	protected ConfigData<Boolean> force;
-	protected ConfigData<Boolean> staticDestination;
+	private ConfigData<Boolean> staticDestination;
 
 	@Override
 	public void loadFromConfig(ConfigurationSection config) {
@@ -92,6 +98,9 @@ public class ParticlesEffect extends SpellEffect {
 		trailDuration = ConfigDataUtil.getInteger(config, "trail.duration");
 		trailTargetOffset = ConfigDataUtil.getVector(config, "trail.target-offset", new Vector());
 		trailTargetRelativeOffset = ConfigDataUtil.getVector(config, "trail.target-relative-offset", new Vector());
+
+		geyserWaterBlocks = ConfigDataUtil.getInteger(config, "geyser.water-blocks");
+		geyserBurstImpulse = ConfigDataUtil.getFloat(config, "geyser.burst-impulse");
 
 		count = ConfigDataUtil.getInteger(config, "count", 5);
 		radius = ConfigDataUtil.getInteger(config, "radius", 50);
@@ -156,6 +165,13 @@ public class ParticlesEffect extends SpellEffect {
 	}
 
 	protected Object getParticleData(@NotNull Particle particle, @Nullable Entity entity, @NotNull Location location, @NotNull SpellData data) {
+		Object nmsData = MagicSpells.getVolatileCodeHandler().getVolatileParticleData(
+			particle,
+			() -> geyserWaterBlocks.get(data),
+			() -> geyserBurstImpulse.get(data)
+		);
+		if (nmsData != null) return nmsData;
+
 		Class<?> type = particle.getDataType();
 
 		if (type == Color.class) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/EnchantSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/EnchantSpell.java
@@ -4,6 +4,7 @@ import java.util.Map;
 import java.util.List;
 import java.util.HashMap;
 
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.enchantments.Enchantment;
 import org.bukkit.inventory.EntityEquipment;
@@ -21,11 +22,13 @@ public class EnchantSpell extends InstantSpell {
 	private final Map<Enchantment, Integer> enchantments = new HashMap<>();
 
 	private final ConfigData<Boolean> safeEnchants;
+	private final ConfigData<Boolean> requireSupportedItem;
 
 	public EnchantSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
 		safeEnchants = getConfigDataBoolean("safe-enchants", true);
+		requireSupportedItem = getConfigDataBoolean("require-supported-item", true);
 
 		List<String> enchantList = getConfigStringList("enchantments", List.of());
 		if (enchantList.isEmpty()) {
@@ -64,22 +67,23 @@ public class EnchantSpell extends InstantSpell {
 		if (item.isEmpty()) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
 		boolean safeEnchants = this.safeEnchants.get(data);
+		boolean requireSupportedItem = this.requireSupportedItem.get(data);
+
 		for (Enchantment e : enchantments.keySet())
-			enchant(item, safeEnchants, e, enchantments.get(e));
+			enchant(item, safeEnchants, requireSupportedItem, e, enchantments.get(e));
 
 		playSpellEffects(data);
 
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
-	private void enchant(ItemStack item, boolean safeEnchants, Enchantment enchant, int level) {
+	private void enchant(ItemStack item, boolean safeEnchants, boolean requireSupportedItem, Enchantment enchant, int level) {
 		if (level <= 0) {
 			item.removeEnchantment(enchant);
 			return;
 		}
 
-		if (!enchant.canEnchantItem(item)) return;
-
+		if (requireSupportedItem && item.getType() != Material.BOOK && !enchant.canEnchantItem(item)) return;
 		if (safeEnchants) level = Math.clamp(level, enchant.getStartLevel(), enchant.getMaxLevel());
 
 		item.addUnsafeEnchantment(enchant, level);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/EnchantSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/EnchantSpell.java
@@ -18,29 +18,41 @@ import com.nisovin.magicspells.handlers.EnchantmentHandler;
 
 public class EnchantSpell extends InstantSpell {
 
-	private final Map<Enchantment, Integer> enchantments;
+	private final Map<Enchantment, Integer> enchantments = new HashMap<>();
 
-	private ConfigData<Boolean> safeEnchants;
+	private final ConfigData<Boolean> safeEnchants;
 
 	public EnchantSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
 
-		enchantments = new HashMap<>();
-
-		List<String> enchantmentList = getConfigStringList("enchantments", null);
-
 		safeEnchants = getConfigDataBoolean("safe-enchants", true);
 
-		if (enchantmentList != null && !enchantmentList.isEmpty()) {
-			for (String string : enchantmentList) {
-				Enchantment enchant = null;
-				int level = 1;
-				String[] str = string.split(" ");
-				if (str[0] != null) enchant = EnchantmentHandler.getEnchantment(str[0]);
-				if (str.length > 1 && str[1] != null) level = Integer.parseInt(str[1]);
-				if (enchant != null) enchantments.put(enchant, level);
+		List<String> enchantList = getConfigStringList("enchantments", List.of());
+		if (enchantList.isEmpty()) {
+			MagicSpells.error("EnchantSpell '" + internalName + "' has no 'enchantments' defined!");
+			return;
+		}
+
+		for (int i = 0; i < enchantList.size(); i++) {
+			String[] splits = enchantList.get(i).split(" ", 2);
+			Enchantment enchant = EnchantmentHandler.getEnchantment(splits[0]);
+			if (enchant == null) {
+				MagicSpells.error("EnchantSpell '" + internalName + "' has an invalid enchantment key '" + splits[0] + "' on element '#" + i + "'");
+				continue;
 			}
-		} else MagicSpells.error("EnchantSpell '" + internalName + "' has invalid enchantments defined!");
+
+			int level = enchant.getStartLevel();
+			if (splits.length > 1) {
+				try {
+					level = Integer.parseInt(splits[1]);
+				} catch (NumberFormatException _) {
+					MagicSpells.error("EnchantSpell '" + internalName + "' has an invalid enchantment level '" + splits[1] + "' on element '#" + i + "'");
+					continue;
+				}
+			}
+
+			enchantments.put(enchant, level);
+		}
 	}
 
 	@Override
@@ -49,7 +61,7 @@ public class EnchantSpell extends InstantSpell {
 		if (eq == null) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
 		ItemStack item = eq.getItemInMainHand();
-		if (item.getType().isAir()) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
+		if (item.isEmpty()) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
 		boolean safeEnchants = this.safeEnchants.get(data);
 		for (Enchantment e : enchantments.keySet())
@@ -61,13 +73,16 @@ public class EnchantSpell extends InstantSpell {
 	}
 
 	private void enchant(ItemStack item, boolean safeEnchants, Enchantment enchant, int level) {
-		if (!enchant.canEnchantItem(item)) return;
-		if (safeEnchants && level > enchant.getMaxLevel()) level = enchant.getMaxLevel();
-		if (level <= 0) item.removeEnchantment(enchant);
-		else {
-			if (safeEnchants) item.addEnchantment(enchant, level);
-			else item.addUnsafeEnchantment(enchant, level);
+		if (level <= 0) {
+			item.removeEnchantment(enchant);
+			return;
 		}
+
+		if (!enchant.canEnchantItem(item)) return;
+
+		if (safeEnchants) level = Math.clamp(level, enchant.getStartLevel(), enchant.getMaxLevel());
+
+		item.addUnsafeEnchantment(enchant, level);
 	}
 
 	public Map<Enchantment, Integer> getEnchantments() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/TimeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/TimeSpell.java
@@ -1,44 +1,74 @@
 package com.nisovin.magicspells.spells.instant;
 
 import org.bukkit.World;
+import org.bukkit.GameRules;
 import org.bukkit.entity.Player;
+
+import net.kyori.adventure.util.TriState;
 
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.CastResult;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
-public class TimeSpell extends InstantSpell implements TargetedLocationSpell {
+public class TimeSpell extends InstantSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
-	private final ConfigData<Integer> timeToSet;
+	private final ConfigData<Integer> time;
+
+	private final ConfigData<Boolean> addTime;
+	private final ConfigData<Boolean> setPlayerTime;
+
+	private final ConfigData<TriState> advance;
 
 	private String strAnnounce;
-		
+
 	public TimeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
-		timeToSet = getConfigDataInt("time-to-set", 0);
-		strAnnounce = getConfigString("str-announce", "The sun suddenly appears in the sky.");
+
+		time = getConfigDataInt("time", getConfigDataInt("time-to-set", 0));
+
+		addTime = getConfigDataBoolean("add-time", false);
+		setPlayerTime = getConfigDataBoolean("set-player-time", false);
+
+		advance = getConfigDataEnum("advance", TriState.class, TriState.NOT_SET);
+
+		strAnnounce = getConfigString("str-announce", "");
 	}
 
 	@Override
 	public CastResult cast(SpellData data) {
-		setTime(data.caster().getWorld(), data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return setTime(data.caster().getWorld(), data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		return setTime(data.target().getWorld(), data);
 	}
 
 	@Override
 	public CastResult castAtLocation(SpellData data) {
-		setTime(data.location().getWorld(), data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return setTime(data.location().getWorld(), data);
 	}
 
-	private void setTime(World world, SpellData data) {
-		world.setTime(timeToSet.get(data));
-		for (Player p : world.getPlayers()) sendMessage(strAnnounce, p, data);
+	private CastResult setTime(World world, SpellData data) {
+		long time = this.time.get(data);
+		if (addTime.get(data)) time += world.getTime();
+
+		if (setPlayerTime.get(data)) {
+			if (!(data.target() instanceof Player player)) return noTarget(data);
+			player.setPlayerTime(time, true); // Reset with "time: 0".
+		} else world.setTime(time);
+
+		Boolean advance = this.advance.get(data).toBoolean();
+		if (advance != null) world.setGameRule(GameRules.ADVANCE_TIME, advance);
+
+		sendMessageNear(strAnnounce, data);
 		playSpellEffects(data);
+
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
 	public String getStrAnnounce() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/TimeSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/TimeSpell.java
@@ -8,37 +8,57 @@ import com.nisovin.magicspells.util.CastResult;
 import com.nisovin.magicspells.util.MagicConfig;
 import com.nisovin.magicspells.spells.InstantSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 
-public class TimeSpell extends InstantSpell implements TargetedLocationSpell {
+public class TimeSpell extends InstantSpell implements TargetedEntitySpell, TargetedLocationSpell {
 
-	private final ConfigData<Integer> timeToSet;
+	private final ConfigData<Integer> time;
+
+	private final ConfigData<Boolean> addTime;
+	private final ConfigData<Boolean> setPlayerTime;
 
 	private String strAnnounce;
-		
+
 	public TimeSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		
-		timeToSet = getConfigDataInt("time-to-set", 0);
-		strAnnounce = getConfigString("str-announce", "The sun suddenly appears in the sky.");
+
+		time = getConfigDataInt("time", getConfigDataInt("time-to-set", 0));
+
+		addTime = getConfigDataBoolean("add-time", false);
+		setPlayerTime = getConfigDataBoolean("set-player-time", false);
+
+		strAnnounce = getConfigString("str-announce", "");
 	}
 
 	@Override
 	public CastResult cast(SpellData data) {
-		setTime(data.caster().getWorld(), data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return setTime(data.caster().getWorld(), data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		return setTime(data.target().getWorld(), data);
 	}
 
 	@Override
 	public CastResult castAtLocation(SpellData data) {
-		setTime(data.location().getWorld(), data);
-		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+		return setTime(data.location().getWorld(), data);
 	}
 
-	private void setTime(World world, SpellData data) {
-		world.setTime(timeToSet.get(data));
-		for (Player p : world.getPlayers()) sendMessage(strAnnounce, p, data);
+	private CastResult setTime(World world, SpellData data) {
+		long time = this.time.get(data);
+		if (addTime.get(data)) time += world.getTime();
+
+		if (setPlayerTime.get(data)) {
+			if (!(data.target() instanceof Player player)) return noTarget(data);
+			player.setPlayerTime(time, true); // Reset with "time: 0".
+		} else world.setTime(time);
+
+		sendMessageNear(strAnnounce, data);
 		playSpellEffects(data);
+
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 
 	public String getStrAnnounce() {

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/WeatherSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/WeatherSpell.java
@@ -1,0 +1,100 @@
+package com.nisovin.magicspells.spells.instant;
+
+import org.bukkit.World;
+import org.bukkit.GameRules;
+import org.bukkit.WeatherType;
+import org.bukkit.entity.Player;
+
+import net.kyori.adventure.util.TriState;
+
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.CastResult;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spells.TargetedLocationSpell;
+
+public class WeatherSpell extends InstantSpell implements TargetedEntitySpell, TargetedLocationSpell {
+
+	private final ConfigData<TriState> rain;
+	private final ConfigData<TriState> thunder;
+	private final ConfigData<TriState> advance;
+
+	private final ConfigData<Integer> durationClear;
+	private final ConfigData<Integer> durationWeather;
+	private final ConfigData<Integer> durationThunder;
+
+	private final ConfigData<PlayerWeather> playerWeather;
+
+	public WeatherSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		rain = getConfigDataEnum("rain", TriState.class, TriState.NOT_SET);
+		thunder = getConfigDataEnum("thunder", TriState.class, TriState.NOT_SET);
+		advance = getConfigDataEnum("advance", TriState.class, TriState.NOT_SET);
+
+		durationClear = getConfigDataInt("duration-clear", -1);
+		durationWeather = getConfigDataInt("duration-weather", -1);
+		durationThunder = getConfigDataInt("duration-thunder", -1);
+
+		playerWeather = getConfigDataEnum("player-weather", PlayerWeather.class, null);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		return weather(data.caster().getWorld(), data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		return weather(data.target().getWorld(), data);
+	}
+
+	@Override
+	public CastResult castAtLocation(SpellData data) {
+		return weather(data.location().getWorld(), data);
+	}
+
+	private CastResult weather(World world, SpellData data) {
+		PlayerWeather playerWeather = this.playerWeather.get(data);
+
+		if (playerWeather == null) {
+			Boolean rain = this.rain.get(data).toBoolean();
+			if (rain != null) world.setStorm(rain);
+
+			Boolean thunder = this.thunder.get(data).toBoolean();
+			if (thunder != null) world.setThundering(thunder);
+
+			Boolean advance = this.advance.get(data).toBoolean();
+			if (advance != null) world.setGameRule(GameRules.ADVANCE_WEATHER, advance);
+
+			int durationWeather = this.durationWeather.get(data);
+			if (durationWeather >= 0) world.setWeatherDuration(durationWeather);
+
+			int durationThunder = this.durationThunder.get(data);
+			if (durationThunder >= 0) world.setThunderDuration(durationThunder);
+
+			int durationClear = this.durationClear.get(data);
+			if (durationClear >= 0) world.setClearWeatherDuration(durationClear);
+		} else {
+			if (!(data.target() instanceof Player player)) return noTarget(data);
+
+			switch (playerWeather) {
+				case CLEAR -> player.setPlayerWeather(WeatherType.CLEAR);
+				case DOWNFALL -> player.setPlayerWeather(WeatherType.DOWNFALL);
+				case RESET -> player.resetPlayerWeather();
+			}
+		}
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	private enum PlayerWeather {
+		CLEAR,
+		DOWNFALL,
+		RESET,
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/WeatherSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/WeatherSpell.java
@@ -1,0 +1,94 @@
+package com.nisovin.magicspells.spells.instant;
+
+import org.bukkit.World;
+import org.bukkit.WeatherType;
+import org.bukkit.entity.Player;
+
+import net.kyori.adventure.util.TriState;
+
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.CastResult;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.spells.TargetedLocationSpell;
+
+public class WeatherSpell extends InstantSpell implements TargetedEntitySpell, TargetedLocationSpell {
+
+	private final ConfigData<TriState> rain;
+	private final ConfigData<TriState> thunder;
+
+	private final ConfigData<Integer> durationClear;
+	private final ConfigData<Integer> durationWeather;
+	private final ConfigData<Integer> durationThunder;
+
+	private final ConfigData<PlayerWeather> playerWeather;
+
+	public WeatherSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		rain = getConfigDataEnum("rain", TriState.class, TriState.NOT_SET);
+		thunder = getConfigDataEnum("thunder", TriState.class, TriState.NOT_SET);
+
+		durationClear = getConfigDataInt("duration-clear", -1);
+		durationWeather = getConfigDataInt("duration-weather", -1);
+		durationThunder = getConfigDataInt("duration-thunder", -1);
+
+		playerWeather = getConfigDataEnum("player-weather", PlayerWeather.class, null);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		return weather(data.caster().getWorld(), data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		return weather(data.target().getWorld(), data);
+	}
+
+	@Override
+	public CastResult castAtLocation(SpellData data) {
+		return weather(data.location().getWorld(), data);
+	}
+
+	private CastResult weather(World world, SpellData data) {
+		PlayerWeather playerWeather = this.playerWeather.get(data);
+
+		if (playerWeather == null) {
+			Boolean rain = this.rain.get(data).toBoolean();
+			if (rain != null) world.setStorm(rain);
+
+			Boolean thunder = this.thunder.get(data).toBoolean();
+			if (thunder != null) world.setThundering(thunder);
+
+			int durationWeather = this.durationWeather.get(data);
+			if (durationWeather >= 0) world.setWeatherDuration(durationWeather);
+
+			int durationThunder = this.durationThunder.get(data);
+			if (durationThunder >= 0) world.setThunderDuration(durationThunder);
+
+			int durationClear = this.durationClear.get(data);
+			if (durationClear >= 0) world.setClearWeatherDuration(durationClear);
+		} else {
+			if (!(data.target() instanceof Player player)) return noTarget(data);
+
+			switch (playerWeather) {
+				case CLEAR -> player.setPlayerWeather(WeatherType.CLEAR);
+				case DOWNFALL -> player.setPlayerWeather(WeatherType.DOWNFALL);
+				case RESET -> player.resetPlayerWeather();
+			}
+		}
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	private enum PlayerWeather {
+		CLEAR,
+		DOWNFALL,
+		RESET,
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/LightningSpell.java
@@ -6,12 +6,12 @@ import java.util.HashMap;
 
 import org.bukkit.Location;
 import org.bukkit.event.Listener;
+import org.bukkit.entity.EntityType;
 import org.bukkit.damage.DamageType;
 import org.bukkit.event.EventHandler;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.damage.DamageSource;
 import org.bukkit.entity.LightningStrike;
-import org.bukkit.event.entity.PigZapEvent;
 import org.bukkit.event.entity.CreeperPowerEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 
@@ -155,17 +155,11 @@ public class LightningSpell extends TargetedSpell implements TargetedLocationSpe
 		}
 
 		@EventHandler
-		public void onPigZap(PigZapEvent event) {
-			ChargeOption option = striking.get(event.getLightning().getUniqueId());
-			if (option == null || option.transformEntities && option.changePig) return;
-
-			event.setCancelled(true);
-		}
-
-		@EventHandler
 		public void onZap(EntityZapEvent event) {
 			ChargeOption option = striking.get(event.getBolt().getUniqueId());
-			if (option == null || option.transformEntities) return;
+
+			if (option == null) return;
+			if (option.transformEntities && (event.getEntity().getType() != EntityType.PIG || option.changePig)) return;
 
 			event.setCancelled(true);
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ParticleCloudSpell.java
@@ -20,6 +20,7 @@ import org.jetbrains.annotations.NotNull;
 import net.kyori.adventure.text.Component;
 
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
@@ -41,18 +42,25 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 	private final ConfigData<Particle.Spell> spellOptions;
 	private final ConfigData<DustTransition> dustTransition;
 
+	private final ConfigData<Color> trailColor;
+	private final ConfigData<Integer> trailDuration;
+	private final ConfigData<Vector> trailTargetOffset;
+	private final ConfigData<Vector> trailTargetRelativeOffset;
+
 	private final ConfigData<Particle> particle;
 
 	private final ConfigData<Integer> waitTime;
 	private final ConfigData<Integer> shriekDelay;
 	private final ConfigData<Integer> ticksDuration;
 	private final ConfigData<Integer> durationOnUse;
+	private final ConfigData<Integer> geyserWaterBlocks;
 	private final ConfigData<Integer> reapplicationDelay;
 
 	private final ConfigData<Float> radius;
 	private final ConfigData<Float> radiusOnUse;
 	private final ConfigData<Float> radiusPerTick;
 	private final ConfigData<Float> dragonBreathPower;
+	private final ConfigData<Float> geyserBurstImpulse;
 	private final ConfigData<Float> sculkChargeRotation;
 
 	private final ConfigData<Boolean> useGravity;
@@ -81,6 +89,14 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 				new DustTransition(Color.RED, Color.BLACK, 1)
 		);
 		spellOptions = ConfigDataUtil.getSpellOptions(config.getMainConfig(), internalKey + "spell.color", internalKey + "spell.power", null);
+
+		trailColor = getConfigDataColor("trail.color", null);
+		trailDuration = getConfigDataInt("trail.duration", _ -> null);
+		trailTargetOffset = getConfigDataVector("trail.target-offset", new Vector());
+		trailTargetRelativeOffset = getConfigDataVector("trail.target-relative-offset", new Vector());
+
+		geyserWaterBlocks = getConfigDataInt("geyser.water-blocks", _ -> null);
+		geyserBurstImpulse = getConfigDataFloat("geyser.burst-impulse", _ -> null);
 
 		ConfigData<Material> material = getConfigDataMaterial("material", null);
 		if (material.isConstant()) {
@@ -180,7 +196,7 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 					cloud.addCustomEffect(eff.get(finalData), true);
 
 			Particle particle = this.particle.get(finalData);
-			cloud.setParticle(particle, getParticleData(particle, finalData));
+			if (particle != Particle.VIBRATION) cloud.setParticle(particle, getParticleData(particle, finalData));
 
 			Component customName = this.customName.get(finalData);
 			if (customName != null) {
@@ -194,6 +210,13 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 	}
 
 	private Object getParticleData(@NotNull Particle particle, @NotNull SpellData data) {
+		Object nmsData = MagicSpells.getVolatileCodeHandler().getVolatileParticleData(
+			particle,
+			() -> geyserWaterBlocks.get(data),
+			() -> geyserBurstImpulse.get(data)
+		);
+		if (nmsData != null) return nmsData;
+
 		Class<?> type = particle.getDataType();
 
 		if (type == ItemStack.class) return item.get(data);
@@ -206,6 +229,22 @@ public class ParticleCloudSpell extends TargetedSpell implements TargetedLocatio
 			return particle == Particle.ENTITY_EFFECT ?
 				argbColor.get(data) :
 				rgbColor.get(data);
+		}
+
+		if (type == Particle.Trail.class) {
+			Color color = trailColor.get(data);
+			if (color == null) return null;
+
+			Integer duration = trailDuration.get(data);
+			if (duration == null) return null;
+
+			Vector relativeOffset = trailTargetRelativeOffset.get(data);
+			Vector offset = trailTargetOffset.get(data);
+
+			Location loc = data.location().add(offset);
+			if (!relativeOffset.isZero()) Util.applyRelativeOffset(loc, relativeOffset);
+
+			return new Particle.Trail(loc, color, duration);
 		}
 
 		return switch (particle) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
@@ -6,7 +6,10 @@ import java.util.ArrayList;
 import java.io.IOException;
 import java.io.FileInputStream;
 
+import org.bukkit.World;
+import org.bukkit.Material;
 import org.bukkit.Location;
+import org.bukkit.block.Block;
 
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.EditSession;
@@ -30,7 +33,7 @@ import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 
-	private final List<EditSession> sessions;
+	private final List<EditSession> sessions = new ArrayList<>();
 
 	private Clipboard clipboard;
 
@@ -40,8 +43,11 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 	private final ConfigData<Integer> undoDelay;
 
 	private final ConfigData<Boolean> pasteAir;
+	private final ConfigData<Boolean> pasteStructureVoid;
+
 	private final ConfigData<Boolean> removePaste;
 	private final ConfigData<Boolean> pasteAtCaster;
+	private final ConfigData<Boolean> preventOverwrite;
 
 	public PasteSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -56,10 +62,11 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 		undoDelay = getConfigDataInt("undo-delay", 0);
 
 		pasteAir = getConfigDataBoolean("paste-air", false);
+		pasteStructureVoid = getConfigDataBoolean("paste-structure-void", false);
+
 		removePaste = getConfigDataBoolean("remove-paste", true);
 		pasteAtCaster = getConfigDataBoolean("paste-at-caster", false);
-
-		sessions = new ArrayList<>();
+		preventOverwrite = getConfigDataBoolean("prevent-overwrite", false);
 	}
 
 	@Override
@@ -110,11 +117,35 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 		target.add(0, yOffset.get(data), 0);
 		data = data.location(target);
 
-		try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(target.getWorld()))) {
+		World world = target.getWorld();
+		BlockVector3 pasteTo = BukkitAdapter.asBlockVector(target);
+
+		boolean ignoreAir = !pasteAir.get(data);
+		boolean ignoreStructureVoid = !pasteStructureVoid.get(data);
+
+		if (preventOverwrite.get(data)) {
+			BlockVector3 offset = pasteTo.subtract(clipboard.getOrigin());
+
+			for (BlockVector3 pos : clipboard.getRegion()) {
+				BlockVector3 worldPos = pos.add(offset);
+				Block origin = world.getBlockAt(worldPos.x(), worldPos.y(), worldPos.z());
+				if (origin.getType().isAir()) continue;
+
+				Material place = BukkitAdapter.adapt(clipboard.getFullBlock(pos).getBlockType());
+
+				if (ignoreAir && place.isAir()) continue;
+				if (ignoreStructureVoid && place == Material.STRUCTURE_VOID) continue;
+
+				return noTarget(data);
+			}
+		}
+
+		try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
 			Operation operation = new ClipboardHolder(clipboard)
 				.createPaste(editSession)
-				.to(BlockVector3.at(target.getX(), target.getY(), target.getZ()))
-				.ignoreAirBlocks(!pasteAir.get(data))
+				.to(pasteTo)
+				.ignoreAirBlocks(ignoreAir)
+				.ignoreStructureVoidBlocks(ignoreStructureVoid)
 				.build();
 
 			Operations.complete(operation);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/PasteSpell.java
@@ -5,8 +5,15 @@ import java.util.List;
 import java.util.ArrayList;
 import java.io.IOException;
 import java.io.FileInputStream;
+import java.util.function.Predicate;
 
+import org.bukkit.World;
+import org.bukkit.Material;
 import org.bukkit.Location;
+import org.bukkit.block.Block;
+import org.bukkit.block.BlockType;
+
+import io.papermc.paper.registry.RegistryKey;
 
 import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.EditSession;
@@ -30,7 +37,7 @@ import com.nisovin.magicspells.events.SpellTargetLocationEvent;
 
 public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 
-	private final List<EditSession> sessions;
+	private final List<EditSession> sessions = new ArrayList<>();
 
 	private Clipboard clipboard;
 
@@ -42,6 +49,9 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 	private final ConfigData<Boolean> pasteAir;
 	private final ConfigData<Boolean> removePaste;
 	private final ConfigData<Boolean> pasteAtCaster;
+	private final ConfigData<Boolean> pasteStructureVoid;
+
+	private final Predicate<BlockType> preventOverwrite;
 
 	public PasteSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -58,8 +68,11 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 		pasteAir = getConfigDataBoolean("paste-air", false);
 		removePaste = getConfigDataBoolean("remove-paste", true);
 		pasteAtCaster = getConfigDataBoolean("paste-at-caster", false);
+		pasteStructureVoid = getConfigDataBoolean("paste-structure-void", false);
 
-		sessions = new ArrayList<>();
+		if (config.isBoolean(internalKey + "prevent-overwrite")) {
+			preventOverwrite = getConfigBoolean("prevent-overwrite", false) ? _ -> true : null;
+		} else preventOverwrite = getConfigRegistryEntryPredicate("prevent-overwrite", RegistryKey.BLOCK);
 	}
 
 	@Override
@@ -110,11 +123,37 @@ public class PasteSpell extends TargetedSpell implements TargetedLocationSpell {
 		target.add(0, yOffset.get(data), 0);
 		data = data.location(target);
 
-		try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(target.getWorld()))) {
+		World world = target.getWorld();
+		BlockVector3 pasteTo = BukkitAdapter.asBlockVector(target);
+
+		boolean ignoreAir = !pasteAir.get(data);
+		boolean ignoreStructureVoid = !pasteStructureVoid.get(data);
+
+		if (preventOverwrite != null) {
+			BlockVector3 offset = pasteTo.subtract(clipboard.getOrigin());
+
+			for (BlockVector3 pos : clipboard.getRegion()) {
+				BlockVector3 worldPos = pos.add(offset);
+				Block origin = world.getBlockAt(worldPos.x(), worldPos.y(), worldPos.z());
+
+				if (origin.isEmpty()) continue;
+				if (!preventOverwrite.test(origin.getType().asBlockType())) continue;
+
+				Material place = BukkitAdapter.adapt(clipboard.getFullBlock(pos).getBlockType());
+
+				if (ignoreAir && place.isAir()) continue;
+				if (ignoreStructureVoid && place == Material.STRUCTURE_VOID) continue;
+
+				return noTarget(data);
+			}
+		}
+
+		try (EditSession editSession = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(world))) {
 			Operation operation = new ClipboardHolder(clipboard)
 				.createPaste(editSession)
-				.to(BlockVector3.at(target.getX(), target.getY(), target.getZ()))
-				.ignoreAirBlocks(!pasteAir.get(data))
+				.to(pasteTo)
+				.ignoreAirBlocks(ignoreAir)
+				.ignoreStructureVoidBlocks(ignoreStructureVoid)
 				.build();
 
 			Operations.complete(operation);

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/SpellEffectManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/SpellEffectManager.java
@@ -80,6 +80,7 @@ public class SpellEffectManager {
 		addSpellEffect(EffectLibLineEffect.class);
 		addSpellEffect(EnderSignalEffect.class);
 		addSpellEffect(EntityEffect.class);
+		addSpellEffect(ExperienceEffect.class);
 		addSpellEffect(ExplosionEffect.class);
 		addSpellEffect(FireworksEffect.class);
 		addSpellEffect(GameTestAddMarkerEffect.class);

--- a/core/src/main/java/com/nisovin/magicspells/variables/meta/ExperienceVariable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/meta/ExperienceVariable.java
@@ -17,7 +17,7 @@ public class ExperienceVariable extends MetaVariable {
 	@Override
 	public void set(String player, double amount) {
 		Player p = Bukkit.getPlayerExact(player);
-		if (p != null) p.setExp((int) amount);
+		if (p != null) p.setExp((float) amount);
 	}
 
 }

--- a/nms/latest/src/main/java/com/nisovin/magicspells/volatilecode/latest/VolatileCodeLatest.java
+++ b/nms/latest/src/main/java/com/nisovin/magicspells/volatilecode/latest/VolatileCodeLatest.java
@@ -4,6 +4,7 @@ import java.util.*;
 import java.lang.invoke.VarHandle;
 import java.util.function.Consumer;
 import java.lang.invoke.MethodType;
+import java.util.function.Supplier;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 
@@ -11,6 +12,7 @@ import it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap;
 
 import org.bukkit.World;
 import org.bukkit.Bukkit;
+import org.bukkit.Particle;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Entity;
@@ -29,6 +31,7 @@ import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.craftbukkit.entity.CraftLivingEntity;
 
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 import net.kyori.adventure.text.Component;
 
@@ -290,6 +293,32 @@ public class VolatileCodeLatest extends VolatileCodeHandle {
 		}
 
 		return count;
+	}
+
+	@Override
+	public @Nullable Object getVolatileParticleData(
+		Particle particle,
+		Supplier<Integer> geyserWaterBlocks,
+		Supplier<Float> geyserBurstImpulse
+	) {
+		Class<?> type = particle.getDataType();
+
+		if (type == Particle.Geyser.class) {
+			Integer waterBlocks = geyserWaterBlocks.get();
+			if (waterBlocks == null) return null;
+
+			return new Particle.Geyser(waterBlocks);
+		}
+
+		if (type == Particle.GeyserBase.class) {
+			Integer waterBlocks = geyserWaterBlocks.get();
+			Float burstImpulse = geyserBurstImpulse.get();
+			if (waterBlocks == null || burstImpulse == null) return null;
+
+			return new Particle.GeyserBase(waterBlocks, burstImpulse);
+		}
+
+		return null;
 	}
 
 }

--- a/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
+++ b/nms/shared/src/main/java/com/nisovin/magicspells/volatilecode/VolatileCodeHandle.java
@@ -1,16 +1,22 @@
 package com.nisovin.magicspells.volatilecode;
 
+import java.util.function.Supplier;
+
 import org.bukkit.World;
+import org.bukkit.Particle;
 import org.bukkit.entity.*;
 import org.bukkit.Location;
 import org.bukkit.util.Vector;
 import org.bukkit.inventory.ItemStack;
 
+import org.jetbrains.annotations.Nullable;
+
 import net.kyori.adventure.text.Component;
+
+import com.nisovin.magicspells.util.glow.GlowManager;
 
 import io.papermc.paper.advancement.AdvancementDisplay.Frame;
 
-import com.nisovin.magicspells.util.glow.GlowManager;
 
 public abstract class VolatileCodeHandle {
 
@@ -43,5 +49,14 @@ public abstract class VolatileCodeHandle {
 	public abstract long countGlobalRegionSchedulerTasks();
 
 	public abstract long countEntitySchedulerTasks();
+
+	@Nullable
+	public Object getVolatileParticleData(
+		Particle particle,
+		Supplier<Integer> geyserWaterBlocks,
+		Supplier<Float> geyserBurstImpulse
+	) {
+		return null;
+	}
 
 }

--- a/nms/v26_1_2/build.gradle
+++ b/nms/v26_1_2/build.gradle
@@ -3,6 +3,6 @@ plugins {
 }
 
 dependencies {
-    paperweight.paperDevBundle("26.2.build.+")
+    paperweight.paperDevBundle("26.1.2.build.+")
     implementation project(":nms:shared")
 }

--- a/nms/v26_1_2/src/main/java/com/nisovin/magicspells/volatilecode/v26_1_2/VolatileCode_v26_1_2.java
+++ b/nms/v26_1_2/src/main/java/com/nisovin/magicspells/volatilecode/v26_1_2/VolatileCode_v26_1_2.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.volatilecode.latest;
+package com.nisovin.magicspells.volatilecode.v26_1_2;
 
 import java.util.*;
 import java.lang.invoke.VarHandle;
@@ -48,21 +48,20 @@ import net.minecraft.advancements.*;
 import net.minecraft.world.phys.Vec3;
 import net.minecraft.resources.Identifier;
 import net.minecraft.server.MinecraftServer;
+import net.minecraft.world.entity.EntityType;
 import net.minecraft.network.protocol.game.*;
-import net.minecraft.world.entity.EntityTypes;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.item.PrimedTnt;
 import net.minecraft.core.particles.ParticleTypes;
 import net.minecraft.core.particles.ParticleOptions;
-import net.minecraft.advancements.triggers.Criterion;
 import net.minecraft.network.syncher.SynchedEntityData;
 import net.minecraft.network.syncher.EntityDataAccessor;
 import net.minecraft.core.particles.ColorParticleOption;
-import net.minecraft.advancements.triggers.ImpossibleTrigger;
+import net.minecraft.advancements.criterion.ImpossibleTrigger;
 import net.minecraft.world.entity.boss.enderdragon.EnderDragon;
 
-public class VolatileCodeLatest extends VolatileCodeHandle {
+public class VolatileCode_v26_1_2 extends VolatileCodeHandle {
 
 	private final Identifier TOAST_KEY = Identifier.fromNamespaceAndPath("magicspells", "toast_effect");
 
@@ -77,7 +76,7 @@ public class VolatileCodeLatest extends VolatileCodeHandle {
 	private final VarHandle RUN_HANDLE;
 
 	@SuppressWarnings("unchecked")
-	public VolatileCodeLatest(VolatileCodeHelper helper) throws Exception {
+	public VolatileCode_v26_1_2(VolatileCodeHelper helper) throws Exception {
 		super(helper);
 
 		MethodHandles.Lookup lookup = MethodHandles.lookup();
@@ -154,7 +153,7 @@ public class VolatileCodeLatest extends VolatileCodeHandle {
 
 	@Override
 	public void playDragonDeathEffect(Location location) {
-		EnderDragon dragon = new EnderDragon(EntityTypes.ENDER_DRAGON, ((CraftWorld) location.getWorld()).getHandle());
+		EnderDragon dragon = new EnderDragon(EntityType.ENDER_DRAGON, ((CraftWorld) location.getWorld()).getHandle());
 		dragon.setPos(location.x(), location.y(), location.z());
 
 		BlockPos pos = new BlockPos(location.getBlockX(), location.getBlockY(), location.getBlockZ());
@@ -251,7 +250,7 @@ public class VolatileCodeLatest extends VolatileCodeHandle {
 
 	@Override
 	public GlowManager getGlowManager() {
-		return new VolatileGlowManagerLatest(helper);
+		return new VolatileGlowManager_v26_1_2(helper);
 	}
 
 	@Override

--- a/nms/v26_1_2/src/main/java/com/nisovin/magicspells/volatilecode/v26_1_2/VolatileGlowManager_v26_1_2.java
+++ b/nms/v26_1_2/src/main/java/com/nisovin/magicspells/volatilecode/v26_1_2/VolatileGlowManager_v26_1_2.java
@@ -1,4 +1,4 @@
-package com.nisovin.magicspells.volatilecode.latest;
+package com.nisovin.magicspells.volatilecode.v26_1_2;
 
 import org.jetbrains.annotations.NotNull;
 
@@ -12,7 +12,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelOutboundHandlerAdapter;
 
-import net.minecraft.world.scores.TeamColor;
+import net.minecraft.ChatFormatting;
 import net.minecraft.network.protocol.Packet;
 import net.minecraft.world.scores.PlayerTeam;
 import net.minecraft.world.scores.Scoreboard;
@@ -42,7 +42,7 @@ import com.nisovin.magicspells.util.glow.LibsDisguiseHelper;
 import com.nisovin.magicspells.volatilecode.VolatileCodeHelper;
 import com.nisovin.magicspells.util.glow.PacketBasedGlowManager;
 
-public class VolatileGlowManagerLatest extends PacketBasedGlowManager<Packet<?>, ClientboundSetEntityDataPacket, ClientboundSetPlayerTeamPacket> {
+public class VolatileGlowManager_v26_1_2 extends PacketBasedGlowManager<Packet<?>, ClientboundSetEntityDataPacket, ClientboundSetPlayerTeamPacket> {
 
 	private static final EntityDataAccessor<Byte> DATA_SHARED_FLAGS_ID = new EntityDataAccessor<>(0, EntityDataSerializers.BYTE);
 
@@ -50,7 +50,7 @@ public class VolatileGlowManagerLatest extends PacketBasedGlowManager<Packet<?>,
 	private final MethodHandle teamPacketHandle;
 	private final VolatileCodeHelper helper;
 
-	public VolatileGlowManagerLatest(VolatileCodeHelper helper) {
+	public VolatileGlowManager_v26_1_2(VolatileCodeHelper helper) {
 		this.helper = helper;
 
 		try {
@@ -92,12 +92,14 @@ public class VolatileGlowManagerLatest extends PacketBasedGlowManager<Packet<?>,
 		Visibility visibility = getStringOption("name-tag-visibility", Visibility.ALWAYS, StringRepresentable.createNameLookup(Visibility.values()), config, helper::error);
 
 		Scoreboard scoreboard = new Scoreboard();
-		for (TeamColor color : TeamColor.values()) {
-			PlayerTeam team = new PlayerTeam(scoreboard, "magicspells:" + color.getSerializedName());
+		for (ChatFormatting formatting : ChatFormatting.values()) {
+			if (!formatting.isColor()) continue;
+
+			PlayerTeam team = new PlayerTeam(scoreboard, "magicspells:" + formatting.getName());
 			team.setSeeFriendlyInvisibles(seeFriendlyInvisibles);
 			team.setNameTagVisibility(visibility);
 			team.setCollisionRule(collision);
-			team.setColor(Optional.of(color));
+			team.setColor(formatting);
 
 			teamPackets.add(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, true));
 		}
@@ -110,8 +112,10 @@ public class VolatileGlowManagerLatest extends PacketBasedGlowManager<Packet<?>,
 		List<ClientboundSetPlayerTeamPacket> packets = new ArrayList<>();
 
 		Scoreboard scoreboard = new Scoreboard();
-		for (TeamColor color : TeamColor.values()) {
-			PlayerTeam team = new PlayerTeam(scoreboard, "magicspells:" + color.getSerializedName());
+		for (ChatFormatting formatting : ChatFormatting.values()) {
+			if (!formatting.isColor()) continue;
+
+			PlayerTeam team = new PlayerTeam(scoreboard, "magicspells:" + formatting.getName());
 			packets.add(ClientboundSetPlayerTeamPacket.createRemovePacket(team));
 		}
 
@@ -245,7 +249,7 @@ public class VolatileGlowManagerLatest extends PacketBasedGlowManager<Packet<?>,
 				return;
 			}
 
-			synchronized (VolatileGlowManagerLatest.this) {
+			synchronized (VolatileGlowManager_v26_1_2.this) {
 				if (glows.isEmpty() && perPlayerGlows.isEmpty()) {
 					super.write(ctx, msg, promise);
 					return;

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -9,6 +9,7 @@ include("towny")
 
 include(":nms:shared")
 include(":nms:latest")
+include(":nms:v26_1_2")
 
 pluginManagement {
     repositories {

--- a/shop/build.gradle
+++ b/shop/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation project(":core")
-    implementation("org.incendo:cloud-paper:2.0.0-beta.14")
+    implementation("org.incendo:cloud-paper:2.0.0-beta.16")
     implementation("net.milkbowl.vault:VaultAPI:1.7") { transitive = false }
 }
 


### PR DESCRIPTION
> Added `26.2` version support.


## Changes:

- `TimeSpell` can now target players when cast as a sub-spell.
- Removed the default `TimeSpell` message for `str-announce` for convenience.



## Additions:

- `.instant.TimeSpell`:
  - Added `time` as an alias to `time-to-set`.
  - Added `add-time` and `set-player-time` boolean toggles. Player time can be reset with `time: 0`.
- `.targeted.PasteSpell`:
  - Added `paste-structure-void` (boolean, defaults to `false`) - Toggle whether `structure_void` within the schematic will be placed or ignored.
  - Added `prevent-overwrite` - May be a boolean or a ([Predicate](https://github.com/TheComputerGeek2/MagicSpells/wiki/Other-Data-Types#predicate) of [Material](https://jasperlorelai.eu/paperdocs/-/org/bukkit/Material.html), but exclusively block types) - When unspecified or empty, all blocks are overwritten like usual. When `true`, after filtering out `paste-air` & `paste-structure-void`, this option will prevent the paste from succeeding if a schematic block overrides any block in the world. When a Predicate, it only prevents overwriting of blocks that match the predicate. For example, you can allow the replacement of blocks that have the [`#replaceable`](https://minecraft.wiki/w/Block_tag_(Java_Edition)#replaceable) tag (plants, liquids, water, etc. - **but also `light` blocks**). But you can easily prevent extra blocks with the predicate, like `light`, `barrier`, `bedrock`, etc.

    ```yml
    prevent-overwrite: "!#replaceable && (light && bedrock && barrier)"`
    ```

- Added `.instant.WeatherSpell`:
  - `rain` and `thunder` - Boolean values, unset by default.
  - `duration-clear`, `duration-weather`, `duration-thunder` - Integer ticks. These options override the default randomised weather clocks caused by `rain` & `thunder`. 
  - `player-weather` - Ignores all other options because it affects only the player weather. Can be `clear`, `downfall` or `reset`.
- Added `experience` spell effect with integer options `level` and `progress` (`[0, 100]` interval), and a `reset` boolean option. The spell effect can fake the change in experience level and/or progress for the player target of the effect.
- Added `require-supported-item` to `EnchantSpell`, a boolean option, defaulting to `true`. When disabled, this allows items which are normally not supported by an enchantment to be enchanted on the item. This will always pass for `book`.
- Added options to `ParticleCloudSpell` for configuring the appearance of the `trail` particle. Under a `trail` section, you can now configure `color` ([Color](https://github.com/TheComputerGeek2/MagicSpells/wiki/Other-Data-Types#color)), `duration` (Integer), `target-offset` ([Vector](https://github.com/TheComputerGeek2/MagicSpells/wiki/Other-Data-Types#vector)), and `target-relative-offset` ([Vector](https://github.com/TheComputerGeek2/MagicSpells/wiki/Other-Data-Types#vector)).
- Added options to configure the `26.2` geyser particles:
  - To the `particles` spell effect and the `ParticleCloudSpell`: Under a `geyser` section, you can use `water-blocks` (Integer) and `burst-impulse` (Float).
  - To the `effectlib` effects: `geyserWaterBlocks` (Integer) and `geyserBurstImpulse` (Float).



## Fixes:

- Fixed an issue with `meta_experience_points` not accepting float values, but only integer values, while its acceptable value range is `0.0` to `1.0`.
- Fixed an issue with the `switch` expression function by EvalEx failing to compare numeric values properly.
- The `attributedefault` modifier condition now properly checks against the default attributes of the target entity type, not the server's default attributes.
- Fixed an issue with `ParticleCloudSpell` failing when the `trail` and `vibration` particles were used. `trail` now has new options to configure the particle appearance. The way `vibration` plays in the particle cloud makes less sense to be available in the spell, so the spell plays the default potion particles instead.