### PR TITLE
Reflect Spell

### DIFF
--- a/core/src/main/java/com/nisovin/magicspells/Spell.java
+++ b/core/src/main/java/com/nisovin/magicspells/Spell.java
@@ -1131,7 +1131,7 @@ public abstract class Spell implements Comparable<Spell>, Listener {
 		if (castEvent.haveReagentsChanged()) {
 			boolean hasReagents = hasReagents(data.caster(), castEvent.getReagents());
 			if (!hasReagents && state != SpellCastState.MISSING_REAGENTS) {
-				castEvent.setSpellCastState(SpellCastState.MISSING_REAGENTS);
+				castEvent.setSpellCastState(state = SpellCastState.MISSING_REAGENTS);
 				debug(2, "    Spell cast state changed: " + state);
 			} else if (hasReagents && state == SpellCastState.MISSING_REAGENTS) {
 				castEvent.setSpellCastState(state = SpellCastState.NORMAL);

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellCastEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellCastEvent.java
@@ -53,6 +53,11 @@ public class SpellCastEvent extends SpellEvent implements Cancellable {
 		reagentsChanged = false;
 	}
 
+	@Override
+	public LivingEntity getCaster() {
+		return spellData.caster();
+	}
+
 	/**
 	 * Gets the current spell cast state.
 	 *

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellCastedEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellCastedEvent.java
@@ -51,6 +51,11 @@ public class SpellCastedEvent extends SpellEvent {
 		this(castEvent.getSpell(), castEvent.getSpellCastState(), result.action(), result.data(), castEvent.getCooldown(), castEvent.getReagents());
 	}
 
+	@Override
+	public LivingEntity getCaster() {
+		return spellData.caster();
+	}
+
 	/**
 	 * Gets the current spell cast state.
 	 * @return the spell cast state

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellPreImpactEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellPreImpactEvent.java
@@ -7,46 +7,54 @@ import org.bukkit.entity.LivingEntity;
 
 import com.nisovin.magicspells.Spell;
 import com.nisovin.magicspells.MagicSpells;
+import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.handlers.DebugHandler;
 
 public class SpellPreImpactEvent extends SpellEvent implements Cancellable {
 
-	private LivingEntity target;
-	private float power;
-	private Spell deliverySpell;
+	private final Spell deliverySpell;
+
+	private SpellData spellData;
+
 	private boolean redirect;
 	private boolean cancelled;
 
+	@Deprecated
 	public SpellPreImpactEvent(Spell spellPayload, Spell deliverySpell, LivingEntity caster, LivingEntity target, float power) {
-		super(spellPayload, caster);
-		this.target = target;
-		this.power = power;
+		this(spellPayload, deliverySpell, new SpellData(caster, target, power));
+	}
+
+	public SpellPreImpactEvent(Spell spellPayload, Spell deliverySpell, SpellData spellData) {
+		super(spellPayload, spellData.caster());
 		this.deliverySpell = deliverySpell;
-		redirect = false;
-		cancelled = false;
+		this.spellData = spellData;
 		if (DebugHandler.isSpellPreImpactEventCheckEnabled()) MagicSpells.plugin.getLogger().info(toString());
 	}
-	
+
 	public LivingEntity getTarget() {
-		return target;
+		return spellData.target();
 	}
 	
 	public boolean getRedirected() {
 		return redirect;
 	}
-	
+
 	public void setRedirected(boolean redirect) {
 		this.redirect = redirect;
 	}
-	
+
 	public float getPower() {
-		return power;
+		return spellData.power();
 	}
-	
+
 	public void setPower(float power) {
-		this.power = power;
+		spellData = spellData.power(power);
 	}
-	
+
+	public SpellData getSpellData() {
+		return spellData;
+	}
+
 	public Spell getDeliverySpell() {
 		return deliverySpell;
 	}
@@ -60,14 +68,14 @@ public class SpellPreImpactEvent extends SpellEvent implements Cancellable {
 	public void setCancelled(boolean cancelled) {
 		this.cancelled = cancelled;
 	}
-	
+
 	@Override
 	public String toString() {
-		String casterLabel = "Caster: " + (caster == null ? "null" : caster.toString());
-		String targetLabel = "Target: " + (target == null ? "null" : target.toString());
-		String spellLabel = "SpellPayload: " + (spell == null ? "null" : spell.toString());
-		String payloadSpellLabel = "Delivery Spell: " + (deliverySpell == null ? "null" : deliverySpell.toString());
+		String casterLabel = "Caster: " + caster;
+		String targetLabel = "Target: " + spellData.target();
+		String spellLabel = "SpellPayload: " + (spell == null ? "null" : spell.getInternalName());
+		String payloadSpellLabel = "Delivery Spell: " + (deliverySpell == null ? "null" : deliverySpell.getInternalName());
 		return Arrays.deepToString(new String[]{ casterLabel, targetLabel, spellLabel, payloadSpellLabel });
 	}
-	
+
 }

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellPreImpactEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellPreImpactEvent.java
@@ -31,6 +31,11 @@ public class SpellPreImpactEvent extends SpellEvent implements Cancellable {
 		if (DebugHandler.isSpellPreImpactEventCheckEnabled()) MagicSpells.plugin.getLogger().info(toString());
 	}
 
+	@Override
+	public LivingEntity getCaster() {
+		return spellData.caster();
+	}
+
 	public LivingEntity getTarget() {
 		return spellData.target();
 	}

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
@@ -91,6 +91,14 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 		return spellData;
 	}
 
+	/**
+	 * Sets the spell's {@link SpellData} to the provided value.
+	 * @param data the new data
+	 */
+	public void setSpellData(SpellData data) {
+		spellData = data;
+	}
+
 	@Override
 	public boolean isCancelled() {
 		return cancelled;

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellTargetEvent.java
@@ -35,6 +35,11 @@ public class SpellTargetEvent extends SpellEvent implements Cancellable {
 		this.spellData = new SpellData(caster, target, power, null);
 	}
 
+	@Override
+	public LivingEntity getCaster() {
+		return spellData.caster();
+	}
+
 	/**
 	 * Gets the living entity that is being targeted by the spell.
 	 * @return the targeted living entity

--- a/core/src/main/java/com/nisovin/magicspells/events/SpellTargetLocationEvent.java
+++ b/core/src/main/java/com/nisovin/magicspells/events/SpellTargetLocationEvent.java
@@ -31,6 +31,11 @@ public class SpellTargetLocationEvent extends SpellEvent implements Cancellable 
 		spellData = new SpellData(caster, target, power, null);
 	}
 
+	@Override
+	public LivingEntity getCaster() {
+		return spellData.caster();
+	}
+
 	/**
 	 * Gets the location that is being targeted by the spell.
 	 * @return the targeted living entity

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/FlamewalkSpell.java
@@ -150,6 +150,7 @@ public class FlamewalkSpell extends BuffSpell {
 					if (!targetEvent.callEvent()) continue;
 
 					SpellData subData = targetEvent.getSpellData();
+					target = subData.target();
 
 					int fireTicks;
 					if (!data.constantFireTicks) {
@@ -161,7 +162,7 @@ public class FlamewalkSpell extends BuffSpell {
 					addUseAndChargeCost(caster);
 
 					playSpellEffects(EffectPosition.TARGET, target, subData);
-					playSpellEffectsTrail(caster.getLocation(), entity.getLocation(), subData);
+					playSpellEffectsTrail(subData.caster().getLocation(), target.getLocation(), subData);
 				}
 
 			}

--- a/core/src/main/java/com/nisovin/magicspells/spells/buff/ReflectSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/buff/ReflectSpell.java
@@ -18,9 +18,9 @@ import com.nisovin.magicspells.events.SpellPreImpactEvent;
 // NO API CHANGES - NEEDS TOTAL REWORK
 public class ReflectSpell extends BuffSpell {
 
-	private final Map<UUID, ReflectData> reflectors;
-	private final Set<String> shieldBreakerNames;
-	private final Set<String> delayedReflectionSpells;
+	private final Map<UUID, ReflectData> reflectors = new HashMap<>();
+	private final Set<String> shieldBreakerNames = new HashSet<>();
+	private final Set<String> delayedReflectionSpells = new HashSet<>();
 
 	private final ConfigData<Float> reflectedSpellPowerMultiplier;
 
@@ -30,10 +30,6 @@ public class ReflectSpell extends BuffSpell {
 
 	public ReflectSpell(MagicConfig config, String spellName) {
 		super(config, spellName);
-
-		reflectors = new HashMap<>();
-		shieldBreakerNames = new HashSet<>();
-		delayedReflectionSpells = new HashSet<>();
 
 		shieldBreakerNames.addAll(getConfigStringList("shield-breakers", new ArrayList<>()));
 		delayedReflectionSpells.addAll(getConfigStringList("delayed-reflection-spells", new ArrayList<>()));
@@ -93,17 +89,15 @@ public class ReflectSpell extends BuffSpell {
 		if (!target.isValid()) return;
 		if (!isActive(target)) return;
 
-		if (shieldBreakerNames != null && shieldBreakerNames.contains(event.getSpell().getInternalName())) {
+		if (shieldBreakerNames.contains(event.getSpell().getInternalName())) {
 			turnOff(target);
 			return;
 		}
-		if (delayedReflectionSpells != null && delayedReflectionSpells.contains(event.getSpell().getInternalName())) {
-			// Let the delayed reflection spells target the reflector so the animations run
-			// It will get reflected later
-			return;
-		}
 
-		event.setTarget(event.getCaster());
+		// Let the delayed reflection spells target the reflector so the reflection is handled on impact instead.
+		if (delayedReflectionSpells.contains(event.getSpell().getInternalName())) return;
+
+		event.setSpellData(event.getSpellData().invert());
 		ReflectData data = reflectors.get(target.getUniqueId());
 
 		addUseAndChargeCost(target);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BeamSpell.java
@@ -19,6 +19,7 @@ import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
@@ -268,7 +269,7 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 			//check entities in the beam range
 			for (LivingEntity e : loc.getNearbyLivingEntities(hitRadius, verticalHitRadius)) {
 				if (!e.isValid() || immune.contains(e)) continue;
-				if (!validTargetList.canTarget(data.caster(), e)) continue;
+				if (!validTargetList.canTarget(locData.caster(), e)) continue;
 
 				SpellTargetEvent event = new SpellTargetEvent(this, locData, e);
 				if (!event.callEvent()) continue;
@@ -276,19 +277,30 @@ public class BeamSpell extends InstantSpell implements TargetedLocationSpell, Ta
 				SpellData subData = event.getSpellData();
 				LivingEntity entity = event.getTarget();
 
-				if (hitSpell != null) hitSpell.subcast(subData.noLocation());
 				if (entityLocationSpell != null) entityLocationSpell.subcast(subData.noTarget());
+				if (hitSpell != null) {
+					SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), BeamSpell.this, subData);
+					if (preImpact.callEvent()) {
+						subData = preImpact.getSpellData();
+
+						if (preImpact.getRedirected()) {
+							step.multiply(-1);
+							locData = subData.caster(entity);
+							continue mainLoop;
+						} else hitSpell.subcast(subData.noLocation());
+					}
+				}
 
 				playSpellEffects(EffectPosition.TARGET, entity, subData);
-				playSpellEffectsTrail(data.caster().getLocation(), entity.getLocation(), subData);
-				immune.add(e);
+				playSpellEffectsTrail(subData.caster().getLocation(), entity.getLocation(), subData);
+				immune.add(entity);
 				if (stopOnHitEntity) break mainLoop;
 			}
 		}
 
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
-			playSpellEffects(EffectPosition.DELAYED, loc, data.location(loc));
+			playSpellEffects(EffectPosition.DELAYED, loc, locData.location(loc));
 			if (endSpell != null) endSpell.subcast(locData);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/BlockBeamSpell.java
@@ -14,7 +14,6 @@ import org.bukkit.util.EulerAngle;
 import org.bukkit.entity.ArmorStand;
 import org.bukkit.event.EventHandler;
 import org.bukkit.inventory.ItemStack;
-import org.bukkit.attribute.Attribute;
 import org.bukkit.entity.LivingEntity;
 import org.bukkit.persistence.PersistentDataType;
 
@@ -28,6 +27,7 @@ import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.util.magicitems.MagicItem;
 import com.nisovin.magicspells.util.magicitems.MagicItems;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.TargetedLocationSpell;
 import com.nisovin.magicspells.spells.TargetedEntityFromLocationSpell;
@@ -298,7 +298,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 				stand.getPersistentDataContainer().set(MS_BLOCK_BEAM, PersistentDataType.BOOLEAN, true);
 
 				if (hpFix) {
-					stand.getAttribute(Attribute.MAX_HEALTH).setBaseValue(health);
+					Util.setMaxHealth(stand, health);
 					stand.setHealth(health);
 				}
 
@@ -310,7 +310,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 			//check entities in the beam range
 			for (LivingEntity e : loc.getNearbyLivingEntities(hitRadius, verticalHitRadius)) {
 				if (!e.isValid() || immune.contains(e)) continue;
-				if (!validTargetList.canTarget(data.caster(), e)) continue;
+				if (!validTargetList.canTarget(locData.caster(), e)) continue;
 
 				SpellTargetEvent event = new SpellTargetEvent(this, locData, e);
 				if (!event.callEvent()) continue;
@@ -318,10 +318,21 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 				SpellData subData = event.getSpellData();
 				LivingEntity subTarget = event.getTarget();
 
-				if (hitSpell != null) hitSpell.subcast(subData.noLocation());
+				if (hitSpell != null) {
+					SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), BlockBeamSpell.this, subData);
+					if (preImpact.callEvent()) {
+						subData = preImpact.getSpellData();
+
+						if (preImpact.getRedirected()) {
+							step.multiply(-1);
+							locData = subData.caster(e);
+							continue mainLoop;
+						} else hitSpell.subcast(subData.noLocation());
+					}
+				}
 
 				playSpellEffects(EffectPosition.TARGET, subTarget, subData);
-				playSpellEffectsTrail(data.caster().getLocation(), subTarget.getLocation(), subData);
+				playSpellEffectsTrail(subData.caster().getLocation(), subTarget.getLocation(), subData);
 				immune.add(e);
 
 				if (stopOnHitEntity) break mainLoop;
@@ -330,7 +341,7 @@ public class BlockBeamSpell extends InstantSpell implements TargetedLocationSpel
 
 		//end of the beam
 		if (!zoneManager.willFizzle(loc, this) && d >= maxDistance) {
-			playSpellEffects(EffectPosition.DELAYED, loc, data.location(loc));
+			playSpellEffects(EffectPosition.DELAYED, loc, locData.location(loc));
 			if (endSpell != null) endSpell.subcast(locData);
 		}
 

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ForcepushSpell.java
@@ -63,7 +63,7 @@ public class ForcepushSpell extends InstantSpell {
 			else target.setVelocity(velocity);
 
 			playSpellEffects(EffectPosition.TARGET, target, subData);
-			playSpellEffectsTrail(data.caster().getLocation(), target.getLocation(), subData);
+			playSpellEffectsTrail(subData.caster().getLocation(), target.getLocation(), subData);
 		}
 
 		playSpellEffects(EffectPosition.CASTER, data.caster(), data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ProjectileSpell.java
@@ -6,7 +6,6 @@ import org.bukkit.Color;
 import org.bukkit.Location;
 import org.bukkit.entity.*;
 import org.bukkit.util.Vector;
-import org.bukkit.block.Block;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.entity.PotionSplashEvent;
 import org.bukkit.event.entity.EntityExplodeEvent;
@@ -286,40 +285,27 @@ public class ProjectileSpell extends InstantSpell implements TargetedLocationSpe
 	}
 
 	@EventHandler
-	public void onProjectileHit(ProjectileHitEvent e) {
-		Projectile projectile = e.getEntity();
-		Block block = e.getHitBlock();
-		Entity entity = e.getHitEntity();
+	public void onProjectileHit(ProjectileHitEvent event) {
+		Projectile projectile = event.getEntity();
 
-		Iterator<ProjectileTracker> iterator = trackerSet.iterator();
+		Set<ProjectileTracker> trackers = new HashSet<>(trackerSet);
+		for (ProjectileTracker tracker : trackers) {
+			if (!projectile.equals(tracker.getProjectile())) continue;
 
-		if (block != null) {
-			while (iterator.hasNext()) {
-				ProjectileTracker tracker = iterator.next();
-				if (tracker.getProjectile() == null) continue;
-				if (!tracker.getProjectile().equals(projectile)) continue;
+			SpellData subData = tracker.getSpellData();
 
-				SpellData subData = tracker.getSpellData().location(projectile.getLocation());
+			if (event.getHitBlock() != null) {
+				subData = subData.location(projectile.getLocation());
+
 				if (tracker.getGroundSpell() != null) tracker.getGroundSpell().subcast(subData);
-				tracker.stop(false);
-				iterator.remove();
+
+				tracker.stop();
 				break;
 			}
-		}
 
-		if (entity instanceof LivingEntity livingEntity) {
-			while (iterator.hasNext()) {
-				ProjectileTracker tracker = iterator.next();
-				if (tracker.getProjectile() == null) continue;
-				if (!tracker.getProjectile().equals(projectile)) continue;
-
-				SpellData subData = tracker.getSpellData().target(livingEntity);
-				if (tracker.getHitSpell() != null) tracker.getHitSpell().subcast(subData);
-
-				playSpellEffects(EffectPosition.TARGET, livingEntity, subData);
-				e.setCancelled(true);
-				tracker.stop(false);
-				iterator.remove();
+			if (event.getHitEntity() instanceof LivingEntity target) {
+				event.setCancelled(true);
+				tracker.hitEntity(target, subData.target(target));
 				break;
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/RoarSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/RoarSpell.java
@@ -37,16 +37,16 @@ public class RoarSpell extends InstantSpell {
 
 			SpellTargetEvent targetEvent = new SpellTargetEvent(this, data, mob);
 			if (!targetEvent.callEvent()) continue;
+			SpellData subData = targetEvent.getSpellData();
 
 			LivingEntity le = targetEvent.getTarget();
 			if (!(le instanceof Mob target)) continue;
 
-			target.setTarget(data.caster());
+			target.setTarget(subData.caster());
 			count++;
 
-			SpellData subData = targetEvent.getSpellData();
 			playSpellEffects(EffectPosition.TARGET, target, subData);
-			playSpellEffectsTrail(data.caster().getLocation(), target.getLocation(), subData);
+			playSpellEffectsTrail(subData.caster().getLocation(), target.getLocation(), subData);
 		}
 
 		if (cancelIfNoTargets.get(data) && count == 0) return noTarget(data);

--- a/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/instant/ThrowBlockSpell.java
@@ -351,7 +351,7 @@ public class ThrowBlockSpell extends InstantSpell implements TargetedLocationSpe
 			}
 
 			double damage = event.getDamage();
-			if (info.powerAffectsDamage) damage *= info.data.power();
+			if (info.powerAffectsDamage) damage *= subData.power();
 
 			if (info.checkPlugins && info.data.hasCaster() && spell.checkFakeDamageEvent(info.data.caster(), info.data.target(), DamageCause.ENTITY_ATTACK, damage)) {
 				event.setCancelled(true);

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingMissileSpell.java
@@ -18,8 +18,8 @@ import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.spells.TargetedSpell;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.util.config.ConfigData;
+import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
@@ -414,30 +414,35 @@ public class HomingMissileSpell extends TargetedSpell implements TargetedEntityS
 			counter++;
 
 			if (hitSpell == null) return;
-
 			hitBox.setCenter(currentLocation);
-			if (hitBox.contains(targetLoc)) {
-				SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), HomingMissileSpell.this, data.caster(), data.target(), data.power());
-				EventUtil.call(preImpact);
-				// Should we bounce the missile back?
-				if (!preImpact.getRedirected()) {
-					// Apparently didn't get redirected, carry out the plans
-					hitSpell.subcast(data.noLocation());
-					if (entityLocationSpell != null) entityLocationSpell.subcast(data.noTarget());
+			if (!hitBox.contains(targetLoc)) return;
 
-					playSpellEffects(EffectPosition.TARGET, data.target(), data);
-					if (stopOnHitTarget) stop();
-				} else {
-					if (!data.hasCaster()) {
-						stop();
-						return;
-					}
+			SpellTargetEvent targetEvent = new SpellTargetEvent(HomingMissileSpell.this, data);
+			if (!targetEvent.callEvent()) return;
+			SpellData subData = targetEvent.getSpellData();
 
-					currentVelocity.multiply(-1);
-					data = data.power(preImpact.getPower()).invert();
-				}
+			SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), HomingMissileSpell.this, subData);
+			if (!preImpact.callEvent()) {
+				if (stopOnHitTarget) stop();
+				return;
 			}
+			subData = preImpact.getSpellData();
 
+			if (preImpact.getRedirected()) {
+				if (!subData.hasCaster()) {
+					stop();
+					return;
+				}
+
+				currentVelocity.multiply(-1);
+				data = subData.invert();
+			} else {
+				hitSpell.subcast(subData.noLocation());
+				if (entityLocationSpell != null) entityLocationSpell.subcast(subData.noTarget());
+
+				playSpellEffects(EffectPosition.TARGET, subData.target(), subData);
+				if (stopOnHitTarget) stop();
+			}
 		}
 
 		private void playIntermediateEffectLocations(Location old, Vector movement) {

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/HomingProjectileSpell.java
@@ -23,6 +23,7 @@ import com.nisovin.magicspells.util.config.ConfigData;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spells.TargetedEntitySpell;
 import com.nisovin.magicspells.util.config.ConfigDataUtil;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
@@ -382,15 +383,33 @@ public class HomingProjectileSpell extends TargetedSpell implements TargetedEnti
 
 			counter++;
 
+			if (hitSpell == null) return;
 			hitBox.setCenter(currentLocation);
-			if (hitBox.contains(targetLoc)) {
-				SpellTargetEvent targetEvent = new SpellTargetEvent(HomingProjectileSpell.this, data);
-				if (!targetEvent.callEvent()) return;
-				data = targetEvent.getSpellData();
+			if (!hitBox.contains(targetLoc)) return;
 
-				if (hitSpell != null) hitSpell.subcast(data.noLocation());
-				playSpellEffects(EffectPosition.TARGET, data.target(), data);
+			SpellTargetEvent targetEvent = new SpellTargetEvent(HomingProjectileSpell.this, data);
+			if (!targetEvent.callEvent()) return;
+			SpellData subData = targetEvent.getSpellData();
 
+			SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), HomingProjectileSpell.this, subData);
+			if (!preImpact.callEvent()) {
+				stop();
+				return;
+			}
+			subData = preImpact.getSpellData();
+
+			if (preImpact.getRedirected()) {
+				if (!subData.hasCaster()) {
+					stop();
+					return;
+				}
+
+				currentVelocity.multiply(-1);
+				data = subData.invert();
+			} else {
+				hitSpell.subcast(subData.noLocation());
+
+				playSpellEffects(EffectPosition.TARGET, subData.target(), subData);
 				stop();
 			}
 		}

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/ProjectileModifySpell.java
@@ -1,7 +1,6 @@
 package com.nisovin.magicspells.spells.targeted;
 
 import java.util.List;
-import java.util.HashSet;
 import java.util.Iterator;
 
 import org.apache.commons.math4.core.jdkmath.AccurateMath;
@@ -237,8 +236,6 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		double hRadiusSquared = box.getHorizontalRadius() * box.getHorizontalRadius();
 		double vRadiusSquared = box.getVerticalRadius() * box.getVerticalRadius();
 
-		Iterator<ParticleProjectileTracker> iterator = new HashSet<>(ParticleProjectileSpell.getProjectileTrackers()).iterator();
-
 		int maxTargets = this.maxTargets.get(data);
 		int cone = this.cone.get(data);
 
@@ -252,11 +249,11 @@ public class ProjectileModifySpell extends TargetedSpell implements TargetedLoca
 		boolean affectOwnedProjectiles = this.affectOwnedProjectiles.get(data);
 		boolean affectEnemyProjectiles = this.affectEnemyProjectiles.get(data);
 
-		Location currentLoc;
+		Iterator<ParticleProjectileTracker> iterator = ParticleProjectileSpell.getProjectileTrackers().iterator();
 		while (iterator.hasNext()) {
 			ParticleProjectileTracker tracker = iterator.next();
 			if (tracker == null || tracker.isStopped()) continue;
-			currentLoc = tracker.getCurrentLocation();
+			Location currentLoc = tracker.getCurrentLocation();
 			if (currentLoc == null) continue;
 			if (!currentLoc.getWorld().equals(location.getWorld())) continue;
 			if (!box.contains(currentLoc)) continue;

--- a/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
+++ b/core/src/main/java/com/nisovin/magicspells/spells/targeted/VolleySpell.java
@@ -7,7 +7,6 @@ import org.bukkit.Location;
 import org.bukkit.Registry;
 import org.bukkit.util.Vector;
 import org.bukkit.entity.Arrow;
-import org.bukkit.entity.Entity;
 import org.bukkit.event.Listener;
 import org.bukkit.potion.PotionType;
 import org.bukkit.event.EventHandler;
@@ -17,6 +16,7 @@ import org.bukkit.potion.PotionEffect;
 import org.bukkit.event.EventPriority;
 import org.bukkit.entity.AbstractArrow;
 import org.bukkit.event.entity.EntityRemoveEvent;
+import org.bukkit.event.entity.ProjectileHitEvent;
 import org.bukkit.event.entity.EntityDamageByEntityEvent;
 import org.bukkit.event.entity.EntityDamageEvent.DamageCause;
 
@@ -139,24 +139,35 @@ public class VolleySpell extends TargetedSpell implements TargetedLocationSpell,
 	private static class ArrowListener implements Listener {
 
 		@EventHandler
-		public void onArrowHit(EntityDamageByEntityEvent event) {
-			if (event.getCause() != DamageCause.PROJECTILE || !(event.getEntity() instanceof LivingEntity target)) return;
-
-			Entity damagerEntity = event.getDamager();
-			if (!(damagerEntity instanceof Arrow arrow)) return;
+		public void onArrowDamage(EntityDamageByEntityEvent event) {
+			if (event.getCause() != DamageCause.PROJECTILE) return;
+			if (!(event.getDamager() instanceof Arrow arrow)) return;
 
 			VolleyData data = ARROW_DATA.get(arrow.getUniqueId());
 			if (data == null) return;
 
 			event.setDamage(data.damage);
+		}
 
-			SpellPreImpactEvent preImpactEvent = new SpellPreImpactEvent(data.spell, data.spell, (LivingEntity) arrow.getShooter(), target, 1);
-			preImpactEvent.callEvent();
-			if (!preImpactEvent.getRedirected()) return;
+		@EventHandler
+		public void onArrowHit(ProjectileHitEvent event) {
+			if (!(event.getEntity() instanceof Arrow arrow)) return;
+			if (!(event.getHitEntity() instanceof LivingEntity target)) return;
+
+			VolleyData data = ARROW_DATA.get(arrow.getUniqueId());
+			if (data == null) return;
+
+			SpellPreImpactEvent preImpact = new SpellPreImpactEvent(data.spell, data.spell, new SpellData((LivingEntity) arrow.getShooter(), target));
+			if (!preImpact.callEvent()) {
+				event.setCancelled(true);
+				return;
+			}
+
+			if (!preImpact.getRedirected()) return;
 
 			event.setCancelled(true);
+			arrow.setShooter(target);
 			arrow.setVelocity(arrow.getVelocity().multiply(-1));
-			arrow.teleportAsync(arrow.getLocation().add(arrow.getVelocity()));
 		}
 
 		@EventHandler(priority = EventPriority.MONITOR)

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ItemProjectileTracker.java
@@ -14,10 +14,10 @@ import com.nisovin.magicspells.util.Util;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.SpellData;
 import com.nisovin.magicspells.util.ValidTargetList;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.events.TrackerMoveEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.instant.ItemProjectileSpell;
 
@@ -139,11 +139,8 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 		currentLocation.setDirection(entity.getVelocity());
 
 		if (callEvents) {
-			TrackerMoveEvent trackerMoveEvent = new TrackerMoveEvent(this, previousLocation, currentLocation);
-			EventUtil.call(trackerMoveEvent);
-			if (stopped) {
-				return;
-			}
+			new TrackerMoveEvent(this, previousLocation, currentLocation).callEvent();
+			if (stopped) return;
 		}
 
 		data = data.location(currentLocation);
@@ -163,11 +160,23 @@ public class ItemProjectileTracker implements Runnable, Tracker {
 
 			SpellTargetEvent event = new SpellTargetEvent(spell, data, target);
 			if (!event.callEvent()) continue;
-
 			SpellData subData = event.getSpellData();
 
 			if (spell != null) spell.playEffects(EffectPosition.TARGET, subData.target(), subData);
-			if (spellOnHitEntity != null) spellOnHitEntity.subcast(subData.noLocation());
+
+			if (spellOnHitEntity != null) {
+				SpellPreImpactEvent preImpact = new SpellPreImpactEvent(spellOnHitEntity.getSpell(), spell, subData);
+				if (preImpact.callEvent()) {
+					subData = preImpact.getSpellData();
+
+					if (preImpact.getRedirected()) {
+						setCaster(subData.target());
+						entity.setVelocity(entity.getVelocity().multiply(-1));
+						return;
+					} else spellOnHitEntity.subcast(subData.noLocation());
+				}
+			}
+
 			if (stopOnHitEntity) stop();
 			return;
 		}

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -24,12 +24,12 @@ import de.slikey.effectlib.effect.ModifiedEffect;
 import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.TrackerMoveEvent;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.events.ParticleProjectileHitEvent;
 import com.nisovin.magicspells.spelleffects.util.EffectlibSpellEffect;
@@ -309,11 +309,8 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 		previousLocation = Util.makeFinite(previousLocation);
 
 		if (callEvents) {
-			TrackerMoveEvent trackerMoveEvent = new TrackerMoveEvent(this, previousLocation, currentLocation);
-			EventUtil.call(trackerMoveEvent);
-			if (stopped) {
-				return;
-			}
+			new TrackerMoveEvent(this, previousLocation, currentLocation).callEvent();
+			if (stopped) return;
 		}
 
 		if (hugSurface) {
@@ -558,8 +555,18 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 			target = targetEvent.getTarget();
 
 			if (casterSpell != null && target.equals(data.caster())) casterSpell.subcast(subData, false, false, HIT_ORDERING);
-			if (entitySpell != null && !target.equals(data.caster())) entitySpell.subcast(subData, false, false, HIT_ORDERING);
 			if (entityLocationSpell != null) entityLocationSpell.subcast(subData.noTarget());
+			if (entitySpell != null && !target.equals(data.caster())) {
+				SpellPreImpactEvent preImpact = new SpellPreImpactEvent(entitySpell.getSpell(), spell, subData);
+				if (preImpact.callEvent()) {
+					subData = preImpact.getSpellData();
+
+					if (preImpact.getRedirected()) {
+						setCaster(subData.target());
+						currentVelocity.multiply(-1);
+					} else entitySpell.subcast(subData, false, false, HIT_ORDERING);
+				}
+			}
 
 			if (spell != null) spell.playEffects(EffectPosition.TARGET, currentLoc, subData);
 

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ParticleProjectileTracker.java
@@ -415,9 +415,8 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 		if (stopped) return;
 
 		if (spell == null || interactions == null || interactions.isEmpty()) return;
-		Set<ParticleProjectileTracker> toRemove = new HashSet<>();
-		Set<ParticleProjectileTracker> trackers = new HashSet<>(ParticleProjectileSpell.getProjectileTrackers());
-		for (ParticleProjectileTracker collisionTracker : trackers) {
+
+		for (ParticleProjectileTracker collisionTracker : new HashSet<>(ParticleProjectileSpell.getProjectileTrackers())) {
 			boolean isCaster = Objects.equals(data.caster(), collisionTracker.data.caster());
 
 			for (Interaction interaction : interactions) {
@@ -433,21 +432,10 @@ public class ParticleProjectileTracker implements Runnable, Tracker {
 					interaction.collisionSpell().subcast(data.location(middleLoc));
 				}
 
-				if (interaction.stopCausing()) {
-					toRemove.add(collisionTracker);
-					collisionTracker.stop(false);
-				}
-
-				if (interaction.stopWith()) {
-					toRemove.add(this);
-					stop(false);
-				}
+				if (interaction.stopCausing()) collisionTracker.stop();
+				if (interaction.stopWith()) stop();
 			}
 		}
-
-		ParticleProjectileSpell.getProjectileTrackers().removeAll(toRemove);
-		toRemove.clear();
-		trackers.clear();
 	}
 
 	private boolean canInteractWith(ParticleProjectileTracker collisionTracker) {

--- a/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
+++ b/core/src/main/java/com/nisovin/magicspells/util/trackers/ProjectileTracker.java
@@ -19,12 +19,12 @@ import com.nisovin.magicspells.util.*;
 import com.nisovin.magicspells.Subspell;
 import com.nisovin.magicspells.MagicSpells;
 import com.nisovin.magicspells.util.projectile.*;
-import com.nisovin.magicspells.util.compat.EventUtil;
 import com.nisovin.magicspells.events.SpellTargetEvent;
 import com.nisovin.magicspells.events.TrackerMoveEvent;
 import com.nisovin.magicspells.zones.NoMagicZoneManager;
 import com.nisovin.magicspells.spelleffects.SpellEffect;
 import com.nisovin.magicspells.castmodifiers.ModifierSet;
+import com.nisovin.magicspells.events.SpellPreImpactEvent;
 import com.nisovin.magicspells.spelleffects.EffectPosition;
 import com.nisovin.magicspells.spells.instant.ProjectileSpell;
 import com.nisovin.magicspells.spelleffects.util.EffectlibSpellEffect;
@@ -191,8 +191,7 @@ public class ProjectileTracker implements Runnable, Tracker {
 		currentLocation.setDirection(projectile.getVelocity());
 
 		if (callEvents) {
-			TrackerMoveEvent trackerMoveEvent = new TrackerMoveEvent(this, previousLocation, currentLocation);
-			EventUtil.call(trackerMoveEvent);
+			new TrackerMoveEvent(this, previousLocation, currentLocation).callEvent();
 			if (stopped) return;
 		}
 
@@ -289,19 +288,37 @@ public class ProjectileTracker implements Runnable, Tracker {
 
 		SpellData data = this.data.location(location);
 
-		for (LivingEntity entity : location.getNearbyLivingEntities(hitRadius, verticalHitRadius, hitRadius)) {
-			if (!targetList.canTarget(data.caster(), entity)) continue;
+		for (LivingEntity entity : location.getNearbyLivingEntities(hitRadius, verticalHitRadius))
+			if (hitEntity(entity, data))
+				break;
+	}
 
-			SpellTargetEvent event = new SpellTargetEvent(spell, data, entity);
-			if (!event.callEvent()) continue;
+	public boolean hitEntity(LivingEntity entity, SpellData data) {
+		if (!targetList.canTarget(data.caster(), entity)) return false;
 
-			SpellData subData = event.getSpellData();
-			if (hitSpell != null) hitSpell.subcast(subData.noLocation());
-			if (entityLocationSpell != null) entityLocationSpell.subcast(subData.noTarget());
+		SpellTargetEvent event = new SpellTargetEvent(spell, data, entity);
+		if (!event.callEvent()) return false;
 
-			stop();
-			return;
+		SpellData subData = event.getSpellData();
+
+		if (entityLocationSpell != null) entityLocationSpell.subcast(subData.noTarget());
+		if (hitSpell != null) {
+			SpellPreImpactEvent preImpact = new SpellPreImpactEvent(hitSpell.getSpell(), spell, subData);
+			if (preImpact.callEvent()) {
+				subData = preImpact.getSpellData();
+
+				if (preImpact.getRedirected()) {
+					setCaster(subData.target());
+					projectile.setVelocity(projectile.getVelocity().multiply(-1));
+					return true;
+				} else hitSpell.subcast(subData.noLocation());
+			}
 		}
+
+		spell.playEffects(EffectPosition.TARGET, subData.target(), subData);
+
+		stop();
+		return true;
 	}
 
 	@Override


### PR DESCRIPTION
### Changes:

- `ReflectSpell` now properly inverts the caster-target relationship for "redirected" targeted spells.
- `ReflectSpell` can now additionally redirect `BeamSpell`, `BlockBeamSpell`, `ProjectileSpell`, `HomingProjectileSpell`, `ItemProjectileSpell`, and `ParticleProjectileSpell`.
