### PR TITLE
Dialogs

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -942,7 +942,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 	}
 
 	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(@NotNull String key, @NotNull RegistryKey<T> registryKey, @Nullable T def) {
-		return ConfigDataUtil.getRegistryEntry(config.getMainConfig(), internalKey + key, RegistryAccess.registryAccess().getRegistry(registryKey), def);
+		return ConfigDataUtil.getRegistryEntry(config.getMainConfig(), internalKey + key, registryKey, def);
 	}
 
 	protected <T extends Keyed> ConfigData<T> getConfigDataRegistryEntry(@NotNull String key, @NotNull Registry<T> registry, @Nullable T def) {

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierSet.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierSet.java
@@ -54,7 +54,7 @@ public class ModifierSet {
 
 				if (isFromManaSystem) MagicSpells.error("Mana system has a problem with modifier '" + s + "'" + extra);
 				else if (spell != null) MagicSpells.error("Spell '" + spell.getInternalName() + "' has a problem with modifier '" + s + "'" + extra);
-				else MagicSpells.error("Problem with modifier: " + s + "'" + extra);
+				else MagicSpells.error("Problem with modifier: '" + s + "'" + extra);
 				continue;
 			}
 

--- a/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
+++ b/core/src/main/java/com/nisovin/magicspells/castmodifiers/ModifierType.java
@@ -854,7 +854,7 @@ public enum ModifierType {
 			if (!(spellData.caster() instanceof Player caster)) return;
 
 			String value = MagicSpells.doReplacements(data.value, spellData);
-			MagicSpells.getVariableManager().set(data.variable, caster.getName(), value);
+			MagicSpells.getVariableManager().set(data.variable, caster, value);
 		}
 
 		@Override

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/AnvilInputSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/AnvilInputSpell.java
@@ -1,0 +1,133 @@
+package com.nisovin.magicspells.spells.instant;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.HashSet;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.MenuType;
+import org.bukkit.event.EventHandler;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.view.AnvilView;
+import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.event.inventory.InventoryClickEvent;
+import org.bukkit.event.inventory.InventoryCloseEvent;
+
+import com.nisovin.magicspells.Subspell;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.CastResult;
+import com.nisovin.magicspells.util.MagicConfig;
+import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
+import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
+
+@SuppressWarnings("UnstableApiUsage")
+public class AnvilInputSpell extends InstantSpell implements TargetedEntitySpell {
+
+	private static final ItemStack PAPER = ItemStack.of(Material.PAPER);
+	static {
+		PAPER.editMeta(meta -> meta.customName(Component.empty()));
+	}
+
+	private final Map<Player, AnvilView> open = new HashMap<>();
+
+	private final ConfigData<Component> title;
+
+	private Variable variable;
+	private Subspell spellOnClose;
+
+	public AnvilInputSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+
+		title = getConfigDataComponent("title", null);
+	}
+
+	@Override
+	public void initializeVariables() {
+		super.initializeVariables();
+
+		String variableName = getConfigString("variable-name", null);
+		Variable variable = MagicSpells.getVariableManager().getVariable(variableName);
+		if (variable instanceof PlayerStringVariable || variable instanceof GlobalStringVariable) {
+			this.variable = variable;
+			return;
+		}
+		MagicSpells.error("AnvilInputSpell '" + internalName + "' has an invalid 'variable-name' defined!");
+	}
+
+	@Override
+	protected void initialize() {
+		super.initialize();
+
+		spellOnClose = initSubspell(
+			getConfigString("spell-on-close", null),
+			"AnvilInputSpell " + internalName + " has an invalid 'spell-on-close' defined!",
+			true
+		);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		return castAtEntity(data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		if (!(data.target() instanceof Player player)) return noTarget(data);
+
+		AnvilView anvil = MenuType.ANVIL.create(player, title.get(data));
+		anvil.setMaximumRepairCost(0);
+		anvil.setItem(0, PAPER);
+		anvil.open();
+
+		open.put(player, anvil);
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+	@Override
+	protected void turnOff() {
+		for (AnvilView anvil : new HashSet<>(open.values())) anvil.close();
+		open.clear();
+	}
+
+	@EventHandler
+	private void onClick(InventoryClickEvent event) {
+		if (!(event.getWhoClicked() instanceof Player player)) return;
+
+		AnvilView anvil = open.get(player);
+		if (anvil == null) return;
+
+		event.setCancelled(true);
+
+		if (!event.getClick().isMouseClick()) return;
+		if (event.getSlotType() != InventoryType.SlotType.RESULT) return;
+
+		if (variable != null) variable.parseAndSet(player, anvil.getRenameText());
+
+		anvil.close();
+	}
+
+	@EventHandler
+	private void onClose(InventoryCloseEvent event) {
+		if (!(event.getPlayer() instanceof Player player)) return;
+
+		AnvilView anvil = open.get(player);
+		if (anvil == null) return;
+
+		anvil.setItem(0, null);
+
+		if (spellOnClose != null) spellOnClose.subcast(new SpellData(player));
+
+		open.remove(player);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/DialogSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/DialogSpell.java
@@ -1,0 +1,52 @@
+package com.nisovin.magicspells.spells.instant;
+
+import org.bukkit.entity.Player;
+
+import io.papermc.paper.dialog.Dialog;
+
+import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.spells.InstantSpell;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.util.config.dialog.DialogBuilder;
+
+public class DialogSpell extends InstantSpell implements TargetedEntitySpell {
+
+	private ConfigData<Dialog> dialog;
+
+	public DialogSpell(MagicConfig config, String spellName) {
+		super(config, spellName);
+	}
+
+	@Override
+	protected void initializeModifiers() {
+		super.initializeModifiers();
+
+		String error = "DialogSpell '" + internalName + "' reports - ";
+		dialog = DialogBuilder.create(
+			getConfigSection(""),
+			extra -> MagicSpells.error(error + extra),
+			extra -> MagicSpells.debug("    " + error + extra)
+		);
+	}
+
+	@Override
+	public CastResult cast(SpellData data) {
+		return castAtEntity(data.target(data.caster()));
+	}
+
+	@Override
+	public CastResult castAtEntity(SpellData data) {
+		if (!(data.target() instanceof Player player)) return noTarget(data);
+
+		Dialog dialog = this.dialog.get(data);
+		if (dialog == null) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
+
+		player.showDialog(dialog);
+
+		playSpellEffects(data);
+		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseDialogSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/CloseDialogSpell.java
@@ -3,18 +3,13 @@ package com.nisovin.magicspells.spells.targeted;
 import org.bukkit.entity.Player;
 
 import com.nisovin.magicspells.util.*;
-import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 
-public class CloseInventorySpell extends TargetedSpell implements TargetedEntitySpell {
+public class CloseDialogSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private final ConfigData<Integer> delay;
-
-	public CloseInventorySpell(MagicConfig config, String spellName) {
+	public CloseDialogSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-		delay = getConfigDataInt("delay", 0);
 	}
 
 	@Override
@@ -32,18 +27,9 @@ public class CloseInventorySpell extends TargetedSpell implements TargetedEntity
 	}
 
 	private CastResult close(Player target, SpellData data) {
-		int delay = this.delay.get(data);
+		target.closeDialog();
 
-		if (delay > 0) {
-			MagicSpells.scheduleDelayedTask(() -> {
-				target.closeInventory();
-				playSpellEffects(data);
-			}, delay);
-		} else {
-			target.closeInventory();
-			playSpellEffects(data);
-		}
-
+		playSpellEffects(data);
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);
 	}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ScoreboardDataSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ScoreboardDataSpell.java
@@ -11,13 +11,11 @@ import com.nisovin.magicspells.variables.Variable;
 import com.nisovin.magicspells.spells.TargetedSpell;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
-import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
-import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
 
 public class ScoreboardDataSpell extends TargetedSpell implements TargetedEntitySpell {
 
-	private ConfigData<String> variableName;
-	private ConfigData<String> objectiveName;
+	private final ConfigData<String> variableName;
+	private final ConfigData<String> objectiveName;
 
 	public ScoreboardDataSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
@@ -51,10 +49,7 @@ public class ScoreboardDataSpell extends TargetedSpell implements TargetedEntity
 		if (objective == null) return new CastResult(PostCastAction.ALREADY_HANDLED, data);
 
 		int score = objective.getScoreFor(data.target()).getScore();
-
-		if (variable instanceof GlobalStringVariable || variable instanceof PlayerStringVariable)
-			variable.parseAndSet(caster, String.valueOf(score));
-		else variable.set(caster, score);
+		MagicSpells.getVariableManager().set(variable, caster, String.valueOf(score));
 
 		playSpellEffects(data);
 		return new CastResult(PostCastAction.HANDLE_NORMALLY, data);

--- a/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/EntityData.java
@@ -55,9 +55,7 @@ import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.ai.CustomGoal;
 import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.util.config.FunctionData;
-import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.config.ConfigDataUtil;
-import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.util.itemreader.AttributeHandler;
 
 public class EntityData {
@@ -1015,31 +1013,10 @@ public class EntityData {
 	}
 
 	private <T> ConfigData<ItemStack> addOptItemStack(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, Class<T> type, BiConsumer<T, ItemStack> setter) {
-		ConfigData<String> supplier = ConfigDataUtil.getString(config, name, null);
-		if (supplier.isConstant()) {
-			ItemStack item = getItemStack(supplier.get());
-			if (item == null) return data -> null;
+		ConfigData<ItemStack> supplier = ConfigDataUtil.getItemStack(config, name, null);
+		transformers.put(type, new TransformerImpl<>(supplier, setter, true));
 
-			transformers.put(type, new TransformerImpl<>(data -> item, setter, true));
-			return data -> item;
-		}
-
-		ConfigData<ItemStack> itemSupplier = data -> getItemStack(supplier.get(data));
-		transformers.put(type, new TransformerImpl<>(itemSupplier, setter, true));
-
-		return itemSupplier;
-	}
-
-	private ItemStack getItemStack(String string) {
-		if (string == null) return null;
-
-		try {
-			return Bukkit.getItemFactory().createItemStack(string);
-		} catch (IllegalArgumentException ignored) {
-		}
-
-		MagicItem magicItem = MagicItems.getMagicItemFromString(string);
-		return magicItem == null ? null : magicItem.getItemStack();
+		return supplier;
 	}
 
 	private void addOptEquipment(Multimap<Class<?>, Transformer<?>> transformers, ConfigurationSection config, String name, EquipmentSlot slot) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -14,6 +14,7 @@ import org.bukkit.*;
 import org.bukkit.util.Vector;
 import org.bukkit.util.EulerAngle;
 import org.bukkit.entity.EntityType;
+import org.bukkit.inventory.ItemStack;
 import org.bukkit.block.data.BlockData;
 import org.bukkit.Particle.DustOptions;
 import org.bukkit.Particle.DustTransition;
@@ -21,6 +22,8 @@ import org.bukkit.potion.PotionEffectType;
 import org.bukkit.configuration.ConfigurationSection;
 
 import com.nisovin.magicspells.util.*;
+import com.nisovin.magicspells.util.magicitems.MagicItem;
+import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.handlers.PotionEffectHandler;
 
 public class ConfigDataUtil {
@@ -809,17 +812,52 @@ public class ConfigDataUtil {
 	public static ConfigData<UUID> getUniqueID(@NotNull ConfigurationSection config, @NotNull String path, @Nullable UUID def) {
 		ConfigData<String> supplier = getString(config, path, null);
 
-		return (VariableConfigData<UUID>) data -> {
-			String uuid = supplier.get(data);
-			if (uuid == null) return def;
+		if (supplier.isConstant()) {
+			String string = supplier.get();
+			if (string == null) return _ -> def;
 
 			try {
-				return UUID.fromString(uuid);
+				UUID uuid = UUID.fromString(string);
+				return _ -> uuid;
+			}
+			catch (IllegalArgumentException e) {
+				return _ -> def;
+			}
+		}
+
+		return (VariableConfigData<UUID>) data -> {
+			String string = supplier.get(data);
+			if (string == null) return def;
+
+			try {
+				return UUID.fromString(string);
 			}
 			catch (IllegalArgumentException e) {
 				return def;
 			}
 		};
+	}
+
+	public static ConfigData<ItemStack> getItemStack(@NotNull ConfigurationSection config, @NotNull String path, @Nullable ItemStack def) {
+		ConfigData<String> supplier = getString(config, path, null);
+
+		if (supplier.isConstant()) {
+			ItemStack item = parseItemString(supplier.get(), def);
+			return _ -> item;
+		}
+
+		return (VariableConfigData<ItemStack>) data -> parseItemString(supplier.get(data), def);
+	}
+
+	private static ItemStack parseItemString(@Nullable String string, @Nullable ItemStack def) {
+		if (string == null) return def;
+
+		try {
+			return Bukkit.getItemFactory().createItemStack(string);
+		} catch (IllegalArgumentException _) {}
+
+		MagicItem magicItem = MagicItems.getMagicItemFromString(string);
+		return magicItem == null ? def : magicItem.getItemStack();
 	}
 
 	public static ConfigData<Angle> getAngle(@NotNull ConfigurationSection config, @NotNull String path, @Nullable Angle def) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/ConfigDataUtil.java
@@ -7,6 +7,9 @@ import java.util.function.Function;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.RegistryAccess;
+
 import net.kyori.adventure.text.Component;
 import net.kyori.adventure.text.format.NamedTextColor;
 
@@ -731,6 +734,10 @@ public class ConfigDataUtil {
 
 			};
 		}
+	}
+
+	public static <T extends Keyed> ConfigData<T> getRegistryEntry(@NotNull ConfigurationSection config, @NotNull String path, @NotNull RegistryKey<T> registryKey, @Nullable T def) {
+		return getRegistryEntry(config, path, RegistryAccess.registryAccess().getRegistry(registryKey), def);
 	}
 
 	public static <T extends Keyed> ConfigData<T> getRegistryEntry(@NotNull ConfigurationSection config, @NotNull String path, @NotNull Registry<T> registry, @Nullable T def) {

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/BuildContext.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/BuildContext.java
@@ -1,0 +1,80 @@
+package com.nisovin.magicspells.util.config.dialog;
+
+import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.function.BiFunction;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.apache.commons.lang3.function.TriFunction;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.util.ConfigReaderUtil;
+import com.nisovin.magicspells.util.config.ConfigData;
+
+public abstract class BuildContext<T> {
+
+	protected final Debugger debugger;
+
+	protected BuildContext(Debugger debugger) {
+		this.debugger = debugger;
+	}
+
+	@NotNull
+	protected abstract NullConfigData<T> build();
+
+	@NotNull
+	protected <E> NullConfigData<E> required(
+		TriFunction<ConfigurationSection, String, E, ConfigData<E>> configDataFun,
+		ConfigurationSection config,
+		String basePath,
+		String subPath
+	) {
+		String error = "Missing '%s' at '%s'.".formatted(subPath, basePath);
+
+		ConfigData<E> configData = configDataFun.apply(config, subPath, null);
+		if (configData.isNull()) {
+			debugger.config(error);
+			return _ -> null;
+		}
+
+		return data -> {
+			E object = configData.get(data);
+			if (object == null) debugger.cast(error);
+			return object;
+		};
+	}
+
+	protected static <E> ConfigData<List<E>> configDataList(
+		ConfigurationSection config,
+		String basePath,
+		String subPath,
+		BiFunction<ConfigurationSection, String, ConfigData<? extends E>> configDataFun
+	) {
+		List<ConfigData<? extends E>> list = new ArrayList<>();
+		List<?> configList = config.getList(subPath, List.of());
+		for (int i = 0; i < configList.size(); i++) {
+			if (!(configList.get(i) instanceof Map<?, ?> map)) continue;
+			ConfigurationSection section = ConfigReaderUtil.mapToSection(map);
+
+			String path = "%s.%s[%d]".formatted(basePath, subPath, i);
+
+			list.add(configDataFun.apply(section, path));
+		}
+
+		return data -> {
+			List<E> result = new ArrayList<>();
+
+			for (ConfigData<? extends E> element : list) {
+				E item = element.get(data);
+				if (item == null) continue;
+				result.add(item);
+			}
+
+			return result;
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/Debugger.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/Debugger.java
@@ -1,0 +1,23 @@
+package com.nisovin.magicspells.util.config.dialog;
+
+import java.util.function.Consumer;
+
+public final class Debugger {
+
+	private final Consumer<String> config;
+	private final Consumer<String> cast;
+
+	public Debugger(Consumer<String> config, Consumer<String> cast) {
+		this.config = config;
+		this.cast = cast;
+	}
+
+	public void config(String text) {
+		config.accept(text);
+	}
+
+	public void cast(String text) {
+		cast.accept(text);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/DialogBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/DialogBuilder.java
@@ -1,0 +1,71 @@
+package com.nisovin.magicspells.util.config.dialog;
+
+import java.util.function.Consumer;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.key.Key;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+import io.papermc.paper.registry.data.dialog.DialogRegistryEntry;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.base.BaseBuilder;
+import com.nisovin.magicspells.util.config.dialog.types.TypeBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class DialogBuilder extends BuildContext<Dialog> {
+
+	private final ConfigurationSection config;
+
+	public static NullConfigData<Dialog> create(ConfigurationSection config, Consumer<String> debugConfig, Consumer<String> debugCast) {
+		Debugger debugger = new Debugger(debugConfig, debugCast);
+		return new DialogBuilder(debugger, config).build();
+	}
+
+	private DialogBuilder(Debugger debugger, ConfigurationSection config) {
+		super(debugger);
+		this.config = config;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<Dialog> build() {
+		ConfigData<NamespacedKey> copyFromData = ConfigDataUtil.getNamespacedKey(config, "copy-from", null);
+
+		ConfigData<DialogBase> baseData = BaseBuilder.create(debugger, config);
+		ConfigData<DialogType> typeData = TypeBuilder.create(debugger, config);
+
+		return data -> {
+			DialogBase base = baseData.get(data);
+			DialogType type = typeData.get(data);
+			if (base == null || type == null) return null;
+
+			Key copyFrom = copyFromData.get(data);
+
+			return Dialog.create(factory -> {
+				DialogRegistryEntry.Builder builder;
+
+				if (copyFrom == null) builder = factory.empty();
+				else {
+					try {
+						builder = factory.copyFrom(TypedKey.create(RegistryKey.DIALOG, copyFrom));
+					} catch (IllegalArgumentException e) {
+						debugger.cast("Invalid 'copy-from': " + e.getMessage());
+						return;
+					}
+				}
+
+				builder.base(base).type(type);
+			});
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/NullConfigData.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/NullConfigData.java
@@ -1,0 +1,15 @@
+package com.nisovin.magicspells.util.config.dialog;
+
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.util.config.ConfigData;
+
+public interface NullConfigData<T> extends ConfigData<T> {
+
+	@Override
+	@Nullable
+	T get(@NotNull SpellData data);
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/ActionButtonBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/ActionButtonBuilder.java
@@ -1,0 +1,84 @@
+package com.nisovin.magicspells.util.config.dialog.action;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ActionButtonBuilder extends BuildContext<ActionButton> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+	private final String subPath;
+
+	public static NullConfigData<ActionButton> createOptional(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		if (config == null) return _ -> null;
+		return new ActionButtonBuilder(debugger, config, basePath, subPath).build();
+	}
+
+	public static NullConfigData<ActionButton> createRequired(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		if (config == null) {
+			debugger.config("Missing '" + subPath + "' section at '" + basePath + "'.");
+			return _ -> null;
+		}
+		return new ActionButtonBuilder(debugger, config, basePath, subPath).build();
+	}
+
+	private ActionButtonBuilder(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+		this.subPath = subPath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<ActionButton> build() {
+		String path = basePath + "." + subPath;
+
+		NullConfigData<Component> labelData = required(ConfigDataUtil::getComponent, config, path, "label");
+		ConfigData<Component> tooltip = ConfigDataUtil.getComponent(config, "tooltip", null);
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 150);
+		ConfigData<DialogAction> action = dialogActionOptional(config, path, "action");
+
+		return data -> {
+			Component label = labelData.get(data);
+			if (label == null) return null;
+
+			try {
+				return ActionButton.create(label, tooltip.get(data), width.get(data), action.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + subPath + "' button defined in '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+	@NotNull
+	private ConfigData<DialogAction> dialogActionOptional(ConfigurationSection config, String basePath, String subPath) {
+		String path = basePath + "." + subPath;
+		ConfigurationSection section = config.getConfigurationSection(subPath);
+		if (section == null) return _ -> null;
+
+		return switch (section.getString("type")) {
+			case "command_template" -> CommandTemplateAction.create(debugger, section, path, "template");
+			case "static_action" -> StaticAction.create(debugger, section, path, "static");
+			case "custom_click" -> CustomClickAction.create(debugger, section, path, "click");
+			case null, default -> {
+				debugger.config("Invalid 'type' defined in '" + path + "'.");
+				yield _ -> null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/CommandTemplateAction.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/CommandTemplateAction.java
@@ -1,0 +1,45 @@
+package com.nisovin.magicspells.util.config.dialog.action;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class CommandTemplateAction extends BuildContext<DialogAction> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+	private final String subPath;
+
+	protected static NullConfigData<DialogAction> create(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		return new CommandTemplateAction(debugger, config, basePath, subPath).build();
+	}
+
+	private CommandTemplateAction(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+		this.subPath = subPath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogAction> build() {
+		ConfigData<String> templateData = required(ConfigDataUtil::getString, config, basePath, subPath);
+
+		return data -> {
+			String template = templateData.get(data);
+			if (template == null) return null;
+
+			return DialogAction.commandTemplate(template);
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/CustomClickAction.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/CustomClickAction.java
@@ -1,0 +1,165 @@
+package com.nisovin.magicspells.util.config.dialog.action;
+
+import java.util.List;
+import java.io.IOException;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.nbt.*;
+import net.kyori.adventure.key.Key;
+import net.kyori.adventure.nbt.api.BinaryTagHolder;
+import net.kyori.adventure.text.event.ClickCallback;
+
+import org.bukkit.NamespacedKey;
+import org.bukkit.entity.Player;
+import org.bukkit.util.NumberConversions;
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+
+import com.nisovin.magicspells.Subspell;
+import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellData;
+import com.nisovin.magicspells.variables.Variable;
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.variables.variabletypes.GlobalStringVariable;
+import com.nisovin.magicspells.variables.variabletypes.PlayerStringVariable;
+
+@SuppressWarnings("UnstableApiUsage")
+public class CustomClickAction extends BuildContext<DialogAction> {
+
+	private static final ClickCallback.Options CLICK_OPTIONS = ClickCallback.Options.builder()
+		.uses(ClickCallback.UNLIMITED_USES)
+		.build();
+
+	private final ConfigurationSection config;
+	private final String path;
+
+	protected static NullConfigData<DialogAction> create(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		ConfigurationSection section = config.getConfigurationSection(subPath);
+		if (section == null) {
+			debugger.config("Missing '" + subPath + "' section at '" + basePath + "'.");
+			return _ -> null;
+		}
+
+		String path = basePath + "." + subPath;
+		return new CustomClickAction(debugger, section, path).build();
+	}
+
+	private CustomClickAction(Debugger debugger, ConfigurationSection config, String path) {
+		super(debugger);
+		this.config = config;
+		this.path = path;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogAction> build() {
+		return switch (config.getString("type")) {
+			case "custom" -> customPayload();
+			case "spell" -> customSpell();
+			case null, default -> {
+				debugger.config("Invalid 'type' defined in '" + path + "'.");
+				yield _ -> null;
+			}
+		};
+	}
+
+	private NullConfigData<DialogAction> customPayload() {
+		ConfigData<NamespacedKey> idData = required(ConfigDataUtil::getNamespacedKey, config, path, "id");
+		ConfigData<String> additionsData = ConfigDataUtil.getString(config, "additions", null);
+
+		return data -> {
+			Key id = idData.get(data);
+			if (id == null) return null;
+
+			String additionsString = additionsData.get(data);
+			BinaryTagHolder additions = null;
+			if (additionsString != null) additions = BinaryTagHolder.binaryTagHolder(additionsString);
+
+			return DialogAction.customClick(id, additions);
+		};
+	}
+
+	private NullConfigData<DialogAction> customSpell() {
+		String spellName = config.getString("spell");
+		String error = "Invalid 'spell' defined at '" + path + "': '" + spellName + "'.";
+		if (spellName == null) {
+			debugger.config(error);
+			return _ -> null;
+		}
+		Subspell spell = new Subspell(spellName);
+		if (!spell.process()) {
+			debugger.config(error);
+			return _ -> null;
+		}
+
+		ConfigData<List<VariableAction>> actionsData = configDataList(config, path, "variables", (config, path) -> {
+			ConfigData<String> keyData = required(ConfigDataUtil::getString, config, path, "key");
+			ConfigData<String> variableData = required(ConfigDataUtil::getString, config, path, "variable");
+
+			return data -> {
+				String key = keyData.get(data);
+				String varName = variableData.get(data);
+				if (key == null || varName == null) return null;
+
+				Variable variable = MagicSpells.getVariableManager().getVariable(varName);
+				if (variable == null) {
+					debugger.cast("Invalid 'variable' defined at '" + path + "'.");
+					return null;
+				}
+
+				return new VariableAction(debugger, variable, varName, key);
+			};
+		});
+
+		return data -> DialogAction.customClick((view, audience) -> {
+			if (!(audience instanceof Player player)) return;
+
+			List<VariableAction> actions = actionsData.get(data);
+			if (!actions.isEmpty()) {
+				CompoundBinaryTag compoundTag;
+				try {
+					compoundTag = TagStringIO.tagStringIO().asCompound(view.payload().string());
+				} catch (IOException _) {
+					return;
+				}
+
+				for (VariableAction action : actions) action.set(compoundTag, player);
+			}
+
+			spell.subcast(new SpellData(player));
+		}, CLICK_OPTIONS);
+	}
+
+	private record VariableAction(Debugger debugger, Variable variable, String variableName, String key) {
+
+		private void set(CompoundBinaryTag compoundTag, Player player) {
+			BinaryTag tag = compoundTag.get(key);
+			if (tag == null) {
+				debugger.cast("'variables' key '" + key + "' not found under 'inputs'.");
+				return;
+			}
+
+			if (variable instanceof GlobalStringVariable || variable instanceof PlayerStringVariable) {
+				MagicSpells.getVariableManager().set(variable, player, switch (tag) {
+					case StringBinaryTag stringTag -> stringTag.value();
+					case ByteBinaryTag byteTag -> String.valueOf(byteTag.value() != 0);
+					case FloatBinaryTag floatTag -> String.valueOf(floatTag.value());
+					default -> throw new UnsupportedOperationException("Not supported yet.");
+				});
+			} else {
+				MagicSpells.getVariableManager().set(variable, player, switch (tag) {
+					case StringBinaryTag stringTag -> NumberConversions.toDouble(stringTag.value());
+					case NumberBinaryTag numTag -> numTag.doubleValue();
+					default -> throw new UnsupportedOperationException("Not supported yet.");
+				});
+			}
+		}
+
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/StaticAction.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/action/StaticAction.java
@@ -1,0 +1,99 @@
+package com.nisovin.magicspells.util.config.dialog.action;
+
+import java.util.function.Function;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.event.ClickEvent;
+
+import org.apache.commons.lang3.function.TriFunction;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.data.dialog.action.DialogAction;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class StaticAction extends BuildContext<DialogAction> {
+
+	private final ConfigurationSection config;
+	private final String path;
+
+	protected static NullConfigData<DialogAction> create(Debugger debugger, ConfigurationSection config, String basePath, String subPath) {
+		ConfigurationSection section = config.getConfigurationSection(subPath);
+		if (section == null) {
+			debugger.config("Missing '" + subPath + "' section at '" + basePath + "'.");
+			return _ -> null;
+		}
+
+		String path = basePath + "." + subPath;
+		return new StaticAction(debugger, section, path).build();
+	}
+
+	private StaticAction(Debugger debugger, ConfigurationSection config, String path) {
+		super(debugger);
+		this.config = config;
+		this.path = path;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogAction> build() {
+		ConfigData<ClickEvent> eventData = switch (config.getString("type")) {
+			case "open_url" -> clickEventString(ClickEvent::openUrl, config, path, "url");
+			case "run_command" -> clickEventString(ClickEvent::runCommand, config, path, "command");
+			case "suggest_command" -> clickEventString(ClickEvent::suggestCommand, config, path, "command");
+			case "copy_to_clipboard" -> clickEventString(ClickEvent::copyToClipboard, config, path, "text");
+			//case "callback" -> ClickEvent#callback; // same as "custom_click" DialogAction
+			//case "custom" -> ClickEvent#custom; // same as "custom_click" DialogAction
+			case "show_dialog" -> clickEvent(this::configDataDialog, ClickEvent::showDialog, config, path, "dialog");
+			case null, default -> {
+				debugger.config("Invalid 'type' defined in '" + path + "'.");
+				yield _ -> null;
+			}
+		};
+
+		return data -> {
+			ClickEvent event = eventData.get(data);
+			if (event == null) return null;
+
+			return DialogAction.staticAction(event);
+		};
+	}
+
+	private ConfigData<Dialog> configDataDialog(ConfigurationSection config, String path, Dialog def) {
+		return ConfigDataUtil.getRegistryEntry(config, path, RegistryKey.DIALOG, def);
+	}
+
+	private NullConfigData<ClickEvent> clickEventString(
+		Function<String, ClickEvent> clickEventFun,
+		ConfigurationSection config,
+		String basePath,
+		String subPath
+	) {
+		return clickEvent(ConfigDataUtil::getString, clickEventFun, config, basePath, subPath);
+	}
+
+	private <T> NullConfigData<ClickEvent> clickEvent(
+		TriFunction<ConfigurationSection, String, T, ConfigData<T>> configDataFun,
+		Function<T, ClickEvent> clickEventFun,
+		ConfigurationSection config,
+		String basePath,
+		String subPath
+	) {
+		ConfigData<T> valData = required(configDataFun, config, basePath, subPath);
+
+		return data -> {
+			T val = valData.get(data);
+			if (val == null) return null;
+			return clickEventFun.apply(val);
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/BaseBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/BaseBuilder.java
@@ -1,0 +1,145 @@
+package com.nisovin.magicspells.util.config.dialog.base;
+
+import java.util.List;
+
+import org.bukkit.inventory.ItemStack;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+import io.papermc.paper.registry.data.dialog.DialogBase;
+import io.papermc.paper.registry.data.dialog.body.DialogBody;
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.body.ItemDialogBody;
+import io.papermc.paper.registry.data.dialog.body.PlainMessageDialogBody;
+import io.papermc.paper.registry.data.dialog.DialogBase.DialogAfterAction;
+
+@SuppressWarnings("UnstableApiUsage")
+public class BaseBuilder extends BuildContext<DialogBase> {
+
+	private static final String PATH = "base";
+
+	private final ConfigurationSection config;
+
+	@NotNull
+	public static NullConfigData<DialogBase> create(Debugger debugger, ConfigurationSection config) {
+		ConfigurationSection section = config.getConfigurationSection(PATH);
+
+		if (section == null) {
+			debugger.config("Missing '" + PATH + "'.");
+			return _ -> null;
+		}
+
+		return new BaseBuilder(debugger, section).build();
+	}
+
+	private BaseBuilder(Debugger debugger, ConfigurationSection config) {
+		super(debugger);
+		this.config = config;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogBase> build() {
+		ConfigData<Component> titleData = required(ConfigDataUtil::getComponent, config, PATH, "title");
+
+		ConfigData<Boolean> canCloseWithEscape = ConfigDataUtil.getBoolean(config, "can-close-with-escape", true);
+		ConfigData<DialogAfterAction> afterAction = ConfigDataUtil.getEnum(config, "after-action", DialogAfterAction.class, DialogAfterAction.CLOSE);
+
+		ConfigData<List<DialogBody>> body = configDataList(config, PATH, "body", (config, path) ->
+			switch (config.getString("type")) {
+				case "item" -> itemBody(config, path);
+				case "message" -> plainMessage(config, path);
+				case null, default -> {
+					debugger.config("Invalid 'type' defined at '" + path + "'.");
+					yield null;
+				}
+			}
+		);
+
+		ConfigData<List<DialogInput>> inputs = configDataList(config, PATH, "inputs", (config, path) ->
+			switch (config.getString("type")) {
+				case "bool" -> BooleanInput.create(debugger, config, path);
+				case "number_range" -> NumberRangeInput.create(debugger, config, path);
+				case "single_option" -> SingleOptionInput.create(debugger, config, path);
+				case "text" -> TextInput.create(debugger, config, path);
+				case null, default -> {
+					debugger.config("Invalid 'type' defined at '" + path + "'.");
+					yield null;
+				}
+			}
+		);
+
+		return data -> {
+			Component title = titleData.get(data);
+			if (title == null) return null;
+
+			return DialogBase.builder(title)
+				//.externalTitle() // Unused until you can add these dialogs to registry.
+				.canCloseWithEscape(canCloseWithEscape.get(data))
+				.pause(false)
+				.afterAction(afterAction.get(data))
+				.body(body.get(data))
+				.inputs(inputs.get(data))
+				.build();
+		};
+	}
+
+	private NullConfigData<PlainMessageDialogBody> plainMessage(ConfigurationSection config, String path) {
+		ConfigData<Component> messageData = required(ConfigDataUtil::getComponent, config, path, "message");
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 200);
+
+		return data -> {
+			Component message = messageData.get(data);
+			if (message == null) return null;
+
+			try {
+				return DialogBody.plainMessage(message, width.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid 'width' defined at '" + path + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+	private NullConfigData<ItemDialogBody> itemBody(ConfigurationSection config, String path) {
+		ConfigData<ItemStack> itemData = required(ConfigDataUtil::getItemStack, config, path, "item");
+
+		ConfigurationSection descSection = config.getConfigurationSection("description");
+		NullConfigData<PlainMessageDialogBody> description;
+		if (descSection != null) description = plainMessage(descSection, path);
+		else description = _ -> null;
+
+		ConfigData<Boolean> showDecorations = ConfigDataUtil.getBoolean(config, "show-decorations", true);
+		ConfigData<Boolean> showTooltip = ConfigDataUtil.getBoolean(config, "show-tooltip", true);
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 16);
+		ConfigData<Integer> height = ConfigDataUtil.getInteger(config, "height", 16);
+
+		return data -> {
+			ItemStack item = itemData.get(data);
+			if (item == null) return null;
+
+			try {
+				return DialogBody.item(item)
+					.description(description.get(data))
+					.showDecorations(showDecorations.get(data))
+					.showTooltip(showTooltip.get(data))
+					.width(width.get(data))
+					.height(height.get(data))
+					.build();
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + path + "' defined: " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/BooleanInput.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/BooleanInput.java
@@ -1,0 +1,56 @@
+package com.nisovin.magicspells.util.config.dialog.base;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class BooleanInput extends BuildContext<DialogInput> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogInput> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new BooleanInput(debugger, config, basePath).build();
+	}
+
+	private BooleanInput(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogInput> build() {
+		ConfigData<String> keyData = required(ConfigDataUtil::getString, config, basePath, "key");
+		ConfigData<Component> labelData = required(ConfigDataUtil::getComponent, config, basePath, "label");
+
+		ConfigData<Boolean> initial = ConfigDataUtil.getBoolean(config, "initial", false);
+		ConfigData<String> onTrue = ConfigDataUtil.getString(config, "on-true", "true");
+		ConfigData<String> onFalse = ConfigDataUtil.getString(config, "on-false", "false");
+
+		return data -> {
+			String key = keyData.get(data);
+			Component label = labelData.get(data);
+			if (key == null || label == null) return null;
+
+			try {
+				return DialogInput.bool(key, label, initial.get(data), onTrue.get(data), onFalse.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/NumberRangeInput.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/NumberRangeInput.java
@@ -1,0 +1,68 @@
+package com.nisovin.magicspells.util.config.dialog.base;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class NumberRangeInput extends BuildContext<DialogInput> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogInput> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new NumberRangeInput(debugger, config, basePath).build();
+	}
+
+	private NumberRangeInput(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogInput> build() {
+		ConfigData<String> keyData = required(ConfigDataUtil::getString, config, basePath, "key");
+		ConfigData<Component> labelData = required(ConfigDataUtil::getComponent, config, basePath, "label");
+
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 200);
+		ConfigData<String> labelFormat = ConfigDataUtil.getString(config, "label-format", "options.generic_value");
+		ConfigData<Float> start = ConfigDataUtil.getFloat(config, "start", 0);
+		ConfigData<Float> end = ConfigDataUtil.getFloat(config, "end", 0);
+		ConfigData<Float> initial = ConfigDataUtil.getFloat(config, "initial", 0);
+		ConfigData<Float> step = ConfigDataUtil.getFloat(config, "step", 1);
+
+		return data -> {
+			String key = keyData.get(data);
+			Component label = labelData.get(data);
+			if (key == null || label == null) return null;
+
+			try {
+				return DialogInput.numberRange(
+					key,
+					width.get(data),
+					label,
+					labelFormat.get(data),
+					start.get(data),
+					end.get(data),
+					initial.get(data),
+					step.get(data)
+				);
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/SingleOptionInput.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/SingleOptionInput.java
@@ -1,0 +1,77 @@
+package com.nisovin.magicspells.util.config.dialog.base;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.SingleOptionDialogInput;
+
+@SuppressWarnings("UnstableApiUsage")
+public class SingleOptionInput extends BuildContext<DialogInput> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogInput> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new SingleOptionInput(debugger, config, basePath).build();
+	}
+
+	private SingleOptionInput(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogInput> build() {
+		ConfigData<String> keyData = required(ConfigDataUtil::getString, config, basePath, "key");
+		ConfigData<Component> labelData = required(ConfigDataUtil::getComponent, config, basePath, "label");
+
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 200);
+		ConfigData<Boolean> labelVisible = ConfigDataUtil.getBoolean(config, "label-visible", true);
+
+		ConfigData<List<SingleOptionDialogInput.OptionEntry>> entriesData = configDataList(config, basePath, "entries", (section, basePath) -> {
+			ConfigData<String> idData = required(ConfigDataUtil::getString, section, basePath, "id");
+			ConfigData<Component> display = ConfigDataUtil.getComponent(section, "display", null);
+			ConfigData<Boolean> initial = ConfigDataUtil.getBoolean(section, "initial", false);
+
+			return data -> {
+				String id = idData.get(data);
+				if (id == null) return null;
+
+				return SingleOptionDialogInput.OptionEntry.create(id, display.get(data), initial.get(data));
+			};
+		});
+
+		return data -> {
+			String key = keyData.get(data);
+			Component label = labelData.get(data);
+			if (key == null || label == null) return null;
+
+			List<SingleOptionDialogInput.OptionEntry> entries = entriesData.get(data);
+			if (entries.isEmpty()) {
+				debugger.cast("Empty 'entries' list found at '" + basePath + "'.");
+				return null;
+			}
+
+			try {
+				return DialogInput.singleOption(key, width.get(data), entries, label, labelVisible.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/TextInput.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/base/TextInput.java
@@ -1,0 +1,86 @@
+package com.nisovin.magicspells.util.config.dialog.base;
+
+import org.jetbrains.annotations.NotNull;
+
+import net.kyori.adventure.text.Component;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+import io.papermc.paper.registry.data.dialog.input.DialogInput;
+import io.papermc.paper.registry.data.dialog.input.TextDialogInput.MultilineOptions;
+
+@SuppressWarnings("UnstableApiUsage")
+public class TextInput extends BuildContext<DialogInput> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogInput> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new TextInput(debugger, config, basePath).build();
+	}
+
+	private TextInput(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogInput> build() {
+		ConfigData<String> keyData = required(ConfigDataUtil::getString, config, basePath, "key");
+		ConfigData<Component> labelData = required(ConfigDataUtil::getComponent, config, basePath, "label");
+
+		ConfigData<Integer> width = ConfigDataUtil.getInteger(config, "width", 200);
+		ConfigData<Boolean> labelVisible = ConfigDataUtil.getBoolean(config, "label-visible", true);
+		ConfigData<String> initial = ConfigDataUtil.getString(config, "initial", "");
+		ConfigData<Integer> maxLength = ConfigDataUtil.getInteger(config, "max-length", 32);
+
+		ConfigData<MultilineOptions> multilineOptions = multiLineOptions();
+
+		return data -> {
+			String key = keyData.get(data);
+			Component label = labelData.get(data);
+			MultilineOptions options = multilineOptions.get(data);
+			if (key == null || label == null || options == null) return null;
+
+			try {
+				return DialogInput.text(
+					key,
+					width.get(data),
+					label,
+					labelVisible.get(data),
+					initial.get(data),
+					maxLength.get(data),
+					options
+				);
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+	private @NotNull NullConfigData<MultilineOptions> multiLineOptions() {
+		ConfigurationSection section = config.getConfigurationSection("multiline-options");
+		if (section == null) return _ -> null;
+
+		ConfigData<Integer> maxLines = ConfigDataUtil.getInteger(section, "max-lines", _ -> null);
+		ConfigData<Integer> height = ConfigDataUtil.getInteger(section, "height", _ -> null);
+
+		return data -> {
+			try {
+				return MultilineOptions.create(maxLines.get(data), height.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid 'multiline-options' at '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/ConfirmationBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/ConfirmationBuilder.java
@@ -1,0 +1,49 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.util.config.dialog.action.ActionButtonBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ConfirmationBuilder extends BuildContext<DialogType> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new ConfirmationBuilder(debugger, config, basePath).build();
+	}
+
+	private ConfirmationBuilder(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		ConfigurationSection yesSection = config.getConfigurationSection("button-yes");
+		ConfigurationSection noSection = config.getConfigurationSection("button-no");
+
+		ConfigData<ActionButton> yesData = ActionButtonBuilder.createRequired(debugger, yesSection, basePath, "button-yes");
+		ConfigData<ActionButton> noData = ActionButtonBuilder.createRequired(debugger, noSection, basePath, "button-no");
+
+		return data -> {
+			ActionButton yes = yesData.get(data);
+			ActionButton no = noData.get(data);
+			if (yes == null || no == null) return null;
+
+			return DialogType.confirmation(yes, no);
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/DialogListBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/DialogListBuilder.java
@@ -1,0 +1,103 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import java.util.List;
+import java.util.ArrayList;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.Registry;
+import org.bukkit.NamespacedKey;
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.dialog.Dialog;
+import io.papermc.paper.registry.TypedKey;
+import io.papermc.paper.registry.tag.TagKey;
+import io.papermc.paper.registry.RegistryKey;
+import io.papermc.paper.registry.RegistryAccess;
+import io.papermc.paper.registry.set.RegistrySet;
+import io.papermc.paper.registry.set.RegistryKeySet;
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.util.config.dialog.action.ActionButtonBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class DialogListBuilder extends BuildContext<DialogType> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new DialogListBuilder(debugger, config, basePath).build();
+	}
+
+	private DialogListBuilder(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		RegistryKeySet<Dialog> dialogs = getDialogKeySet();
+
+		ConfigurationSection exitSection = config.getConfigurationSection("exit");
+		NullConfigData<ActionButton> exit = ActionButtonBuilder.createOptional(debugger, exitSection, basePath, "exit");
+
+		ConfigData<Integer> columns = ConfigDataUtil.getInteger(config, "columns", 2);
+		ConfigData<Integer> buttonWidth = ConfigDataUtil.getInteger(config, "button-width", 150);
+
+		return data -> {
+			try {
+				return DialogType.dialogList(dialogs, exit.get(data), columns.get(data), buttonWidth.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+	private RegistryKeySet<Dialog> getDialogKeySet() {
+		List<TypedKey<Dialog>> keys = new ArrayList<>();
+		Registry<Dialog> registry = RegistryAccess.registryAccess().getRegistry(RegistryKey.DIALOG);
+
+		List<String> strings = config.getStringList("dialogs");
+		for (int i = 0; i < strings.size(); i++) {
+			String string = strings.get(i);
+			String subPath = "dialogs[" + i + "]";
+
+			if (!string.startsWith("#")) {
+				NamespacedKey key = NamespacedKey.fromString(string);
+				if (key == null || registry.get(key) == null) {
+					debugger.config("Invalid '%s' registry entry at '%s': '%s'".formatted(subPath, basePath, string));
+					continue;
+				}
+
+				keys.add(TypedKey.create(RegistryKey.DIALOG, key));
+				continue;
+			}
+
+			NamespacedKey key = NamespacedKey.fromString(string.substring(1));
+			if (key == null) {
+				debugger.config("Invalid '%s' key at '%s': '%s'".formatted(subPath, basePath, string));
+				continue;
+			}
+
+			TagKey<Dialog> tagKey = TagKey.create(RegistryKey.DIALOG, key);
+			if (!registry.hasTag(tagKey)) {
+				debugger.config("Invalid '%s' key at '%s': '%s'".formatted(subPath, basePath, string));
+				continue;
+			}
+
+			keys.addAll(registry.getTag(tagKey).values());
+		}
+
+		return RegistrySet.keySet(RegistryKey.DIALOG, keys);
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/MultiActionBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/MultiActionBuilder.java
@@ -1,0 +1,71 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import java.util.List;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.castmodifiers.ModifierSet;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.util.config.dialog.action.ActionButtonBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class MultiActionBuilder extends BuildContext<DialogType> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new MultiActionBuilder(debugger, config, basePath).build();
+	}
+
+	private MultiActionBuilder(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		ConfigData<List<ActionButton>> actionsData = configDataList(config, basePath, "actions", (config, path) -> {
+			List<String> modifierList = config.getStringList("modifiers");
+			ModifierSet modifiers = modifierList.isEmpty() ? null : new ModifierSet(modifierList);
+
+			NullConfigData<ActionButton> button = ActionButtonBuilder.createRequired(debugger, config, basePath, path);
+
+			return data -> {
+				if (modifiers != null && !modifiers.apply(data.caster(), data).check()) return null;
+				return button.get(data);
+			};
+		});
+
+		ConfigurationSection exitSection = config.getConfigurationSection("exit");
+		NullConfigData<ActionButton> exit = ActionButtonBuilder.createOptional(debugger, exitSection, basePath, "exit");
+
+		ConfigData<Integer> columns = ConfigDataUtil.getInteger(config, "columns", 2);
+
+		return data -> {
+			List<ActionButton> actions = actionsData.get(data);
+			if (actions.isEmpty()) {
+				debugger.cast("Empty 'actions' list found at '" + basePath + "'.");
+				return null;
+			}
+
+			try {
+				return DialogType.multiAction(actions, exit.get(data), columns.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/NoticeBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/NoticeBuilder.java
@@ -1,0 +1,42 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.util.config.dialog.action.ActionButtonBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class NoticeBuilder extends BuildContext<DialogType> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new NoticeBuilder(debugger, config, basePath).build();
+	}
+
+	private NoticeBuilder(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		ConfigurationSection buttonSection = config.getConfigurationSection("button");
+		NullConfigData<ActionButton> buttonData = ActionButtonBuilder.createOptional(debugger, buttonSection, basePath, "button");
+
+		return data -> {
+			ActionButton button = buttonData.get(data);
+			return button == null ? DialogType.notice() : DialogType.notice(button);
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/ServerListTypeBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/ServerListTypeBuilder.java
@@ -1,0 +1,51 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.ActionButton;
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.util.config.ConfigDataUtil;
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+import com.nisovin.magicspells.util.config.dialog.action.ActionButtonBuilder;
+
+@SuppressWarnings("UnstableApiUsage")
+public class ServerListTypeBuilder extends BuildContext<DialogType> {
+
+	private final ConfigurationSection config;
+	private final String basePath;
+
+	protected static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config, String basePath) {
+		return new ServerListTypeBuilder(debugger, config, basePath).build();
+	}
+
+	private ServerListTypeBuilder(Debugger debugger, ConfigurationSection config, String basePath) {
+		super(debugger);
+		this.config = config;
+		this.basePath = basePath;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		ConfigurationSection exitSection = config.getConfigurationSection("exit");
+		NullConfigData<ActionButton> exit = ActionButtonBuilder.createOptional(debugger, exitSection, basePath, "exit");
+
+		ConfigData<Integer> columns = ConfigDataUtil.getInteger(config, "columns", 2);
+		ConfigData<Integer> buttonWidth = ConfigDataUtil.getInteger(config, "button-width", 150);
+
+		return data -> {
+			try {
+				return DialogType.serverLinks(exit.get(data), columns.get(data), buttonWidth.get(data));
+			} catch (IllegalArgumentException e) {
+				debugger.cast("Invalid '" + basePath + "': " + e.getMessage());
+				return null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/TypeBuilder.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/config/dialog/types/TypeBuilder.java
@@ -1,0 +1,51 @@
+package com.nisovin.magicspells.util.config.dialog.types;
+
+import org.jetbrains.annotations.NotNull;
+
+import org.bukkit.configuration.ConfigurationSection;
+
+import io.papermc.paper.registry.data.dialog.type.DialogType;
+
+import com.nisovin.magicspells.util.config.dialog.Debugger;
+import com.nisovin.magicspells.util.config.dialog.BuildContext;
+import com.nisovin.magicspells.util.config.dialog.NullConfigData;
+
+@SuppressWarnings("UnstableApiUsage")
+public class TypeBuilder extends BuildContext<DialogType> {
+
+	private static final String PATH = "dialog-type";
+
+	private final ConfigurationSection config;
+
+	public static NullConfigData<DialogType> create(Debugger debugger, ConfigurationSection config) {
+		ConfigurationSection section = config.getConfigurationSection(PATH);
+
+		if (section == null) {
+			debugger.config("Missing '" + PATH + "'.");
+			return _ -> null;
+		}
+
+		return new TypeBuilder(debugger, section).build();
+	}
+
+	private TypeBuilder(Debugger debugger, ConfigurationSection config) {
+		super(debugger);
+		this.config = config;
+	}
+
+	@Override
+	protected @NotNull NullConfigData<DialogType> build() {
+		return switch (config.getString("type")) {
+			case "confirmation" -> ConfirmationBuilder.create(debugger, config, PATH);
+			case "dialog_list" -> DialogListBuilder.create(debugger, config, PATH);
+			case "multi_action" -> MultiActionBuilder.create(debugger, config, PATH);
+			case "notice" -> NoticeBuilder.create(debugger, config, PATH);
+			case "server_links" -> ServerListTypeBuilder.create(debugger, config, PATH);
+			case null, default -> {
+				debugger.config("Invalid 'type' defined in '" + PATH + "'.");
+				yield _ -> null;
+			}
+		};
+	}
+
+}

--- a/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/managers/VariableManager.java
@@ -326,6 +326,10 @@ public class VariableManager {
 		set(var, player, amount);
 	}
 
+	public void set(Variable variable, Player player, double amount) {
+		set(variable, player.getName(), amount);
+	}
+
 	public void set(Variable variable, String player, double amount) {
 		if (variable == null) return;
 		variable.set(player, amount);
@@ -344,6 +348,10 @@ public class VariableManager {
 	public void set(String variable, String player, String amount) {
 		Variable var = variables.get(variable);
 		set(var, player, amount);
+	}
+
+	public void set(Variable variable, Player player, String amount) {
+		set(variable, player.getName(), amount);
 	}
 
 	public void set(Variable variable, String player, String amount) {

--- a/core/src/main/java/com/nisovin/magicspells/util/messagelistener/listeners/ProtocolLibListener.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/messagelistener/listeners/ProtocolLibListener.java
@@ -41,7 +41,7 @@ public class ProtocolLibListener implements MessageListener {
 
 		String variable = recordedData.listenerData.storeChatOutput();
 		String message = recordedData.recorded.toString();
-		MagicSpells.getVariableManager().set(variable, player.getName(), message);
+		MagicSpells.getVariableManager().set(variable, player, message);
 	}
 
 	@Override

--- a/core/src/main/java/com/nisovin/magicspells/variables/Variable.java
+++ b/core/src/main/java/com/nisovin/magicspells/variables/Variable.java
@@ -58,7 +58,9 @@ public abstract class Variable {
 	public abstract void set(String player, double amount);
 
 	public void parseAndSet(String player, String textValue) {
-		set(player, Double.parseDouble(textValue));
+		try {
+			set(player, Double.parseDouble(textValue));
+		} catch (NumberFormatException _) {}
 	}
 
 	public double getValue(Player player) {


### PR DESCRIPTION
# Additions:

- Added `.targeted.CloseDialogSpell` - Closes a dialog and returns the target to the previous non-dialog or game menu screen.
- Added [`.instant.DialogSpell`](https://github.com/JasperLorelai/MagicSpells/wiki/DialogSpell). This spell logs exceptions caused by cast-time expression resolving (ConfigData) if the plugin's debug is enabled using `/ms debug`.
- Added `.instant.AnvilInputSpell` with `title` ([Rich Text](https://github.com/TheComputerGeek2/MagicSpells/wiki/Expression#rich-text)), `variable-name` (String variable), and `spell-on-close` (sub-spell). The spell opens an anvil view, awaiting user input. If the anvil result item is clicked, the "rename text" is stored in the variable. The config can compare against an initial value during `spell-on-close` cast to know if a new value was submitted.